### PR TITLE
fix(dr): install PostgreSQL client non-interactively

### DIFF
--- a/.github/workflows/postgres-logical-backup.yml
+++ b/.github/workflows/postgres-logical-backup.yml
@@ -52,7 +52,12 @@ jobs:
       - name: Install PostgreSQL 17 client
         run: |
           sudo install -d -m 0755 /usr/share/postgresql-common/pgdg
-          curl -fsSL https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo gpg --dearmor -o /usr/share/postgresql-common/pgdg/apt.postgresql.org.gpg
+          key_asc="$RUNNER_TEMP/postgresql-pgdg.asc"
+          key_gpg="$RUNNER_TEMP/postgresql-pgdg.gpg"
+          curl -fsSL https://www.postgresql.org/media/keys/ACCC4CF8.asc -o "$key_asc"
+          gpg --batch --yes --dearmor --output "$key_gpg" "$key_asc"
+          sudo install -m 0644 "$key_gpg" /usr/share/postgresql-common/pgdg/apt.postgresql.org.gpg
+          rm -f "$key_asc" "$key_gpg"
           echo "deb [signed-by=/usr/share/postgresql-common/pgdg/apt.postgresql.org.gpg] https://apt.postgresql.org/pub/repos/apt $(. /etc/os-release && echo "$VERSION_CODENAME")-pgdg main" | sudo tee /etc/apt/sources.list.d/pgdg.list > /dev/null
           sudo apt-get update
           sudo apt-get install -y postgresql-client-17


### PR DESCRIPTION
## Scope
Corrección mínima del workflow P2.7A3 tras el primer `workflow_dispatch` real desde `main`.

Incluye únicamente:
- `.github/workflows/postgres-logical-backup.yml`

## Problema observado
El run `32086059950` llegó correctamente hasta `Install PostgreSQL 17 client` y falló porque `gpg` intentó abrir `/dev/tty` en GitHub Actions:

`gpg: cannot open '/dev/tty': No such device or address`

Los pasos de backup, AWS OIDC y publicación S3 quedaron skipped; cleanup terminó correctamente.

## Corrección
- Descarga la clave PGDG a `$RUNNER_TEMP`.
- Ejecuta `gpg --batch --yes --dearmor` sin interacción.
- Instala el keyring resultante con `sudo install`.
- Elimina los archivos temporales de clave.

## Validación
- rama basada en `main` actual
- 1 commit ahead / 0 behind
- 1 archivo modificado
- `git diff --check`: PASS

## Seguridad operacional
No modifica credenciales, Neon, AWS IAM, S3, Render, scripts de backup ni lógica de publicación. Sólo corrige la instalación no interactiva del cliente PostgreSQL 17 en el runner.