### PR TITLE
fix(dr): prefer PostgreSQL 17 client binaries

### DIFF
--- a/.github/workflows/postgres-logical-backup.yml
+++ b/.github/workflows/postgres-logical-backup.yml
@@ -61,6 +61,9 @@ jobs:
           echo "deb [signed-by=/usr/share/postgresql-common/pgdg/apt.postgresql.org.gpg] https://apt.postgresql.org/pub/repos/apt $(. /etc/os-release && echo "$VERSION_CODENAME")-pgdg main" | sudo tee /etc/apt/sources.list.d/pgdg.list > /dev/null
           sudo apt-get update
           sudo apt-get install -y postgresql-client-17
+          test -x /usr/lib/postgresql/17/bin/pg_dump
+          test -x /usr/lib/postgresql/17/bin/pg_restore
+          echo "/usr/lib/postgresql/17/bin" >> "$GITHUB_PATH"
 
       - name: Verify PostgreSQL 17 client tools
         shell: bash


### PR DESCRIPTION
## Scope
Corrección mínima de P2.7A3 tras el segundo `workflow_dispatch` real.

Incluye únicamente:
- `.github/workflows/postgres-logical-backup.yml`

## Problema observado
El run `32086698633` instaló correctamente `postgresql-client-17`, pero el runner siguió resolviendo `pg_dump` y `pg_restore` desde PostgreSQL 16 preinstalado en `PATH`. La verificación falló antes de tocar Neon/AWS/S3.

## Corrección
- Verifica que existan `/usr/lib/postgresql/17/bin/pg_dump` y `pg_restore`.
- Añade `/usr/lib/postgresql/17/bin` a `$GITHUB_PATH` para todos los steps posteriores.

## Validación
- rama basada en `main` actual
- 1 commit ahead / 0 behind
- 1 archivo modificado
- 3 líneas añadidas, 0 eliminadas

## Seguridad operacional
No modifica credenciales, Neon, IAM, S3, Render ni scripts de backup. Sólo fija la precedencia del cliente PostgreSQL 17 ya instalado.