### PR TITLE
feat(dr): enforce pre-migration recovery gate P2.7A5

### DIFF
--- a/DEPLOYMENT_RUNBOOK.md
+++ b/DEPLOYMENT_RUNBOOK.md
@@ -240,6 +240,64 @@ See DISASTER_RECOVERY_RUNBOOK.md.
 
 Schema-changing production deployments require a verified recovery point before migration.
 
+P2.7A5 makes this requirement executable and fail-closed.
+
+Immediately before a schema-changing deployment:
+
+1. trigger or verify a fresh PostgreSQL Logical Backup for production;
+2. wait for successful off-platform publication;
+3. retrieve the exact manifest and complete.json from the immutable backup bucket using an authorized read-only/operator identity;
+4. do not edit, rename, regenerate, or hand-author either evidence file;
+5. identify the currently deployed production release commit before checking out/cutting over the candidate release.
+
+Export only for the controlled deployment shell:
+
+PRE_MIGRATION_RECOVERY_MANIFEST=/secure/temp/<exact-production-manifest>.json
+
+PRE_MIGRATION_RECOVERY_COMPLETE=/secure/temp/complete.json
+
+PRE_MIGRATION_SOURCE_RELEASE_COMMIT=<currently deployed production release commit>
+
+PRE_MIGRATION_OPERATOR=<operator identity>
+
+PRE_MIGRATION_TARGET_ENV=production
+
+PRE_MIGRATION_MAX_AGE_MINUTES=120
+
+MIGRATION_DATABASE_URL=<load-from-secret-manager>
+
+PRE_MIGRATION_SOURCE_RELEASE_COMMIT refers to the release serving production before the candidate migration. It is not the candidate release commit.
+
+deploy_production.sh mounts the manifest and complete marker read-only and executes:
+
+python -m scripts.pre_migration_recovery_gate
+
+The gate must PASS before Alembic is invoked.
+
+The executable gate verifies:
+
+- manifest SHA-256 against complete.json;
+- manifest/dump binding recorded by complete.json;
+- production source label;
+- the currently deployed production release;
+- recovery-point age no greater than 120 minutes by default;
+- no invalid future timestamps;
+- exact database identity through source_identity_sha256;
+- production database name;
+- current Alembic revision;
+- PostgreSQL major-version compatibility;
+- PostGIS major.minor compatibility.
+
+The complete marker is accepted as publication evidence only because the P2.7A3 publisher writes it after successful remote verification of the dump and manifest.
+
+If any check fails the result is NO MIGRATION.
+
+Do not bypass the gate merely because a backup file exists.
+
+Do not substitute a locally generated manifest/complete marker for evidence retrieved from the protected off-platform backup domain.
+
+After a successful production cutover, update the scheduled-backup release metadata so future backups identify the newly deployed production release.
+
 Go-live PITR/history target is >= 7 days, and current provider settings must be checked against that target before release approval.
 
 Successful isolated restore testing is required.

--- a/DISASTER_RECOVERY_RUNBOOK.md
+++ b/DISASTER_RECOVERY_RUNBOOK.md
@@ -472,3 +472,150 @@ Operational acceptance boundary
 P2.7A4 proves and documents recovery semantics.
 
 P2.7A6 remains responsible for final production disaster-recovery acceptance, including any provider-loss scenario, independent Vault recovery copy/replica requirement, measured recovery evidence, and go-live sign-off.
+
+13. P2.7A5 executable pre-migration recovery gate
+
+P2.7A5 status:
+
+IMPLEMENTED - executable fail-closed gate is present and unit-tested.
+
+Operational execution against real production recovery evidence is still required before P2.7A5 is declared fully accepted. Final disaster-recovery acceptance remains P2.7A6.
+
+Purpose
+
+Every production migration must have a recovery point that is demonstrably bound to the production state immediately before the migration.
+
+A backup file existing somewhere is insufficient.
+
+The gate runs before Alembic.
+
+If validation fails, the required result is:
+
+NO MIGRATION
+
+Recovery evidence
+
+The gate consumes two P2.7A3 artifacts obtained from the protected off-platform backup domain:
+
+- the exact production manifest
+- its complete.json publication marker
+
+The manifest must not be renamed or modified after retrieval.
+
+The complete marker must not be regenerated locally.
+
+The operator does not need to download the full PostgreSQL dump for this gate.
+
+Publication-chain verification
+
+The gate verifies:
+
+- manifest format
+- complete-marker format
+- manifest_sha256
+- manifest filename binding
+- dump filename binding
+- dump SHA-256 binding
+- dump size binding
+- source label
+- release commit
+- backup timestamp
+- publication timestamp
+
+The P2.7A3 complete marker is meaningful because it is published only after the remote dump and manifest have been verified.
+
+Database binding
+
+The recovery point is compared to the database referenced by the ephemeral MIGRATION_DATABASE_URL.
+
+The gate verifies:
+
+- database name
+- source_identity_sha256
+- current Alembic revision
+- PostgreSQL major version
+- PostGIS major.minor version
+
+source_identity_sha256 binds the recovery point to the host/port/database identity without writing the database URL or hostname into the gate result.
+
+Release binding
+
+PRE_MIGRATION_SOURCE_RELEASE_COMMIT must identify the currently deployed production release before migration.
+
+It must match both the recovery manifest and complete marker.
+
+It is deliberately not the candidate release commit.
+
+Freshness
+
+The default maximum recovery-point age for a schema-changing production migration is:
+
+120 minutes
+
+The backup creation timestamp is authoritative for freshness.
+
+A future timestamp beyond the allowed clock-skew tolerance is invalid.
+
+A normal <= 24 hour logical-backup RPO is not, by itself, sufficient for the stricter pre-migration gate.
+
+Operator evidence
+
+The deployment supplies:
+
+- PRE_MIGRATION_SOURCE_RELEASE_COMMIT
+- PRE_MIGRATION_OPERATOR
+- PRE_MIGRATION_TARGET_ENV=production
+- PRE_MIGRATION_MAX_AGE_MINUTES
+- PRE_MIGRATION_RECOVERY_MANIFEST
+- PRE_MIGRATION_RECOVERY_COMPLETE
+
+A successful gate emits a sanitized PASS record containing:
+
+- verification status
+- verification timestamp
+- operator
+- source production release
+- backup timestamp
+- backup age
+- Alembic revision
+- source_identity_sha256
+- manifest_sha256
+
+The record does not contain a database URL, password, storage credential, or provider endpoint.
+
+Fail-closed rules
+
+NO MIGRATION is required when any of the following is true:
+
+- recovery evidence is missing or invalid
+- manifest_sha256 does not match
+- manifest and complete marker disagree
+- dump SHA-256 or size bindings disagree
+- source label is not production
+- recovery release does not match the currently deployed production release
+- recovery point is older than the configured pre-migration limit
+- evidence timestamps are invalid
+- database name differs
+- source_identity_sha256 differs
+- Alembic revision differs
+- PostgreSQL major version differs
+- PostGIS major.minor version differs
+- target environment is not production
+
+Security boundary
+
+The evidence files must be retrieved from the protected off-platform recovery domain using an authorized operator/read-only identity.
+
+The deployment mounts them read-only.
+
+MIGRATION_DATABASE_URL remains ephemeral and is not written into the evidence.
+
+The executable gate does not weaken the separate Vault recovery contract.
+
+Acceptance boundary
+
+P2.7A5 code completeness is not equivalent to operational acceptance.
+
+A real execution against production recovery evidence must PASS before this gate is considered operationally accepted.
+
+P2.7A6 remains responsible for final DR acceptance and go-live sign-off.

--- a/deploy_production.sh
+++ b/deploy_production.sh
@@ -68,6 +68,7 @@ log "Litoral Trace - production deployment"
 log "=========================================================="
 
 require_command docker
+require_command realpath
 
 docker compose version >/dev/null 2>&1 \
     || fail "Docker Compose v2 ('docker compose') is required."
@@ -81,6 +82,32 @@ cd "$APP_DIR"
 # deployment environment. MIGRATION_DATABASE_URL is deliberately not part of
 # either long-lived service environment.
 require_nonempty_env MIGRATION_DATABASE_URL
+
+# P2.7A5 requires recovery evidence materialized from the immutable
+# off-platform backup domain before any migration attempt.
+require_nonempty_env PRE_MIGRATION_RECOVERY_MANIFEST
+require_nonempty_env PRE_MIGRATION_RECOVERY_COMPLETE
+require_nonempty_env PRE_MIGRATION_SOURCE_RELEASE_COMMIT
+require_nonempty_env PRE_MIGRATION_OPERATOR
+
+PRE_MIGRATION_TARGET_ENV="${PRE_MIGRATION_TARGET_ENV:-production}"
+PRE_MIGRATION_MAX_AGE_MINUTES="${PRE_MIGRATION_MAX_AGE_MINUTES:-120}"
+
+[ "$PRE_MIGRATION_TARGET_ENV" = "production" ] \
+    || fail "PRE_MIGRATION_TARGET_ENV must be production."
+
+[ -f "$PRE_MIGRATION_RECOVERY_MANIFEST" ] \
+    || fail "Pre-migration recovery manifest does not exist."
+
+[ -f "$PRE_MIGRATION_RECOVERY_COMPLETE" ] \
+    || fail "Pre-migration recovery complete marker does not exist."
+
+RECOVERY_MANIFEST_PATH="$(
+    realpath "$PRE_MIGRATION_RECOVERY_MANIFEST"
+)"
+RECOVERY_COMPLETE_PATH="$(
+    realpath "$PRE_MIGRATION_RECOVERY_COMPLETE"
+)"
 
 log "Validating Compose configuration..."
 docker compose -f "$COMPOSE_FILE" config --quiet
@@ -97,11 +124,31 @@ docker compose -f "$COMPOSE_FILE" run \
     app \
     python -m litoral_trace.storage.readiness
 
+# P2.7A5 fail-closed gate. Recovery evidence is mounted read-only and the
+# database owner credential is passed through the environment without being
+# persisted in the service definition.
+log "Verifying pre-migration recovery point..."
+docker compose -f "$COMPOSE_FILE" run \
+    --rm \
+    --no-deps \
+    -e MIGRATION_DATABASE_URL \
+    -e PRE_MIGRATION_SOURCE_RELEASE_COMMIT \
+    -e PRE_MIGRATION_OPERATOR \
+    -e PRE_MIGRATION_TARGET_ENV \
+    -e PRE_MIGRATION_MAX_AGE_MINUTES \
+    -v "${RECOVERY_MANIFEST_PATH}:/run/litoral-recovery/manifest.json:ro" \
+    -v "${RECOVERY_COMPLETE_PATH}:/run/litoral-recovery/complete.json:ro" \
+    app \
+    python -m scripts.pre_migration_recovery_gate \
+        --manifest /run/litoral-recovery/manifest.json \
+        --complete-marker /run/litoral-recovery/complete.json \
+        --source-label production
+
 log "Applying Alembic migrations with an ephemeral owner credential..."
 docker compose -f "$COMPOSE_FILE" run \
     --rm \
     --no-deps \
-    -e MIGRATION_DATABASE_URL="$MIGRATION_DATABASE_URL" \
+    -e MIGRATION_DATABASE_URL \
     app \
     python -m alembic upgrade head
 

--- a/scripts/pre_migration_recovery_gate.py
+++ b/scripts/pre_migration_recovery_gate.py
@@ -1,0 +1,771 @@
+from __future__ import annotations
+
+import argparse
+from collections.abc import Callable
+from datetime import UTC, datetime, timedelta
+import hashlib
+import json
+import os
+from pathlib import Path, PurePosixPath
+import re
+import sys
+from typing import Any
+
+from scripts.postgres_backup_publish import REMOTE_FORMAT_VERSION
+from scripts.postgres_logical_backup import (
+    BackupToolError,
+    FORMAT_VERSION,
+    collect_database_metadata,
+    extract_major_version,
+    require_environment_url,
+    sanitize_cli_error_message,
+)
+
+
+GATE_FORMAT_VERSION = "p27a5.gate.v1"
+DEFAULT_MAX_AGE_MINUTES = 120
+MAX_CLOCK_SKEW_MINUTES = 5
+_SHA256_PATTERN = re.compile(r"^[0-9a-fA-F]{64}$")
+_COMMIT_PATTERN = re.compile(r"^[0-9a-fA-F]{7,64}$")
+
+
+class RecoveryGateError(BackupToolError):
+    """Fail-closed pre-migration recovery-gate error."""
+
+
+DatabaseMetadataCollector = Callable[[str], dict[str, Any]]
+
+
+def _require_mapping(
+    value: object,
+    *,
+    label: str,
+) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        raise RecoveryGateError(
+            f"{label} must be a JSON object."
+        )
+    return value
+
+
+def _load_json_file(
+    path: Path,
+    *,
+    label: str,
+) -> tuple[dict[str, Any], bytes]:
+    try:
+        payload = path.read_bytes()
+    except OSError as exc:
+        raise RecoveryGateError(
+            f"{label} is missing or unreadable."
+        ) from exc
+
+    try:
+        parsed = json.loads(payload)
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise RecoveryGateError(
+            f"{label} is not valid JSON."
+        ) from exc
+
+    return (
+        _require_mapping(
+            parsed,
+            label=label,
+        ),
+        payload,
+    )
+
+
+def _require_fields(
+    payload: dict[str, Any],
+    *,
+    required: set[str],
+    label: str,
+) -> None:
+    missing = sorted(
+        required.difference(payload)
+    )
+    if missing:
+        raise RecoveryGateError(
+            f"{label} is missing required fields."
+        )
+
+
+def _require_nonempty_string(
+    value: object,
+    *,
+    label: str,
+) -> str:
+    normalized = str(
+        value if value is not None else ""
+    ).strip()
+
+    if not normalized:
+        raise RecoveryGateError(
+            f"{label} must not be empty."
+        )
+
+    return normalized
+
+
+def _require_sha256(
+    value: object,
+    *,
+    label: str,
+) -> str:
+    normalized = _require_nonempty_string(
+        value,
+        label=label,
+    ).lower()
+
+    if not _SHA256_PATTERN.fullmatch(
+        normalized
+    ):
+        raise RecoveryGateError(
+            f"{label} is not a canonical SHA-256."
+        )
+
+    return normalized
+
+
+def _require_commit(
+    value: object,
+    *,
+    label: str,
+) -> str:
+    normalized = _require_nonempty_string(
+        value,
+        label=label,
+    ).lower()
+
+    if not _COMMIT_PATTERN.fullmatch(
+        normalized
+    ):
+        raise RecoveryGateError(
+            f"{label} is not a valid commit identifier."
+        )
+
+    return normalized
+
+
+def _require_positive_int(
+    value: object,
+    *,
+    label: str,
+) -> int:
+    try:
+        normalized = int(value)
+    except (TypeError, ValueError) as exc:
+        raise RecoveryGateError(
+            f"{label} must be a positive integer."
+        ) from exc
+
+    if normalized <= 0:
+        raise RecoveryGateError(
+            f"{label} must be a positive integer."
+        )
+
+    return normalized
+
+
+def _parse_utc_timestamp(
+    value: object,
+    *,
+    label: str,
+) -> datetime:
+    normalized = _require_nonempty_string(
+        value,
+        label=label,
+    )
+
+    try:
+        parsed = datetime.strptime(
+            normalized,
+            "%Y-%m-%dT%H:%M:%SZ",
+        ).replace(
+            tzinfo=UTC,
+        )
+    except ValueError as exc:
+        raise RecoveryGateError(
+            f"{label} must use canonical UTC ISO format."
+        ) from exc
+
+    return parsed
+
+
+def _basename_from_remote_key(
+    value: object,
+    *,
+    label: str,
+) -> str:
+    normalized = _require_nonempty_string(
+        value,
+        label=label,
+    )
+
+    if "\\" in normalized:
+        raise RecoveryGateError(
+            f"{label} is not a canonical object key."
+        )
+
+    basename = PurePosixPath(
+        normalized
+    ).name
+
+    if (
+        not basename
+        or basename in {".", ".."}
+    ):
+        raise RecoveryGateError(
+            f"{label} is not a canonical object key."
+        )
+
+    return basename
+
+
+def _major_minor_version(
+    value: object,
+    *,
+    label: str,
+) -> tuple[int, int]:
+    normalized = _require_nonempty_string(
+        value,
+        label=label,
+    )
+
+    match = re.search(
+        r"(\d+)\.(\d+)",
+        normalized,
+    )
+    if not match:
+        raise RecoveryGateError(
+            f"{label} does not expose major.minor version."
+        )
+
+    return (
+        int(match.group(1)),
+        int(match.group(2)),
+    )
+
+
+def _utc_iso(
+    value: datetime,
+) -> str:
+    return value.astimezone(
+        UTC
+    ).replace(
+        microsecond=0
+    ).strftime(
+        "%Y-%m-%dT%H:%M:%SZ"
+    )
+
+
+def verify_recovery_gate(
+    *,
+    manifest_path: Path,
+    complete_marker_path: Path,
+    database_url: str,
+    expected_source_release_commit: str,
+    operator: str,
+    target_environment: str,
+    expected_source_label: str = "production",
+    max_age_minutes: int = DEFAULT_MAX_AGE_MINUTES,
+    now_utc: datetime | None = None,
+    database_metadata_collector: DatabaseMetadataCollector = (
+        collect_database_metadata
+    ),
+) -> dict[str, Any]:
+    if (
+        _require_nonempty_string(
+            target_environment,
+            label="target_environment",
+        ).lower()
+        != "production"
+    ):
+        raise RecoveryGateError(
+            "Pre-migration recovery gate accepts only production target."
+        )
+
+    normalized_operator = _require_nonempty_string(
+        operator,
+        label="operator",
+    )
+    if len(normalized_operator) > 160:
+        raise RecoveryGateError(
+            "operator is too long."
+        )
+
+    normalized_source_label = (
+        _require_nonempty_string(
+            expected_source_label,
+            label="expected_source_label",
+        )
+    )
+
+    expected_commit = _require_commit(
+        expected_source_release_commit,
+        label="expected_source_release_commit",
+    )
+
+    normalized_max_age = _require_positive_int(
+        max_age_minutes,
+        label="max_age_minutes",
+    )
+
+    manifest, manifest_bytes = _load_json_file(
+        manifest_path,
+        label="Recovery manifest",
+    )
+    complete, _ = _load_json_file(
+        complete_marker_path,
+        label="Recovery complete marker",
+    )
+
+    _require_fields(
+        manifest,
+        required={
+            "format_version",
+            "created_at_utc",
+            "source_label",
+            "release_commit",
+            "database_name",
+            "source_identity_sha256",
+            "postgres_server_version",
+            "alembic_revision",
+            "postgis_version",
+            "dump_filename",
+            "dump_sha256",
+            "dump_size_bytes",
+        },
+        label="Recovery manifest",
+    )
+
+    _require_fields(
+        complete,
+        required={
+            "format_version",
+            "source_label",
+            "release_commit",
+            "backup_created_at_utc",
+            "published_at_utc",
+            "dump_key",
+            "dump_sha256",
+            "dump_size_bytes",
+            "manifest_key",
+            "manifest_sha256",
+        },
+        label="Recovery complete marker",
+    )
+
+    if manifest["format_version"] != FORMAT_VERSION:
+        raise RecoveryGateError(
+            "Recovery manifest format is unsupported."
+        )
+
+    if complete["format_version"] != REMOTE_FORMAT_VERSION:
+        raise RecoveryGateError(
+            "Recovery complete-marker format is unsupported."
+        )
+
+    manifest_sha256 = hashlib.sha256(
+        manifest_bytes
+    ).hexdigest()
+
+    expected_manifest_sha256 = _require_sha256(
+        complete["manifest_sha256"],
+        label="complete.manifest_sha256",
+    )
+
+    if manifest_sha256 != expected_manifest_sha256:
+        raise RecoveryGateError(
+            "Recovery manifest SHA-256 does not match complete marker."
+        )
+
+    remote_manifest_basename = (
+        _basename_from_remote_key(
+            complete["manifest_key"],
+            label="complete.manifest_key",
+        )
+    )
+
+    if remote_manifest_basename != manifest_path.name:
+        raise RecoveryGateError(
+            "Recovery manifest filename does not match complete marker."
+        )
+
+    manifest_dump_filename = (
+        _require_nonempty_string(
+            manifest["dump_filename"],
+            label="manifest.dump_filename",
+        )
+    )
+
+    remote_dump_basename = _basename_from_remote_key(
+        complete["dump_key"],
+        label="complete.dump_key",
+    )
+
+    if remote_dump_basename != manifest_dump_filename:
+        raise RecoveryGateError(
+            "Recovery dump binding does not match manifest."
+        )
+
+    manifest_dump_sha256 = _require_sha256(
+        manifest["dump_sha256"],
+        label="manifest.dump_sha256",
+    )
+    complete_dump_sha256 = _require_sha256(
+        complete["dump_sha256"],
+        label="complete.dump_sha256",
+    )
+
+    if manifest_dump_sha256 != complete_dump_sha256:
+        raise RecoveryGateError(
+            "Recovery dump SHA-256 binding is inconsistent."
+        )
+
+    manifest_dump_size = _require_positive_int(
+        manifest["dump_size_bytes"],
+        label="manifest.dump_size_bytes",
+    )
+    complete_dump_size = _require_positive_int(
+        complete["dump_size_bytes"],
+        label="complete.dump_size_bytes",
+    )
+
+    if manifest_dump_size != complete_dump_size:
+        raise RecoveryGateError(
+            "Recovery dump size binding is inconsistent."
+        )
+
+    manifest_source_label = (
+        _require_nonempty_string(
+            manifest["source_label"],
+            label="manifest.source_label",
+        )
+    )
+    complete_source_label = (
+        _require_nonempty_string(
+            complete["source_label"],
+            label="complete.source_label",
+        )
+    )
+
+    if (
+        manifest_source_label
+        != normalized_source_label
+        or complete_source_label
+        != normalized_source_label
+    ):
+        raise RecoveryGateError(
+            "Recovery source label does not match production."
+        )
+
+    manifest_commit = _require_commit(
+        manifest["release_commit"],
+        label="manifest.release_commit",
+    )
+    complete_commit = _require_commit(
+        complete["release_commit"],
+        label="complete.release_commit",
+    )
+
+    if (
+        manifest_commit != expected_commit
+        or complete_commit != expected_commit
+    ):
+        raise RecoveryGateError(
+            "Recovery point does not match the currently deployed release."
+        )
+
+    manifest_created_at = _parse_utc_timestamp(
+        manifest["created_at_utc"],
+        label="manifest.created_at_utc",
+    )
+    complete_created_at = _parse_utc_timestamp(
+        complete["backup_created_at_utc"],
+        label="complete.backup_created_at_utc",
+    )
+    published_at = _parse_utc_timestamp(
+        complete["published_at_utc"],
+        label="complete.published_at_utc",
+    )
+
+    if manifest_created_at != complete_created_at:
+        raise RecoveryGateError(
+            "Recovery timestamps are inconsistent."
+        )
+
+    active_now = (
+        now_utc.astimezone(UTC)
+        if now_utc is not None
+        else datetime.now(UTC)
+    )
+
+    if published_at < manifest_created_at:
+        raise RecoveryGateError(
+            "Recovery publication timestamp precedes backup creation."
+        )
+
+    max_future = active_now + timedelta(
+        minutes=MAX_CLOCK_SKEW_MINUTES
+    )
+
+    if (
+        manifest_created_at > max_future
+        or published_at > max_future
+    ):
+        raise RecoveryGateError(
+            "Recovery evidence has an invalid future timestamp."
+        )
+
+    age = active_now - manifest_created_at
+
+    if age > timedelta(
+        minutes=normalized_max_age
+    ):
+        raise RecoveryGateError(
+            "Recovery point is too old for a schema-changing migration."
+        )
+
+    live_metadata = database_metadata_collector(
+        database_url
+    )
+
+    manifest_database_name = (
+        _require_nonempty_string(
+            manifest["database_name"],
+            label="manifest.database_name",
+        )
+    )
+    live_database_name = (
+        _require_nonempty_string(
+            live_metadata.get("database_name"),
+            label="live.database_name",
+        )
+    )
+
+    if manifest_database_name != live_database_name:
+        raise RecoveryGateError(
+            "Recovery point targets a different database."
+        )
+
+    manifest_identity = _require_sha256(
+        manifest["source_identity_sha256"],
+        label="manifest.source_identity_sha256",
+    )
+    live_identity = _require_sha256(
+        live_metadata.get("source_identity_sha256"),
+        label="live.source_identity_sha256",
+    )
+
+    if manifest_identity != live_identity:
+        raise RecoveryGateError(
+            "Recovery point targets a different database identity."
+        )
+
+    manifest_alembic = _require_nonempty_string(
+        manifest["alembic_revision"],
+        label="manifest.alembic_revision",
+    )
+    live_alembic = _require_nonempty_string(
+        live_metadata.get("alembic_revision"),
+        label="live.alembic_revision",
+    )
+
+    if manifest_alembic != live_alembic:
+        raise RecoveryGateError(
+            "Recovery point Alembic revision does not match production."
+        )
+
+    manifest_pg_major = extract_major_version(
+        _require_nonempty_string(
+            manifest["postgres_server_version"],
+            label="manifest.postgres_server_version",
+        )
+    )
+    live_pg_major = extract_major_version(
+        _require_nonempty_string(
+            live_metadata.get(
+                "postgres_server_version"
+            ),
+            label="live.postgres_server_version",
+        )
+    )
+
+    if manifest_pg_major != live_pg_major:
+        raise RecoveryGateError(
+            "Recovery point PostgreSQL major version does not match production."
+        )
+
+    manifest_postgis = _major_minor_version(
+        manifest["postgis_version"],
+        label="manifest.postgis_version",
+    )
+    live_postgis = _major_minor_version(
+        live_metadata.get("postgis_version"),
+        label="live.postgis_version",
+    )
+
+    if manifest_postgis != live_postgis:
+        raise RecoveryGateError(
+            "Recovery point PostGIS major.minor does not match production."
+        )
+
+    age_seconds = max(
+        0,
+        int(age.total_seconds()),
+    )
+
+    return {
+        "format_version": GATE_FORMAT_VERSION,
+        "result": "PASS",
+        "verification_status": "PASS",
+        "verified_at_utc": _utc_iso(
+            active_now
+        ),
+        "target_environment": "production",
+        "operator": normalized_operator,
+        "source_label": normalized_source_label,
+        "source_release_commit": expected_commit,
+        "backup_created_at_utc": _utc_iso(
+            manifest_created_at
+        ),
+        "backup_age_seconds": age_seconds,
+        "alembic_revision": live_alembic,
+        "source_identity_sha256": live_identity,
+        "manifest_sha256": manifest_sha256,
+    }
+
+
+def _positive_cli_int(
+    raw_value: str,
+) -> int:
+    try:
+        value = int(raw_value)
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError(
+            "must be a positive integer"
+        ) from exc
+
+    if value <= 0:
+        raise argparse.ArgumentTypeError(
+            "must be a positive integer"
+        )
+
+    return value
+
+
+def build_argument_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Fail-closed production recovery-point gate "
+            "before schema migration."
+        )
+    )
+    parser.add_argument(
+        "--manifest",
+        required=True,
+    )
+    parser.add_argument(
+        "--complete-marker",
+        required=True,
+    )
+    parser.add_argument(
+        "--source-label",
+        default="production",
+    )
+    parser.add_argument(
+        "--max-age-minutes",
+        type=_positive_cli_int,
+        default=_positive_cli_int(
+            os.environ.get(
+                "PRE_MIGRATION_MAX_AGE_MINUTES",
+                str(DEFAULT_MAX_AGE_MINUTES),
+            )
+        ),
+    )
+    return parser
+
+
+def main(
+    argv: list[str] | None = None,
+) -> int:
+    parser = build_argument_parser()
+    args = parser.parse_args(argv)
+
+    try:
+        database_url = require_environment_url(
+            "MIGRATION_DATABASE_URL"
+        )
+        source_release_commit = (
+            _require_nonempty_string(
+                os.environ.get(
+                    "PRE_MIGRATION_SOURCE_RELEASE_COMMIT"
+                ),
+                label=(
+                    "PRE_MIGRATION_SOURCE_RELEASE_COMMIT"
+                ),
+            )
+        )
+        operator = _require_nonempty_string(
+            os.environ.get(
+                "PRE_MIGRATION_OPERATOR"
+            ),
+            label="PRE_MIGRATION_OPERATOR",
+        )
+        target_environment = (
+            os.environ.get(
+                "PRE_MIGRATION_TARGET_ENV"
+            )
+            or "production"
+        )
+
+        result = verify_recovery_gate(
+            manifest_path=Path(
+                args.manifest
+            ),
+            complete_marker_path=Path(
+                args.complete_marker
+            ),
+            database_url=database_url,
+            expected_source_release_commit=(
+                source_release_commit
+            ),
+            operator=operator,
+            target_environment=target_environment,
+            expected_source_label=(
+                args.source_label
+            ),
+            max_age_minutes=(
+                args.max_age_minutes
+            ),
+        )
+    except BackupToolError as exc:
+        print(
+            sanitize_cli_error_message(
+                str(exc)
+            ),
+            file=sys.stderr,
+        )
+        return 1
+    except Exception as exc:
+        print(
+            sanitize_cli_error_message(
+                str(exc)
+            ),
+            file=sys.stderr,
+        )
+        return 1
+
+    print(
+        json.dumps(
+            result,
+            sort_keys=True,
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_deploy_phase3_unittest.py
+++ b/tests/test_deploy_phase3_unittest.py
@@ -367,6 +367,63 @@ class TestDeployPhase3(unittest.TestCase):
             content,
         )
 
+    def test_deploy_script_enforces_pre_migration_recovery_gate_before_alembic(
+        self,
+    ):
+        content = self._read(
+            "deploy_production.sh"
+        )
+
+        for variable_name in (
+            "PRE_MIGRATION_RECOVERY_MANIFEST",
+            "PRE_MIGRATION_RECOVERY_COMPLETE",
+            "PRE_MIGRATION_SOURCE_RELEASE_COMMIT",
+            "PRE_MIGRATION_OPERATOR",
+            "PRE_MIGRATION_TARGET_ENV",
+            "PRE_MIGRATION_MAX_AGE_MINUTES",
+        ):
+            self.assertIn(
+                variable_name,
+                content,
+            )
+
+        self.assertIn(
+            "python -m scripts.pre_migration_recovery_gate",
+            content,
+        )
+        self.assertIn(
+            "/run/litoral-recovery/manifest.json:ro",
+            content,
+        )
+        self.assertIn(
+            "/run/litoral-recovery/complete.json:ro",
+            content,
+        )
+
+        gate_position = content.index(
+            "python -m scripts.pre_migration_recovery_gate"
+        )
+        migration_position = content.index(
+            "python -m alembic upgrade head"
+        )
+
+        self.assertLess(
+            gate_position,
+            migration_position,
+        )
+
+        self.assertGreaterEqual(
+            content.count(
+                "-e MIGRATION_DATABASE_URL"
+            ),
+            2,
+        )
+        self.assertNotIn(
+            '-e MIGRATION_DATABASE_URL="$MIGRATION_DATABASE_URL"',
+            content,
+        )
+
+
     def test_runbook_documents_private_bucket_iam_and_fail_closed_readiness(self):
         content = self._read(
             "DEPLOYMENT_RUNBOOK.md"

--- a/tests/test_postgres_logical_backup_p27a3_unittest.py
+++ b/tests/test_postgres_logical_backup_p27a3_unittest.py
@@ -1111,16 +1111,21 @@ def test_gitignore_ignores_backups_postgres():
     assert "/backups/postgres/" in gitignore
 
 
-def test_dr_runbook_says_real_drill_is_still_pending():
+def test_dr_runbook_preserves_historical_prepass_and_records_p27a3_closure():
     runbook = DR_RUNBOOK_PATH.read_text(encoding="utf-8")
 
     for token in (
         "tooling implemented/tested locally",
         "REAL pg_dump / pg_restore DRILL STILL REQUIRED",
-        "P2.7A3 is NOT CLOSED",
+        "P2.7A3 status:",
+        "CLOSED on 2026-08-17 after scheduled off-platform backup acceptance.",
+        "GitHub Actions workflow run 32086976028: PASS",
         "direct/unpooled connections",
         "client/server major versions must match",
         "Backup artifacts must never be committed",
         "SHA-256 verified before restore",
+        "This closes P2.7A3 overall.",
     ):
         assert token in runbook
+
+    assert "P2.7A3 is NOT CLOSED" not in runbook

--- a/tests/test_pre_migration_recovery_gate_p27a5_unittest.py
+++ b/tests/test_pre_migration_recovery_gate_p27a5_unittest.py
@@ -1,0 +1,488 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+import hashlib
+import json
+from pathlib import Path
+
+import pytest
+
+from scripts.pre_migration_recovery_gate import (
+    GATE_FORMAT_VERSION,
+    RecoveryGateError,
+    verify_recovery_gate,
+)
+from scripts.postgres_backup_publish import (
+    REMOTE_FORMAT_VERSION,
+)
+from scripts.postgres_logical_backup import (
+    FORMAT_VERSION,
+)
+
+
+NOW = datetime(
+    2026,
+    8,
+    18,
+    1,
+    30,
+    0,
+    tzinfo=UTC,
+)
+RELEASE = (
+    "0c94022ad7ffdae781b85b8dac38f18e64de0e05"
+)
+IDENTITY = "a" * 64
+ALEMBIC = "008_add_platform_control_plane_functions"
+
+
+def _iso(value: datetime) -> str:
+    return value.astimezone(
+        UTC
+    ).strftime(
+        "%Y-%m-%dT%H:%M:%SZ"
+    )
+
+
+def _live_metadata(
+    _database_url: str,
+) -> dict[str, object]:
+    return {
+        "database_name": "neondb",
+        "postgres_server_version": "17.10",
+        "alembic_revision": ALEMBIC,
+        "postgis_version": "3.5.0",
+        "source_identity_sha256": IDENTITY,
+    }
+
+
+def _write_evidence(
+    tmp_path: Path,
+    *,
+    created_at: datetime | None = None,
+    release_commit: str = RELEASE,
+    identity: str = IDENTITY,
+    alembic_revision: str = ALEMBIC,
+    dump_sha256: str | None = None,
+) -> tuple[Path, Path]:
+    created = created_at or (
+        NOW - timedelta(minutes=30)
+    )
+    dump_sha = dump_sha256 or (
+        hashlib.sha256(
+            b"p27a5-dump"
+        ).hexdigest()
+    )
+    dump_filename = (
+        "20260818T010000Z_production.dump"
+    )
+    manifest_filename = (
+        "20260818T010000Z_production.manifest.json"
+    )
+
+    manifest = {
+        "format_version": FORMAT_VERSION,
+        "created_at_utc": _iso(created),
+        "source_label": "production",
+        "release_commit": release_commit,
+        "database_name": "neondb",
+        "source_identity_sha256": identity,
+        "postgres_server_version": "17.10",
+        "alembic_revision": alembic_revision,
+        "postgis_version": "3.5.0",
+        "dump_filename": dump_filename,
+        "dump_sha256": dump_sha,
+        "dump_size_bytes": 91895,
+    }
+
+    manifest_path = (
+        tmp_path / manifest_filename
+    )
+    manifest_path.write_text(
+        json.dumps(
+            manifest,
+            indent=2,
+            sort_keys=True,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    manifest_sha = hashlib.sha256(
+        manifest_path.read_bytes()
+    ).hexdigest()
+
+    complete = {
+        "format_version": REMOTE_FORMAT_VERSION,
+        "source_label": "production",
+        "release_commit": release_commit,
+        "backup_created_at_utc": _iso(created),
+        "published_at_utc": _iso(
+            created + timedelta(minutes=1)
+        ),
+        "dump_key": (
+            "litoral-trace/postgres/production/"
+            "2026/08/18/20260818T010000Z/"
+            f"{dump_filename}"
+        ),
+        "dump_sha256": dump_sha,
+        "dump_size_bytes": 91895,
+        "manifest_key": (
+            "litoral-trace/postgres/production/"
+            "2026/08/18/20260818T010000Z/"
+            f"{manifest_filename}"
+        ),
+        "manifest_sha256": manifest_sha,
+    }
+
+    complete_path = (
+        tmp_path / "complete.json"
+    )
+    complete_path.write_text(
+        json.dumps(
+            complete,
+            indent=2,
+            sort_keys=True,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    return manifest_path, complete_path
+
+
+def _verify(
+    manifest: Path,
+    complete: Path,
+    **kwargs,
+):
+    return verify_recovery_gate(
+        manifest_path=manifest,
+        complete_marker_path=complete,
+        database_url=(
+            "postgresql://ignored-for-unit-test/neondb"
+        ),
+        expected_source_release_commit=(
+            kwargs.pop(
+                "expected_source_release_commit",
+                RELEASE,
+            )
+        ),
+        operator="p27a5-unit-test",
+        target_environment="production",
+        max_age_minutes=kwargs.pop(
+            "max_age_minutes",
+            120,
+        ),
+        now_utc=kwargs.pop(
+            "now_utc",
+            NOW,
+        ),
+        database_metadata_collector=kwargs.pop(
+            "database_metadata_collector",
+            _live_metadata,
+        ),
+        **kwargs,
+    )
+
+
+def test_p27a5_valid_complete_recovery_point_passes(
+    tmp_path,
+):
+    manifest, complete = _write_evidence(
+        tmp_path
+    )
+
+    result = _verify(
+        manifest,
+        complete,
+    )
+
+    assert result["result"] == "PASS"
+    assert (
+        result["verification_status"]
+        == "PASS"
+    )
+    assert (
+        result["format_version"]
+        == GATE_FORMAT_VERSION
+    )
+    assert (
+        result["source_release_commit"]
+        == RELEASE
+    )
+    assert (
+        result["alembic_revision"]
+        == ALEMBIC
+    )
+    assert (
+        result["source_identity_sha256"]
+        == IDENTITY
+    )
+    assert (
+        result["backup_age_seconds"]
+        == 30 * 60
+    )
+
+
+def test_p27a5_rejects_tampered_manifest(
+    tmp_path,
+):
+    manifest, complete = _write_evidence(
+        tmp_path
+    )
+
+    payload = json.loads(
+        manifest.read_text(
+            encoding="utf-8"
+        )
+    )
+    payload["database_name"] = "tampered"
+
+    manifest.write_text(
+        json.dumps(
+            payload,
+            sort_keys=True,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(
+        RecoveryGateError,
+        match="SHA-256",
+    ):
+        _verify(
+            manifest,
+            complete,
+        )
+
+
+def test_p27a5_rejects_wrong_current_release(
+    tmp_path,
+):
+    manifest, complete = _write_evidence(
+        tmp_path
+    )
+
+    with pytest.raises(
+        RecoveryGateError,
+        match="currently deployed release",
+    ):
+        _verify(
+            manifest,
+            complete,
+            expected_source_release_commit=(
+                "1" * 40
+            ),
+        )
+
+
+def test_p27a5_rejects_different_database_identity(
+    tmp_path,
+):
+    manifest, complete = _write_evidence(
+        tmp_path
+    )
+
+    def wrong_database(
+        _url: str,
+    ) -> dict[str, object]:
+        metadata = _live_metadata(
+            _url
+        )
+        metadata[
+            "source_identity_sha256"
+        ] = "b" * 64
+        return metadata
+
+    with pytest.raises(
+        RecoveryGateError,
+        match="different database identity",
+    ):
+        _verify(
+            manifest,
+            complete,
+            database_metadata_collector=(
+                wrong_database
+            ),
+        )
+
+
+def test_p27a5_rejects_alembic_mismatch(
+    tmp_path,
+):
+    manifest, complete = _write_evidence(
+        tmp_path
+    )
+
+    def wrong_revision(
+        _url: str,
+    ) -> dict[str, object]:
+        metadata = _live_metadata(
+            _url
+        )
+        metadata[
+            "alembic_revision"
+        ] = "999_wrong_revision"
+        return metadata
+
+    with pytest.raises(
+        RecoveryGateError,
+        match="Alembic revision",
+    ):
+        _verify(
+            manifest,
+            complete,
+            database_metadata_collector=(
+                wrong_revision
+            ),
+        )
+
+
+def test_p27a5_rejects_stale_recovery_point(
+    tmp_path,
+):
+    manifest, complete = _write_evidence(
+        tmp_path,
+        created_at=(
+            NOW - timedelta(minutes=121)
+        ),
+    )
+
+    with pytest.raises(
+        RecoveryGateError,
+        match="too old",
+    ):
+        _verify(
+            manifest,
+            complete,
+        )
+
+
+def test_p27a5_rejects_future_evidence(
+    tmp_path,
+):
+    manifest, complete = _write_evidence(
+        tmp_path,
+        created_at=(
+            NOW + timedelta(minutes=10)
+        ),
+    )
+
+    with pytest.raises(
+        RecoveryGateError,
+        match="future timestamp",
+    ):
+        _verify(
+            manifest,
+            complete,
+        )
+
+
+def test_p27a5_rejects_dump_binding_mismatch(
+    tmp_path,
+):
+    manifest, complete = _write_evidence(
+        tmp_path
+    )
+
+    marker = json.loads(
+        complete.read_text(
+            encoding="utf-8"
+        )
+    )
+    marker[
+        "dump_sha256"
+    ] = "c" * 64
+
+    complete.write_text(
+        json.dumps(
+            marker,
+            sort_keys=True,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(
+        RecoveryGateError,
+        match="dump SHA-256 binding",
+    ):
+        _verify(
+            manifest,
+            complete,
+        )
+
+
+def test_p27a5_rejects_postgres_major_mismatch(
+    tmp_path,
+):
+    manifest, complete = _write_evidence(
+        tmp_path
+    )
+
+    def wrong_postgres(
+        _url: str,
+    ) -> dict[str, object]:
+        metadata = _live_metadata(
+            _url
+        )
+        metadata[
+            "postgres_server_version"
+        ] = "18.0"
+        return metadata
+
+    with pytest.raises(
+        RecoveryGateError,
+        match="PostgreSQL major version",
+    ):
+        _verify(
+            manifest,
+            complete,
+            database_metadata_collector=(
+                wrong_postgres
+            ),
+        )
+
+
+def test_p27a5_runbooks_define_executable_fail_closed_gate():
+    root = Path(
+        __file__
+    ).resolve().parents[1]
+
+    dr = (
+        root
+        / "DISASTER_RECOVERY_RUNBOOK.md"
+    ).read_text(
+        encoding="utf-8"
+    )
+
+    deployment = (
+        root
+        / "DEPLOYMENT_RUNBOOK.md"
+    ).read_text(
+        encoding="utf-8"
+    )
+
+    for token in (
+        "13. P2.7A5 executable pre-migration recovery gate",
+        "PRE_MIGRATION_SOURCE_RELEASE_COMMIT",
+        "120 minutes",
+        "source_identity_sha256",
+        "manifest_sha256",
+        "before Alembic",
+        "NO MIGRATION",
+    ):
+        assert token in dr
+
+    for token in (
+        "python -m scripts.pre_migration_recovery_gate",
+        "PRE_MIGRATION_RECOVERY_MANIFEST",
+        "PRE_MIGRATION_RECOVERY_COMPLETE",
+        "PRE_MIGRATION_SOURCE_RELEASE_COMMIT",
+        "PRE_MIGRATION_OPERATOR",
+        "PRE_MIGRATION_MAX_AGE_MINUTES=120",
+        "currently deployed production release",
+    ):
+        assert token in deployment


### PR DESCRIPTION
## P2.7A5 — executable pre-migration recovery gate

Adds a fail-closed production recovery-point gate before `alembic upgrade head`.

### Scope
- MODIFY `DEPLOYMENT_RUNBOOK.md`
- MODIFY `DISASTER_RECOVERY_RUNBOOK.md`
- MODIFY `deploy_production.sh`
- CREATE `scripts/pre_migration_recovery_gate.py`
- MODIFY `tests/test_deploy_phase3_unittest.py`
- MODIFY stale P2.7A3 harness assertion in `tests/test_postgres_logical_backup_p27a3_unittest.py`
- CREATE `tests/test_pre_migration_recovery_gate_p27a5_unittest.py`

### Gate semantics
Validates the exact P2.7A3 manifest + `complete.json` publication evidence against the live production database before migration: manifest SHA-256, dump binding, production source label, currently deployed release, max-age/future timestamp checks, database identity, Alembic revision, PostgreSQL major and PostGIS major.minor. Any mismatch returns NO MIGRATION.

### Security
- recovery evidence mounted read-only
- migration credential remains ephemeral
- no DB URL, password, storage credential, or provider endpoint in PASS evidence
- no migration or runtime Vault changes

### Validation
- targeted regression: 103 passed
- `git diff --check`: clean after EOF normalization
- exact scope: 7 files
- staged secret scan: PASS
- branch is 1 commit ahead / 0 behind `p2-enterprise-production`

Operational execution against real production recovery evidence remains required before P2.7A5 is declared fully accepted; final DR acceptance remains P2.7A6.