### PR TITLE
fix(dr): initialize backup workdir from runner temp

### DIFF
--- a/.github/workflows/postgres-logical-backup.yml
+++ b/.github/workflows/postgres-logical-backup.yml
@@ -27,7 +27,6 @@ jobs:
       BACKUP_S3_REGION: ${{ vars.BACKUP_S3_REGION }}
       BACKUP_S3_SSE: ${{ vars.BACKUP_S3_SSE }}
       BACKUP_RELEASE_COMMIT: ${{ vars.BACKUP_RELEASE_COMMIT }}
-      BACKUP_WORKDIR: ${{ runner.temp }}/litoral-trace-postgres-backup
     steps:
       - name: Checkout
         # actions/checkout@v4
@@ -79,6 +78,11 @@ jobs:
           if [ "$missing" -ne 0 ]; then
             exit 1
           fi
+
+      - name: Initialize backup workdir
+        shell: bash
+        run: |
+          echo "BACKUP_WORKDIR=$RUNNER_TEMP/litoral-trace-postgres-backup" >> "$GITHUB_ENV"
 
       - name: Create logical backup
         shell: bash


### PR DESCRIPTION
## Scope
Corrección mínima del workflow P2.7A3 ya activado en `main`.

Incluye únicamente:
- `.github/workflows/postgres-logical-backup.yml`

## Problema corregido
GitHub rechazaba el workflow en validación porque `runner.temp` se usaba dentro de `job.env`, donde ese contexto no está disponible.

## Corrección
- Se elimina `BACKUP_WORKDIR: ${{ runner.temp }}/...` de `job.env`.
- Se inicializa `BACKUP_WORKDIR` desde `$RUNNER_TEMP` en un step dedicado.
- Se persiste mediante `$GITHUB_ENV` para los steps posteriores.

## Validación realizada
- `git diff --check`: PASS
- referencias `${{ runner.* }}` inválidas: 0
- scope staged: 1 archivo
- branch compare: 1 commit ahead / 0 behind de `main`

## Seguridad operacional
No modifica scripts, credenciales, AWS, Neon, Render ni lógica del backup. El fallo previo ocurrió antes de crear jobs, por lo que no ejecutó backup real.

Después del merge, ejecutar `workflow_dispatch` desde `main` y verificar la primera publicación real en S3 antes de cerrar P2.7A3.