### PR TITLE
chore(dr): activate scheduled postgres backup on main

### DIFF
--- a/.github/workflows/postgres-logical-backup.yml
+++ b/.github/workflows/postgres-logical-backup.yml
@@ -1,0 +1,131 @@
+name: PostgreSQL Logical Backup
+
+on:
+  schedule:
+    - cron: "17 0,12 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  id-token: write
+
+concurrency:
+  group: postgres-logical-backup-production
+  cancel-in-progress: false
+
+jobs:
+  postgres-logical-backup:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    environment: production-backup
+    env:
+      BACKUP_DATABASE_URL: ${{ secrets.BACKUP_DATABASE_URL }}
+      BACKUP_S3_KMS_KEY_ID: ${{ secrets.BACKUP_S3_KMS_KEY_ID }}
+      BACKUP_AWS_ROLE_ARN: ${{ vars.BACKUP_AWS_ROLE_ARN }}
+      BACKUP_S3_BUCKET: ${{ vars.BACKUP_S3_BUCKET }}
+      BACKUP_S3_PREFIX: ${{ vars.BACKUP_S3_PREFIX }}
+      BACKUP_S3_REGION: ${{ vars.BACKUP_S3_REGION }}
+      BACKUP_S3_SSE: ${{ vars.BACKUP_S3_SSE }}
+      BACKUP_RELEASE_COMMIT: ${{ vars.BACKUP_RELEASE_COMMIT }}
+      BACKUP_WORKDIR: ${{ runner.temp }}/litoral-trace-postgres-backup
+    steps:
+      - name: Checkout
+        # actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
+
+      - name: Default branch activation note
+        run: |
+          echo "Scheduled execution is operational only when this workflow exists on the repository default branch."
+          echo "workflow_dispatch also requires this workflow file to exist on the default branch."
+          echo "Default-branch activation is an operational release step and is not performed by this workflow."
+
+      - name: Setup Python
+        # actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
+        with:
+          python-version: "3.11"
+
+      - name: Install operator dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install "psycopg[binary]" boto3
+
+      - name: Install PostgreSQL 17 client
+        run: |
+          sudo install -d -m 0755 /usr/share/postgresql-common/pgdg
+          curl -fsSL https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo gpg --dearmor -o /usr/share/postgresql-common/pgdg/apt.postgresql.org.gpg
+          echo "deb [signed-by=/usr/share/postgresql-common/pgdg/apt.postgresql.org.gpg] https://apt.postgresql.org/pub/repos/apt $(. /etc/os-release && echo "$VERSION_CODENAME")-pgdg main" | sudo tee /etc/apt/sources.list.d/pgdg.list > /dev/null
+          sudo apt-get update
+          sudo apt-get install -y postgresql-client-17
+
+      - name: Verify PostgreSQL 17 client tools
+        shell: bash
+        run: |
+          pg_dump --version
+          pg_restore --version
+          pg_dump --version | grep -E "17\."
+          pg_restore --version | grep -E "17\."
+
+      - name: Validate backup configuration
+        shell: bash
+        run: |
+          missing=0
+          for name in BACKUP_DATABASE_URL BACKUP_S3_BUCKET BACKUP_S3_PREFIX BACKUP_S3_REGION BACKUP_RELEASE_COMMIT BACKUP_AWS_ROLE_ARN; do
+            if [ -z "${!name:-}" ]; then
+              echo "Missing required configuration: $name"
+              missing=1
+            fi
+          done
+          if [ "$missing" -ne 0 ]; then
+            exit 1
+          fi
+
+      - name: Create logical backup
+        shell: bash
+        run: |
+          umask 077
+          mkdir -p "$BACKUP_WORKDIR"
+          python scripts/postgres_logical_backup.py \
+            --output-dir "$BACKUP_WORKDIR" \
+            --source-label production \
+            --release-commit "$BACKUP_RELEASE_COMMIT" > "$BACKUP_WORKDIR/backup-result.json"
+          python - <<'PY'
+          import json
+          import os
+          from pathlib import Path
+
+          workdir = Path(os.environ["BACKUP_WORKDIR"]).resolve()
+          payload = json.loads((workdir / "backup-result.json").read_text(encoding="utf-8"))
+          dump_name = payload["dump_filename"]
+          manifest_name = payload["manifest_filename"]
+          dump_path = (workdir / dump_name).resolve()
+          manifest_path = (workdir / manifest_name).resolve()
+
+          if workdir not in dump_path.parents or workdir not in manifest_path.parents:
+              raise SystemExit("Backup outputs must remain inside BACKUP_WORKDIR.")
+
+          (workdir / "dump-path.txt").write_text(str(dump_path), encoding="utf-8")
+          (workdir / "manifest-path.txt").write_text(str(manifest_path), encoding="utf-8")
+          PY
+
+      - name: Configure AWS credentials via OIDC
+        # aws-actions/configure-aws-credentials@v5
+        uses: aws-actions/configure-aws-credentials@61815dcd50bd041e203e49132bacad1fd04d2708
+        with:
+          role-to-assume: ${{ vars.BACKUP_AWS_ROLE_ARN }}
+          role-session-name: litoral-trace-postgres-backup
+          aws-region: ${{ vars.BACKUP_S3_REGION }}
+
+      - name: Publish logical backup
+        shell: bash
+        run: |
+          DUMP_PATH="$(cat "$BACKUP_WORKDIR/dump-path.txt")"
+          MANIFEST_PATH="$(cat "$BACKUP_WORKDIR/manifest-path.txt")"
+          python -m scripts.postgres_backup_publish \
+            --dump-file "$DUMP_PATH" \
+            --manifest "$MANIFEST_PATH" > "$BACKUP_WORKDIR/publish-result.json"
+
+      - name: Cleanup backup workdir
+        if: always()
+        shell: bash
+        run: rm -rf "$RUNNER_TEMP/litoral-trace-postgres-backup"

--- a/scripts/postgres_backup_publish.py
+++ b/scripts/postgres_backup_publish.py
@@ -1,0 +1,592 @@
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+from pathlib import Path
+import re
+import sys
+from typing import Any
+
+import boto3
+from botocore.exceptions import ClientError
+
+from scripts.postgres_logical_backup import (
+    BackupToolError,
+    FORMAT_VERSION,
+    sanitize_cli_error_message,
+    sha256_file,
+    utc_timestamp_iso,
+)
+
+
+REMOTE_FORMAT_VERSION = "p27a3.remote.v1"
+SAFE_BASENAME_PATTERN = re.compile(
+    r"^[A-Za-z0-9][A-Za-z0-9._-]*$"
+)
+SAFE_SOURCE_LABEL_PATTERN = re.compile(
+    r"^[A-Za-z0-9][A-Za-z0-9_-]*$"
+)
+
+
+def require_env(name: str) -> str:
+    value = str(os.environ.get(name) or "").strip()
+    if not value:
+        raise BackupToolError(
+            f"{name} is required."
+        )
+    return value
+
+
+def build_publish_config() -> dict[str, str]:
+    bucket = require_env("BACKUP_S3_BUCKET")
+    prefix = require_env("BACKUP_S3_PREFIX").strip("/")
+    if not prefix:
+        raise BackupToolError(
+            "BACKUP_S3_PREFIX is required."
+        )
+
+    sse = str(
+        os.environ.get("BACKUP_S3_SSE") or "AES256"
+    ).strip() or "AES256"
+    if sse not in {"AES256", "aws:kms"}:
+        raise BackupToolError(
+            "BACKUP_S3_SSE must be AES256 or aws:kms."
+        )
+
+    kms_key_id = str(
+        os.environ.get("BACKUP_S3_KMS_KEY_ID") or ""
+    ).strip()
+    if sse == "aws:kms" and not kms_key_id:
+        raise BackupToolError(
+            "BACKUP_S3_KMS_KEY_ID is required when BACKUP_S3_SSE=aws:kms."
+        )
+
+    return {
+        "bucket": bucket,
+        "prefix": prefix,
+        "region": str(
+            os.environ.get("BACKUP_S3_REGION") or ""
+        ).strip(),
+        "endpoint_url": str(
+            os.environ.get("BACKUP_S3_ENDPOINT_URL") or ""
+        ).strip(),
+        "sse": sse,
+        "kms_key_id": kms_key_id,
+    }
+
+
+def ensure_safe_basename(name: str) -> str:
+    candidate = str(name or "").strip()
+    if not candidate:
+        raise BackupToolError(
+            "Filename must not be empty."
+        )
+    if candidate != Path(candidate).name:
+        raise BackupToolError(
+            "Path traversal is not allowed."
+        )
+    if "/" in candidate or "\\" in candidate:
+        raise BackupToolError(
+            "Path traversal is not allowed."
+        )
+    if not SAFE_BASENAME_PATTERN.fullmatch(candidate):
+        raise BackupToolError(
+            "Filename contains unsafe characters."
+        )
+    return candidate
+
+
+def ensure_safe_source_label(source_label: str) -> str:
+    candidate = str(source_label or "").strip()
+    if not SAFE_SOURCE_LABEL_PATTERN.fullmatch(
+        candidate
+    ):
+        raise BackupToolError(
+            "source_label contains unsafe characters."
+        )
+    return candidate
+
+
+def load_manifest(
+    manifest_path: Path,
+) -> dict[str, Any]:
+    try:
+        manifest = json.loads(
+            manifest_path.read_text(encoding="utf-8")
+        )
+    except json.JSONDecodeError as exc:
+        raise BackupToolError(
+            "Manifest JSON is invalid."
+        ) from exc
+
+    required_fields = {
+        "format_version",
+        "created_at_utc",
+        "source_label",
+        "release_commit",
+        "dump_filename",
+        "dump_sha256",
+        "dump_size_bytes",
+    }
+    missing = required_fields.difference(manifest)
+    if missing:
+        raise BackupToolError(
+            f"Manifest is missing required fields: {sorted(missing)!r}."
+        )
+    if manifest["format_version"] != FORMAT_VERSION:
+        raise BackupToolError(
+            "Unsupported manifest format version."
+        )
+    return manifest
+
+
+def parse_backup_timestamp(
+    created_at_utc: str,
+) -> tuple[str, str, str, str]:
+    match = re.fullmatch(
+        r"(\d{4})-(\d{2})-(\d{2})T"
+        r"(\d{2}):(\d{2}):(\d{2})Z",
+        str(created_at_utc or "").strip(),
+    )
+    if not match:
+        raise BackupToolError(
+            "Manifest created_at_utc must be canonical UTC ISO format."
+        )
+    year, month, day, hour, minute, second = (
+        match.groups()
+    )
+    timestamp = (
+        f"{year}{month}{day}T"
+        f"{hour}{minute}{second}Z"
+    )
+    return year, month, day, timestamp
+
+
+def build_object_keys(
+    *,
+    prefix: str,
+    source_label: str,
+    created_at_utc: str,
+    dump_filename: str,
+    manifest_filename: str,
+) -> dict[str, str]:
+    safe_source_label = ensure_safe_source_label(
+        source_label
+    )
+    safe_dump_filename = ensure_safe_basename(
+        dump_filename
+    )
+    safe_manifest_filename = ensure_safe_basename(
+        manifest_filename
+    )
+    year, month, day, timestamp = parse_backup_timestamp(
+        created_at_utc
+    )
+    base_key = (
+        f"{prefix}/{safe_source_label}/"
+        f"{year}/{month}/{day}/{timestamp}"
+    )
+    return {
+        "dump_key": (
+            f"{base_key}/{safe_dump_filename}"
+        ),
+        "manifest_key": (
+            f"{base_key}/{safe_manifest_filename}"
+        ),
+        "complete_key": (
+            f"{base_key}/complete.json"
+        ),
+    }
+
+
+def compute_sha256_bytes(payload: bytes) -> str:
+    return hashlib.sha256(payload).hexdigest()
+
+
+def build_complete_marker(
+    *,
+    manifest: dict[str, Any],
+    object_keys: dict[str, str],
+    manifest_sha256: str,
+) -> bytes:
+    payload = {
+        "format_version": REMOTE_FORMAT_VERSION,
+        "source_label": manifest["source_label"],
+        "release_commit": manifest["release_commit"],
+        "backup_created_at_utc": manifest[
+            "created_at_utc"
+        ],
+        "published_at_utc": utc_timestamp_iso(),
+        "dump_key": object_keys["dump_key"],
+        "dump_sha256": manifest["dump_sha256"],
+        "dump_size_bytes": int(
+            manifest["dump_size_bytes"]
+        ),
+        "manifest_key": object_keys["manifest_key"],
+        "manifest_sha256": manifest_sha256,
+    }
+    return (
+        json.dumps(
+            payload,
+            indent=2,
+            sort_keys=True,
+        )
+        + "\n"
+    ).encode("utf-8")
+
+
+def build_s3_client(config: dict[str, str]) -> Any:
+    client_kwargs: dict[str, Any] = {}
+    if config["region"]:
+        client_kwargs["region_name"] = config[
+            "region"
+        ]
+    if config["endpoint_url"]:
+        client_kwargs["endpoint_url"] = config[
+            "endpoint_url"
+        ]
+    return boto3.client("s3", **client_kwargs)
+
+
+def build_put_object_kwargs(
+    *,
+    bucket: str,
+    key: str,
+    body: bytes,
+    sha256_hex: str,
+    sse: str,
+    kms_key_id: str,
+    content_type: str,
+) -> dict[str, Any]:
+    kwargs: dict[str, Any] = {
+        "Bucket": bucket,
+        "Key": key,
+        "Body": body,
+        "ContentType": content_type,
+        "Metadata": {
+            "sha256": sha256_hex,
+        },
+        "ServerSideEncryption": sse,
+    }
+    if sse == "aws:kms":
+        kwargs["SSEKMSKeyId"] = kms_key_id
+    return kwargs
+
+
+def is_not_found_error(exc: ClientError) -> bool:
+    code = str(
+        exc.response.get("Error", {}).get("Code", "")
+    )
+    return code in {"404", "NoSuchKey", "NotFound"}
+
+
+def head_remote_object(
+    *,
+    s3_client: Any,
+    bucket: str,
+    key: str,
+) -> dict[str, Any] | None:
+    try:
+        return s3_client.head_object(
+            Bucket=bucket,
+            Key=key,
+        )
+    except ClientError as exc:
+        if is_not_found_error(exc):
+            return None
+        raise
+
+
+def ensure_remote_object_matches(
+    *,
+    head_response: dict[str, Any],
+    expected_size: int,
+    expected_sha256: str,
+) -> None:
+    actual_size = int(
+        head_response.get("ContentLength", -1)
+    )
+    actual_sha256 = str(
+        head_response.get("Metadata", {}).get(
+            "sha256", ""
+        )
+    )
+    if actual_size != int(expected_size):
+        raise BackupToolError(
+            "Remote object length does not match expected content."
+        )
+    if actual_sha256 != expected_sha256:
+        raise BackupToolError(
+            "Remote object SHA-256 metadata does not match expected content."
+        )
+
+
+def publish_object_if_needed(
+    *,
+    s3_client: Any,
+    bucket: str,
+    key: str,
+    body: bytes,
+    sha256_hex: str,
+    sse: str,
+    kms_key_id: str,
+    content_type: str,
+) -> None:
+    existing = head_remote_object(
+        s3_client=s3_client,
+        bucket=bucket,
+        key=key,
+    )
+    if existing is not None:
+        ensure_remote_object_matches(
+            head_response=existing,
+            expected_size=len(body),
+            expected_sha256=sha256_hex,
+        )
+        return
+
+    s3_client.put_object(
+        **build_put_object_kwargs(
+            bucket=bucket,
+            key=key,
+            body=body,
+            sha256_hex=sha256_hex,
+            sse=sse,
+            kms_key_id=kms_key_id,
+            content_type=content_type,
+        )
+    )
+
+
+def verify_remote_object(
+    *,
+    s3_client: Any,
+    bucket: str,
+    key: str,
+    expected_size: int,
+    expected_sha256: str,
+) -> None:
+    head_response = head_remote_object(
+        s3_client=s3_client,
+        bucket=bucket,
+        key=key,
+    )
+    if head_response is None:
+        raise BackupToolError(
+            "Remote object is not reachable after publication."
+        )
+    ensure_remote_object_matches(
+        head_response=head_response,
+        expected_size=expected_size,
+        expected_sha256=expected_sha256,
+    )
+
+
+def validate_local_artifacts(
+    *,
+    dump_path: Path,
+    manifest_path: Path,
+) -> tuple[dict[str, Any], bytes, str]:
+    if not dump_path.exists():
+        raise BackupToolError(
+            "Dump file does not exist."
+        )
+    if not manifest_path.exists():
+        raise BackupToolError(
+            "Manifest file does not exist."
+        )
+
+    ensure_safe_basename(dump_path.name)
+    ensure_safe_basename(manifest_path.name)
+
+    manifest = load_manifest(manifest_path)
+    ensure_safe_source_label(
+        str(manifest["source_label"])
+    )
+
+    if str(manifest["dump_filename"]) != dump_path.name:
+        raise BackupToolError(
+            "Manifest dump_filename does not match supplied dump file."
+        )
+
+    dump_size = int(dump_path.stat().st_size)
+    if dump_size != int(manifest["dump_size_bytes"]):
+        raise BackupToolError(
+            "Dump size does not match the manifest."
+        )
+
+    dump_sha256 = sha256_file(dump_path)
+    if dump_sha256 != str(manifest["dump_sha256"]):
+        raise BackupToolError(
+            "Dump SHA-256 does not match the manifest."
+        )
+
+    manifest_bytes = manifest_path.read_bytes()
+    manifest_sha256 = compute_sha256_bytes(
+        manifest_bytes
+    )
+    return manifest, manifest_bytes, manifest_sha256
+
+
+def run_publish(
+    *,
+    dump_path: Path,
+    manifest_path: Path,
+) -> dict[str, Any]:
+    config = build_publish_config()
+    manifest, manifest_bytes, manifest_sha256 = (
+        validate_local_artifacts(
+            dump_path=dump_path,
+            manifest_path=manifest_path,
+        )
+    )
+    dump_bytes = dump_path.read_bytes()
+    object_keys = build_object_keys(
+        prefix=config["prefix"],
+        source_label=str(manifest["source_label"]),
+        created_at_utc=str(manifest["created_at_utc"]),
+        dump_filename=dump_path.name,
+        manifest_filename=manifest_path.name,
+    )
+
+    s3_client = build_s3_client(config)
+
+    publish_object_if_needed(
+        s3_client=s3_client,
+        bucket=config["bucket"],
+        key=object_keys["dump_key"],
+        body=dump_bytes,
+        sha256_hex=str(manifest["dump_sha256"]),
+        sse=config["sse"],
+        kms_key_id=config["kms_key_id"],
+        content_type="application/octet-stream",
+    )
+    verify_remote_object(
+        s3_client=s3_client,
+        bucket=config["bucket"],
+        key=object_keys["dump_key"],
+        expected_size=len(dump_bytes),
+        expected_sha256=str(manifest["dump_sha256"]),
+    )
+
+    publish_object_if_needed(
+        s3_client=s3_client,
+        bucket=config["bucket"],
+        key=object_keys["manifest_key"],
+        body=manifest_bytes,
+        sha256_hex=manifest_sha256,
+        sse=config["sse"],
+        kms_key_id=config["kms_key_id"],
+        content_type="application/json",
+    )
+    verify_remote_object(
+        s3_client=s3_client,
+        bucket=config["bucket"],
+        key=object_keys["manifest_key"],
+        expected_size=len(manifest_bytes),
+        expected_sha256=manifest_sha256,
+    )
+
+    complete_body = build_complete_marker(
+        manifest=manifest,
+        object_keys=object_keys,
+        manifest_sha256=manifest_sha256,
+    )
+    complete_sha256 = compute_sha256_bytes(
+        complete_body
+    )
+    publish_object_if_needed(
+        s3_client=s3_client,
+        bucket=config["bucket"],
+        key=object_keys["complete_key"],
+        body=complete_body,
+        sha256_hex=complete_sha256,
+        sse=config["sse"],
+        kms_key_id=config["kms_key_id"],
+        content_type="application/json",
+    )
+    verify_remote_object(
+        s3_client=s3_client,
+        bucket=config["bucket"],
+        key=object_keys["complete_key"],
+        expected_size=len(complete_body),
+        expected_sha256=complete_sha256,
+    )
+
+    return {
+        "result": "PASS",
+        "format_version": REMOTE_FORMAT_VERSION,
+        "complete_key": object_keys["complete_key"],
+        "dump_sha256": manifest["dump_sha256"],
+    }
+
+
+def build_argument_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Publish validated PostgreSQL logical backup artifacts to durable off-platform storage."
+    )
+    parser.add_argument(
+        "--dump-file",
+        required=True,
+    )
+    parser.add_argument(
+        "--manifest",
+        required=True,
+    )
+    return parser
+
+
+def sanitize_publish_error_message(
+    message: str,
+) -> str:
+    sanitized = sanitize_cli_error_message(message)
+    sanitized = re.sub(
+        r"https?://\S+",
+        "[REDACTED_ENDPOINT_URL]",
+        sanitized,
+        flags=re.IGNORECASE,
+    )
+    sanitized = re.sub(
+        r"(aws_access_key_id|aws_secret_access_key|session_token)"
+        r"\s*=\s*[^,\s]+",
+        r"\1=[REDACTED]",
+        sanitized,
+        flags=re.IGNORECASE,
+    )
+    return sanitized.strip() or "Operational failure."
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_argument_parser()
+    args = parser.parse_args(argv)
+
+    try:
+        result = run_publish(
+            dump_path=Path(args.dump_file),
+            manifest_path=Path(args.manifest),
+        )
+    except BackupToolError as exc:
+        print(
+            sanitize_publish_error_message(
+                str(exc)
+            ),
+            file=sys.stderr,
+        )
+        return 1
+    except Exception as exc:
+        print(
+            sanitize_publish_error_message(
+                str(exc)
+            ),
+            file=sys.stderr,
+        )
+        return 1
+
+    print(json.dumps(result, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/postgres_logical_backup.py
+++ b/scripts/postgres_logical_backup.py
@@ -1,0 +1,519 @@
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+from pathlib import Path
+import re
+import shutil
+import subprocess
+import sys
+from tempfile import NamedTemporaryFile
+from typing import Any
+from urllib.parse import parse_qs, unquote, urlsplit
+
+import psycopg
+
+
+FORMAT_VERSION = "p27a3.backup.v1"
+DEFAULT_OUTPUT_DIR = Path("backups/postgres")
+CRITICAL_TABLES = (
+    "organizations",
+    "users",
+    "lotes",
+    "audit_logs",
+    "vault_documents",
+    "batch_imports",
+)
+INVENTORY_EXCLUDED_TABLES = frozenset(
+    {
+        "alembic_version",
+        "spatial_ref_sys",
+    }
+)
+
+
+class BackupToolError(RuntimeError):
+    """Fail-closed logical backup error."""
+
+
+def normalize_database_url(raw_url: str) -> str:
+    normalized = str(raw_url or "").strip()
+    if normalized.startswith("postgresql+psycopg://"):
+        return normalized.replace(
+            "postgresql+psycopg://",
+            "postgresql://",
+            1,
+        )
+    if normalized.startswith("postgresql://"):
+        return normalized
+    if normalized.startswith("postgres://"):
+        return normalized.replace(
+            "postgres://",
+            "postgresql://",
+            1,
+        )
+    return normalized
+
+
+def require_environment_url(variable_name: str) -> str:
+    value = str(os.environ.get(variable_name) or "").strip()
+    if not value:
+        raise BackupToolError(
+            f"{variable_name} is required."
+        )
+    return normalize_database_url(value)
+
+
+def parse_database_url(database_url: str) -> dict[str, Any]:
+    normalized_url = normalize_database_url(database_url)
+    parsed = urlsplit(normalized_url)
+
+    if parsed.scheme != "postgresql":
+        raise BackupToolError(
+            "Only PostgreSQL libpq-compatible URLs are supported."
+        )
+
+    hostname = (parsed.hostname or "").strip()
+    database_name = parsed.path.lstrip("/").strip()
+
+    if not hostname or not database_name:
+        raise BackupToolError(
+            "Database URL must include host and database name."
+        )
+
+    query = parse_qs(parsed.query, keep_blank_values=True)
+
+    return {
+        "scheme": parsed.scheme,
+        "hostname": hostname,
+        "port": parsed.port or 5432,
+        "username": unquote(parsed.username or ""),
+        "password": unquote(parsed.password or ""),
+        "database": database_name,
+        "query": query,
+    }
+
+
+def reject_pooled_neon_endpoint(hostname: str) -> None:
+    if "-pooler" in str(hostname or "").strip().lower():
+        raise BackupToolError(
+            "P2.7A3 requires direct/unpooled PostgreSQL connections."
+        )
+
+
+def build_libpq_environment(parsed_url: dict[str, Any]) -> dict[str, str]:
+    environment = os.environ.copy()
+    environment["PGHOST"] = str(parsed_url["hostname"])
+    environment["PGPORT"] = str(parsed_url["port"])
+    environment["PGUSER"] = str(parsed_url["username"])
+    environment["PGPASSWORD"] = str(parsed_url["password"])
+    environment["PGDATABASE"] = str(parsed_url["database"])
+
+    query = parsed_url["query"]
+    if "sslmode" in query and query["sslmode"]:
+        environment["PGSSLMODE"] = query["sslmode"][-1]
+    if "channel_binding" in query and query["channel_binding"]:
+        environment["PGCHANNELBINDING"] = query["channel_binding"][-1]
+
+    return environment
+
+
+def require_binary_in_path(binary_name: str) -> str:
+    resolved = shutil.which(binary_name)
+    if not resolved:
+        raise BackupToolError(
+            f"{binary_name} is required in PATH."
+        )
+    return resolved
+
+
+def extract_major_version(version_text: str) -> int:
+    digits: list[str] = []
+    saw_digit = False
+    for char in str(version_text):
+        if char.isdigit():
+            digits.append(char)
+            saw_digit = True
+            continue
+        if saw_digit:
+            break
+    if not digits:
+        raise BackupToolError(
+            f"Unable to determine major version from {version_text!r}."
+        )
+    return int("".join(digits))
+
+
+def get_binary_version(binary_path: str) -> str:
+    result = subprocess.run(
+        [binary_path, "--version"],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return str(result.stdout or result.stderr).strip()
+
+
+def build_identity_fingerprint(
+    *,
+    hostname: str,
+    port: int,
+    database_name: str,
+) -> str:
+    payload = (
+        f"{str(hostname).strip().lower()}:{int(port)}:"
+        f"{str(database_name).strip().lower()}"
+    )
+    return hashlib.sha256(
+        payload.encode("utf-8")
+    ).hexdigest()
+
+
+def sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        while True:
+            chunk = handle.read(1024 * 1024)
+            if not chunk:
+                break
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def atomic_write_json(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with NamedTemporaryFile(
+        "w",
+        encoding="utf-8",
+        delete=False,
+        dir=path.parent,
+        suffix=".partial",
+    ) as handle:
+        json.dump(
+            payload,
+            handle,
+            indent=2,
+            sort_keys=True,
+        )
+        handle.write("\n")
+        temp_path = Path(handle.name)
+    temp_path.replace(path)
+
+
+def utc_timestamp_for_filename() -> str:
+    from datetime import datetime, timezone
+
+    return datetime.now(timezone.utc).strftime(
+        "%Y%m%dT%H%M%SZ"
+    )
+
+
+def utc_timestamp_iso() -> str:
+    from datetime import datetime, timezone
+
+    return datetime.now(timezone.utc).replace(
+        microsecond=0
+    ).isoformat().replace("+00:00", "Z")
+
+
+def sanitize_cli_error_message(message: str) -> str:
+    sanitized = re.sub(
+        r"postgres(?:ql(?:\+psycopg)?)?://\S+",
+        "[REDACTED_DATABASE_URL]",
+        str(message or ""),
+        flags=re.IGNORECASE,
+    )
+    sanitized = re.sub(
+        r"password\s*=\s*[^,\s]+",
+        "password=[REDACTED]",
+        sanitized,
+        flags=re.IGNORECASE,
+    )
+    return sanitized.strip() or "Operational failure."
+
+
+def collect_database_metadata(database_url: str) -> dict[str, Any]:
+    normalized_url = normalize_database_url(database_url)
+    parsed_url = parse_database_url(normalized_url)
+    reject_pooled_neon_endpoint(parsed_url["hostname"])
+
+    with psycopg.connect(normalized_url) as connection:
+        with connection.cursor() as cursor:
+            cursor.execute("SELECT current_database()")
+            database_name = str(cursor.fetchone()[0])
+
+            cursor.execute("SHOW server_version")
+            postgres_version = str(cursor.fetchone()[0])
+
+            cursor.execute(
+                "SELECT version_num FROM alembic_version"
+            )
+            alembic_revision = str(cursor.fetchone()[0])
+
+            cursor.execute(
+                """
+                SELECT extversion
+                FROM pg_extension
+                WHERE extname = 'postgis'
+                """
+            )
+            postgis_row = cursor.fetchone()
+            postgis_version = (
+                str(postgis_row[0])
+                if postgis_row is not None
+                else None
+            )
+
+            cursor.execute(
+                """
+                SELECT tablename
+                FROM pg_tables
+                WHERE schemaname = 'public'
+                ORDER BY tablename
+                """
+            )
+            raw_inventory = [
+                str(row[0]) for row in cursor.fetchall()
+            ]
+            table_inventory = [
+                table_name
+                for table_name in raw_inventory
+                if table_name not in INVENTORY_EXCLUDED_TABLES
+            ]
+
+            critical_row_counts: dict[str, int] = {}
+            for table_name in CRITICAL_TABLES:
+                if table_name not in raw_inventory:
+                    continue
+                cursor.execute(
+                    f'SELECT COUNT(*) FROM "{table_name}"'
+                )
+                critical_row_counts[table_name] = int(
+                    cursor.fetchone()[0]
+                )
+
+    return {
+        "database_name": database_name,
+        "postgres_server_version": postgres_version,
+        "alembic_revision": alembic_revision,
+        "postgis_version": postgis_version,
+        "table_inventory": table_inventory,
+        "critical_row_counts": critical_row_counts,
+        "source_identity_sha256": build_identity_fingerprint(
+            hostname=parsed_url["hostname"],
+            port=int(parsed_url["port"]),
+            database_name=database_name,
+        ),
+    }
+
+
+def build_pg_dump_command(
+    *,
+    binary_path: str,
+    dump_path: Path,
+) -> list[str]:
+    return [
+        binary_path,
+        "--format=custom",
+        "--file",
+        str(dump_path),
+        "--no-password",
+    ]
+
+
+def create_backup_manifest(
+    *,
+    created_at_utc: str,
+    source_label: str,
+    release_commit: str,
+    metadata: dict[str, Any],
+    pg_dump_version: str,
+    dump_filename: str,
+    dump_sha256: str,
+    dump_size_bytes: int,
+) -> dict[str, Any]:
+    return {
+        "format_version": FORMAT_VERSION,
+        "created_at_utc": created_at_utc,
+        "source_label": source_label,
+        "release_commit": release_commit,
+        "database_name": metadata["database_name"],
+        "source_identity_sha256": metadata[
+            "source_identity_sha256"
+        ],
+        "postgres_server_version": metadata[
+            "postgres_server_version"
+        ],
+        "pg_dump_version": pg_dump_version,
+        "alembic_revision": metadata[
+            "alembic_revision"
+        ],
+        "postgis_version": metadata["postgis_version"],
+        "table_inventory": list(metadata["table_inventory"]),
+        "critical_row_counts": dict(
+            metadata["critical_row_counts"]
+        ),
+        "dump_filename": dump_filename,
+        "dump_sha256": dump_sha256,
+        "dump_size_bytes": int(dump_size_bytes),
+    }
+
+
+def run_backup(
+    *,
+    output_dir: Path,
+    source_label: str,
+    release_commit: str,
+) -> tuple[Path, Path]:
+    backup_database_url = require_environment_url(
+        "BACKUP_DATABASE_URL"
+    )
+    parsed_url = parse_database_url(
+        backup_database_url
+    )
+    reject_pooled_neon_endpoint(
+        parsed_url["hostname"]
+    )
+
+    pg_dump_path = require_binary_in_path(
+        "pg_dump"
+    )
+    pg_dump_version = get_binary_version(
+        pg_dump_path
+    )
+    metadata = collect_database_metadata(
+        backup_database_url
+    )
+
+    if extract_major_version(
+        pg_dump_version
+    ) != extract_major_version(
+        metadata["postgres_server_version"]
+    ):
+        raise BackupToolError(
+            "pg_dump major version must match the source server major version."
+        )
+
+    created_at_utc = utc_timestamp_iso()
+    timestamp = utc_timestamp_for_filename()
+    safe_source_label = (
+        "".join(
+            char
+            for char in source_label
+            if char.isalnum() or char in {"-", "_"}
+        ).strip("_-")
+        or "source"
+    )
+
+    output_dir.mkdir(parents=True, exist_ok=True)
+    final_dump_path = output_dir / (
+        f"{timestamp}_{safe_source_label}.dump"
+    )
+    partial_dump_path = final_dump_path.with_suffix(
+        ".dump.partial"
+    )
+    manifest_path = output_dir / (
+        f"{timestamp}_{safe_source_label}.manifest.json"
+    )
+
+    command = build_pg_dump_command(
+        binary_path=pg_dump_path,
+        dump_path=partial_dump_path,
+    )
+
+    try:
+        subprocess.run(
+            command,
+            check=True,
+            env=build_libpq_environment(parsed_url),
+        )
+    except Exception:
+        if partial_dump_path.exists():
+            partial_dump_path.unlink()
+        raise
+
+    partial_dump_path.replace(final_dump_path)
+    dump_sha256 = sha256_file(final_dump_path)
+    dump_size_bytes = final_dump_path.stat().st_size
+
+    manifest = create_backup_manifest(
+        created_at_utc=created_at_utc,
+        source_label=source_label,
+        release_commit=release_commit,
+        metadata=metadata,
+        pg_dump_version=pg_dump_version,
+        dump_filename=final_dump_path.name,
+        dump_sha256=dump_sha256,
+        dump_size_bytes=dump_size_bytes,
+    )
+    atomic_write_json(
+        manifest_path,
+        manifest,
+    )
+    return final_dump_path, manifest_path
+
+
+def build_argument_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Create an independent PostgreSQL logical backup artifact."
+    )
+    parser.add_argument(
+        "--output-dir",
+        default=str(DEFAULT_OUTPUT_DIR),
+    )
+    parser.add_argument(
+        "--source-label",
+        required=True,
+    )
+    parser.add_argument(
+        "--release-commit",
+        required=True,
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_argument_parser()
+    args = parser.parse_args(argv)
+
+    try:
+        dump_path, manifest_path = run_backup(
+            output_dir=Path(args.output_dir),
+            source_label=str(args.source_label),
+            release_commit=str(args.release_commit),
+        )
+    except BackupToolError as exc:
+        print(
+            sanitize_cli_error_message(str(exc)),
+            file=sys.stderr,
+        )
+        return 1
+    except subprocess.CalledProcessError as exc:
+        print(
+            f"pg_dump failed with exit code {exc.returncode}.",
+            file=sys.stderr,
+        )
+        return 1
+    except Exception as exc:
+        print(
+            sanitize_cli_error_message(str(exc)),
+            file=sys.stderr,
+        )
+        return 1
+
+    print(
+        json.dumps(
+            {
+                "dump_filename": dump_path.name,
+                "manifest_filename": manifest_path.name,
+            },
+            sort_keys=True,
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Scope
Backport mínimo para activar P2.7A3C2 en la rama por defecto `main` sin llevar el resto de P2.

Incluye únicamente:
- `.github/workflows/postgres-logical-backup.yml`
- `scripts/postgres_logical_backup.py`
- `scripts/postgres_backup_publish.py`

## Validación realizada
- `py_compile` de ambos scripts: PASS
- smoke de entrypoints usados por el workflow: PASS
- `git diff --cached --check`: PASS
- archivos byte-for-byte idénticos a los auditados en `b1b1847`
- branch compare: 1 commit ahead / 0 behind de `main`

## Seguridad operacional
- No incluye migraciones ni código de aplicación.
- No modifica el branch de Render.
- No ejecuta backup hasta que el workflow exista en `main`.
- AWS usa GitHub OIDC y el environment `production-backup`.
- El workflow publica primero dump + manifest y `complete.json` al final.

## Objetivo
Habilitar la ejecución programada independiente `pg_dump` → S3 para soportar el RPO lógico <=24h de P2.7A3.

No cerrar P2.7A3 hasta ejecutar manualmente `workflow_dispatch` desde `main` y verificar evidencia real en S3.