### PR TITLE
feat(dr): add independent Vault recovery replica P2.7A6A

### DIFF
--- a/DISASTER_RECOVERY_RUNBOOK.md
+++ b/DISASTER_RECOVERY_RUNBOOK.md
@@ -640,3 +640,216 @@ The gate has demonstrated both required production behaviors:
 No Alembic migration was executed during either acceptance test.
 
 P2.7A6 remains responsible for final DR acceptance and go-live sign-off.
+
+14. P2.7A6 final disaster-recovery acceptance
+
+P2.7A6 status:
+
+ACTIVE - final go-live disaster-recovery acceptance is not yet closed.
+
+P2.7A6 decomposition:
+
+- P2.7A6A independent Vault recovery replica tooling
+- P2.7A6B real Vault provider-loss recovery drill
+- P2.7A6C >= 7-day provider history/PITR acceptance
+- P2.7A6D final DR evidence and go-live sign-off
+
+P2.7A6A status:
+
+IMPLEMENTED - independent S3-compatible Vault recovery replica tooling is present and unit-tested.
+
+Operational provisioning of the independent provider and a real provider-loss drill remain required before P2.7A6A/A6B can be accepted operationally.
+
+Independent-provider requirement
+
+The recovery replica MUST NOT be represented as independent when it shares the same storage provider or the same declared failure domain as the primary Vault.
+
+The tooling therefore fails closed unless:
+
+- VAULT_PRIMARY_PROVIDER_ID differs from VAULT_REPLICA_PROVIDER_ID
+- VAULT_PRIMARY_FAILURE_DOMAIN differs from VAULT_REPLICA_FAILURE_DOMAIN
+- primary and replica do not resolve to the same endpoint/bucket location
+
+A second bucket, object version, or replication rule inside the same declared provider/failure domain is not sufficient evidence for the P2.7A6 provider-loss requirement.
+
+Source database contract
+
+The replica operator uses:
+
+VAULT_BACKUP_DATABASE_URL
+
+This credential is a recovery/backup read capability and must use a direct/unpooled PostgreSQL connection.
+
+The operator reads Vault metadata in a repeatable-read, read-only transaction.
+
+The operational target must contain the P2 Vault schema and vault_documents table.
+
+vault_documents is protected by enabled and forced tenant RLS. A cross-tenant recovery snapshot therefore MUST NOT use an ordinary tenant runtime role.
+
+Before reading any Vault rows, the replica tooling verifies:
+
+- row-level security is enabled on public.vault_documents
+- FORCE ROW LEVEL SECURITY is enabled
+- the connected recovery role has BYPASSRLS capability, or is a controlled superuser used only for an exceptional bootstrap/drill
+
+If those conditions are not satisfied, publication fails closed before a snapshot can be emitted. This prevents an RLS-filtered zero-row result from being misrepresented as a complete recovery snapshot.
+
+For steady-state scheduled operation, use a dedicated recovery/backup role with BYPASSRLS plus only the minimum database/schema/table SELECT grants required for recovery. Do not reuse the application runtime role. Do not use a superuser for recurring backup automation.
+
+The application runtime and migration credentials are not required for normal replica publication.
+
+Authoritative Vault binding
+
+Each manifest records the PostgreSQL recovery tuple:
+
+- organization_id
+- public_id
+- status
+- storage_backend
+- storage_bucket
+- object_key
+- storage_version_id when present
+- size_bytes
+- content_type
+- sha256
+
+Only documents whose authoritative status is available are copied automatically into the recovery replica.
+
+Other lifecycle states are recorded in the snapshot manifest as state_only_not_auto_recoverable.
+
+This prevents backup automation from implicitly resurrecting deleted documents or silently resolving pending/failed deletion states.
+
+Primary verification before replication
+
+For every available document:
+
+1. verify the configured primary bucket matches PostgreSQL
+2. verify tenant-scoped object-key binding
+3. request the exact storage_version_id when PostgreSQL contains one
+4. verify returned version identity when exact versioning is available
+5. verify size
+6. verify content type
+7. stream the entire source object
+8. recompute full SHA-256
+9. compare SHA-256 with PostgreSQL
+
+No object is copied merely because an ETag or size matches.
+
+Replica object layout
+
+Verified replica bytes use tenant-scoped content-addressed keys:
+
+<replica-prefix>/tenants/<organization_id>/objects/sha256/<first-two-sha-chars>/<sha256>
+
+This preserves tenant separation while allowing safe deduplication of identical content within one tenant.
+
+An existing content-addressed replica object is reused only after full verification.
+
+A mismatching existing replica object causes the operation to fail closed.
+
+The publisher MUST NOT overwrite an unexplained corrupt recovery object merely to make a backup run pass.
+
+Replica verification
+
+After write or verified reuse, the replica object is checked again for:
+
+- size
+- content type
+- tenant metadata
+- SHA-256 metadata
+- full streamed SHA-256
+- version binding when the replica provider returns a version ID
+
+Snapshot evidence
+
+Each successful replica run writes:
+
+- manifest.json
+- complete.json
+
+The manifest contains source database identity, Alembic revision, provider/failure-domain identities, document lifecycle state, primary object/version binding, replica key/version binding, and counts.
+
+complete.json is published LAST.
+
+A complete marker is valid only after every available source object has passed source verification, every copied/reused recovery object has passed replica verification, and manifest.json has been remotely verified.
+
+Primary and replica credentials, endpoints, database URLs, and passwords are not written to the result payload.
+
+Operator configuration
+
+Primary S3-compatible storage:
+
+- VAULT_PRIMARY_PROVIDER_ID
+- VAULT_PRIMARY_FAILURE_DOMAIN
+- VAULT_PRIMARY_BUCKET_NAME
+- VAULT_PRIMARY_REGION
+- VAULT_PRIMARY_ENDPOINT_URL when required
+- VAULT_PRIMARY_ACCESS_KEY_ID when required
+- VAULT_PRIMARY_SECRET_ACCESS_KEY when required
+- VAULT_PRIMARY_SESSION_TOKEN when required
+- VAULT_PRIMARY_FORCE_PATH_STYLE
+- VAULT_PRIMARY_USE_TLS
+- VAULT_PRIMARY_VERIFY_TLS
+- VAULT_PRIMARY_CA_BUNDLE_PATH when required
+- VAULT_PRIMARY_KEY_PREFIX
+
+Independent S3-compatible recovery storage:
+
+- VAULT_REPLICA_PROVIDER_ID
+- VAULT_REPLICA_FAILURE_DOMAIN
+- VAULT_REPLICA_BUCKET_NAME
+- VAULT_REPLICA_REGION
+- VAULT_REPLICA_ENDPOINT_URL when required
+- VAULT_REPLICA_ACCESS_KEY_ID when required
+- VAULT_REPLICA_SECRET_ACCESS_KEY when required
+- VAULT_REPLICA_SESSION_TOKEN when required
+- VAULT_REPLICA_FORCE_PATH_STYLE
+- VAULT_REPLICA_USE_TLS
+- VAULT_REPLICA_VERIFY_TLS
+- VAULT_REPLICA_CA_BUNDLE_PATH when required
+- VAULT_REPLICA_KEY_PREFIX
+
+Credentials remain environment/secret-store inputs only.
+
+TLS and certificate verification are mandatory for the operational CLI path.
+
+P2.7A6B acceptance requirement
+
+P2.7A6B must prove recovery while treating the primary Vault provider as unavailable.
+
+The recovery candidate must come from the independent replica, not from a same-provider primary version.
+
+The drill must use an isolated recovery target first and must verify:
+
+- tenant binding
+- public document binding
+- expected lifecycle state
+- size
+- content type
+- SHA-256
+- replica manifest binding
+- complete-marker binding
+- application-compatible recovered bytes
+- elapsed recovery/verification time
+- production modified: NO
+
+P2.7A6C acceptance requirement
+
+The current DR contract requires >= 7 days of provider history/PITR for go-live.
+
+P2.7A6 cannot be signed off while the actual production provider capability remains below this target.
+
+P2.7A6D final sign-off
+
+Final DR acceptance requires all of the following:
+
+- P2.7A1 provider restore evidence
+- P2.7A3 independent PostgreSQL logical recovery evidence
+- P2.7A4 Vault recovery semantics
+- P2.7A5 operational pre-migration gate acceptance
+- P2.7A6B independent Vault provider-loss recovery PASS
+- P2.7A6C >= 7-day provider history/PITR PASS
+- measured recovery evidence
+- no unresolved go-live DR blocker
+
+P2.7A6 remains OPEN until those conditions are satisfied.

--- a/scripts/vault_recovery_replica.py
+++ b/scripts/vault_recovery_replica.py
@@ -1,0 +1,1790 @@
+from __future__ import annotations
+
+import argparse
+from dataclasses import dataclass
+from datetime import UTC, datetime
+import hashlib
+import json
+import os
+import re
+import sys
+import tempfile
+from typing import Any
+from uuid import UUID
+
+import psycopg
+from psycopg.rows import dict_row
+
+from litoral_trace.config.settings import StorageSettings
+from litoral_trace.storage import (
+    Boto3S3ObjectStorage,
+    ObjectStorageClient,
+    ObjectStorageError,
+    ObjectStorageNotFoundError,
+)
+from scripts.postgres_logical_backup import (
+    BackupToolError,
+    build_identity_fingerprint,
+    normalize_database_url,
+    parse_database_url,
+    reject_pooled_neon_endpoint,
+    sanitize_cli_error_message,
+)
+
+
+MANIFEST_FORMAT_VERSION = "p27a6.vault-replica.manifest.v1"
+COMPLETE_FORMAT_VERSION = "p27a6.vault-replica.complete.v1"
+RESULT_FORMAT_VERSION = "p27a6.vault-replica.result.v1"
+
+DEFAULT_PRIMARY_KEY_PREFIX = "vault"
+DEFAULT_REPLICA_KEY_PREFIX = "litoral-trace/vault-recovery"
+
+_REPLICABLE_STATUS = "available"
+_KNOWN_STATUSES = frozenset(
+    {
+        "pending_upload",
+        "available",
+        "upload_failed",
+        "delete_pending",
+        "delete_failed",
+        "deleted",
+    }
+)
+
+_SHA256_RE = re.compile(r"^[0-9a-f]{64}$")
+_COMMIT_RE = re.compile(r"^[0-9a-fA-F]{7,64}$")
+_SNAPSHOT_RE = re.compile(r"^\d{8}T\d{6}Z$")
+
+
+class VaultReplicaError(BackupToolError):
+    """Fail-closed independent Vault-recovery replica error."""
+
+
+@dataclass(frozen=True)
+class RecoveryDomain:
+    provider_id: str
+    failure_domain: str
+
+
+@dataclass(frozen=True)
+class VaultReplicaDocument:
+    organization_id: int
+    public_id: str
+    status: str
+    storage_backend: str
+    storage_bucket: str
+    object_key: str
+    storage_version_id: str | None
+    size_bytes: int
+    content_type: str
+    sha256: str
+
+
+@dataclass(frozen=True)
+class VaultDatabaseSnapshot:
+    database_name: str
+    source_identity_sha256: str
+    postgres_server_version: str
+    postgis_version: str
+    alembic_revision: str
+    documents: tuple[VaultReplicaDocument, ...]
+
+
+def _nonempty(value: object, *, label: str) -> str:
+    normalized = str(
+        value if value is not None else ""
+    ).strip()
+    if not normalized:
+        raise VaultReplicaError(
+            f"{label} must not be empty."
+        )
+    return normalized
+
+
+def _optional_string(value: object) -> str | None:
+    if value is None:
+        return None
+    normalized = str(value).strip()
+    return normalized or None
+
+
+def _sha256(value: object, *, label: str) -> str:
+    normalized = _nonempty(
+        value,
+        label=label,
+    ).lower()
+    if not _SHA256_RE.fullmatch(normalized):
+        raise VaultReplicaError(
+            f"{label} must be a canonical SHA-256."
+        )
+    return normalized
+
+
+def _release_commit(value: object) -> str:
+    normalized = _nonempty(
+        value,
+        label="release_commit",
+    ).lower()
+    if not _COMMIT_RE.fullmatch(normalized):
+        raise VaultReplicaError(
+            "release_commit is not a valid Git commit identifier."
+        )
+    return normalized
+
+
+def _snapshot_id(value: object) -> str:
+    normalized = _nonempty(
+        value,
+        label="snapshot_id",
+    )
+    if not _SNAPSHOT_RE.fullmatch(normalized):
+        raise VaultReplicaError(
+            "snapshot_id must use YYYYMMDDTHHMMSSZ."
+        )
+    return normalized
+
+
+def _utc_iso(value: datetime) -> str:
+    return value.astimezone(
+        UTC
+    ).replace(
+        microsecond=0
+    ).strftime(
+        "%Y-%m-%dT%H:%M:%SZ"
+    )
+
+
+def utc_snapshot_id(value: datetime | None = None) -> str:
+    active = (
+        value.astimezone(UTC)
+        if value is not None
+        else datetime.now(UTC)
+    )
+    return active.strftime(
+        "%Y%m%dT%H%M%SZ"
+    )
+
+
+def _canonical_json_bytes(
+    payload: dict[str, Any],
+) -> bytes:
+    return (
+        json.dumps(
+            payload,
+            indent=2,
+            sort_keys=True,
+            ensure_ascii=True,
+        )
+        + "\n"
+    ).encode("utf-8")
+
+
+def _canonical_content_type(value: object) -> str:
+    normalized = _nonempty(
+        value,
+        label="content_type",
+    )
+    return normalized.split(
+        ";",
+        1,
+    )[0].strip().lower()
+
+
+def _normalize_domain_value(
+    value: object,
+    *,
+    label: str,
+) -> str:
+    normalized = _nonempty(
+        value,
+        label=label,
+    ).strip().lower()
+
+    if any(ord(char) < 32 for char in normalized):
+        raise VaultReplicaError(
+            f"{label} contains invalid control characters."
+        )
+
+    return normalized
+
+
+def assert_independent_domains(
+    *,
+    primary: RecoveryDomain,
+    replica: RecoveryDomain,
+    primary_settings: StorageSettings,
+    replica_settings: StorageSettings,
+) -> None:
+    primary_provider = _normalize_domain_value(
+        primary.provider_id,
+        label="primary provider_id",
+    )
+    replica_provider = _normalize_domain_value(
+        replica.provider_id,
+        label="replica provider_id",
+    )
+
+    if primary_provider == replica_provider:
+        raise VaultReplicaError(
+            "Primary and replica must use different storage providers."
+        )
+
+    primary_failure = _normalize_domain_value(
+        primary.failure_domain,
+        label="primary failure_domain",
+    )
+    replica_failure = _normalize_domain_value(
+        replica.failure_domain,
+        label="replica failure_domain",
+    )
+
+    if primary_failure == replica_failure:
+        raise VaultReplicaError(
+            "Primary and replica must use different failure domains."
+        )
+
+    primary_endpoint = (
+        str(primary_settings.endpoint_url or "")
+        .strip()
+        .rstrip("/")
+        .lower()
+    )
+    replica_endpoint = (
+        str(replica_settings.endpoint_url or "")
+        .strip()
+        .rstrip("/")
+        .lower()
+    )
+
+    primary_bucket = _nonempty(
+        primary_settings.bucket_name,
+        label="primary bucket",
+    )
+    replica_bucket = _nonempty(
+        replica_settings.bucket_name,
+        label="replica bucket",
+    )
+
+    if (
+        primary_endpoint == replica_endpoint
+        and primary_bucket == replica_bucket
+    ):
+        raise VaultReplicaError(
+            "Primary and replica resolve to the same storage location."
+        )
+
+
+def _validate_document(
+    document: VaultReplicaDocument,
+) -> VaultReplicaDocument:
+    try:
+        organization_id = int(
+            document.organization_id
+        )
+    except (TypeError, ValueError) as exc:
+        raise VaultReplicaError(
+            "Vault organization_id is invalid."
+        ) from exc
+
+    if organization_id <= 0:
+        raise VaultReplicaError(
+            "Vault organization_id is invalid."
+        )
+
+    try:
+        public_id = str(
+            UUID(
+                _nonempty(
+                    document.public_id,
+                    label="Vault public_id",
+                )
+            )
+        )
+    except (ValueError, AttributeError) as exc:
+        raise VaultReplicaError(
+            "Vault public_id is invalid."
+        ) from exc
+
+    status = _nonempty(
+        document.status,
+        label="Vault status",
+    )
+
+    if status not in _KNOWN_STATUSES:
+        raise VaultReplicaError(
+            "Vault document has an unsupported status."
+        )
+
+    storage_backend = _nonempty(
+        document.storage_backend,
+        label="Vault storage_backend",
+    ).lower()
+
+    if storage_backend != "s3":
+        raise VaultReplicaError(
+            "Vault recovery replica supports only S3-compatible source objects."
+        )
+
+    storage_bucket = _nonempty(
+        document.storage_bucket,
+        label="Vault storage_bucket",
+    )
+
+    object_key = _nonempty(
+        document.object_key,
+        label="Vault object_key",
+    )
+
+    if object_key.startswith("/") or "\\" in object_key:
+        raise VaultReplicaError(
+            "Vault object_key is not canonical."
+        )
+
+    storage_version_id = _optional_string(
+        document.storage_version_id
+    )
+
+    try:
+        size_bytes = int(
+            document.size_bytes
+        )
+    except (TypeError, ValueError) as exc:
+        raise VaultReplicaError(
+            "Vault size_bytes is invalid."
+        ) from exc
+
+    if size_bytes <= 0:
+        raise VaultReplicaError(
+            "Vault size_bytes must be positive."
+        )
+
+    content_type = _canonical_content_type(
+        document.content_type
+    )
+    digest = _sha256(
+        document.sha256,
+        label="Vault sha256",
+    )
+
+    return VaultReplicaDocument(
+        organization_id=organization_id,
+        public_id=public_id,
+        status=status,
+        storage_backend=storage_backend,
+        storage_bucket=storage_bucket,
+        object_key=object_key,
+        storage_version_id=storage_version_id,
+        size_bytes=size_bytes,
+        content_type=content_type,
+        sha256=digest,
+    )
+
+
+def _document_from_row(
+    row: dict[str, Any],
+) -> VaultReplicaDocument:
+    return _validate_document(
+        VaultReplicaDocument(
+            organization_id=row["organization_id"],
+            public_id=row["public_id"],
+            status=row["status"],
+            storage_backend=row["storage_backend"],
+            storage_bucket=row["storage_bucket"],
+            object_key=row["object_key"],
+            storage_version_id=row[
+                "storage_version_id"
+            ],
+            size_bytes=row["size_bytes"],
+            content_type=row["content_type"],
+            sha256=row["sha256"],
+        )
+    )
+
+
+def _assert_vault_backup_visibility(
+    security_row: dict[str, Any] | None,
+) -> None:
+    if not security_row:
+        raise VaultReplicaError(
+            "Unable to verify Vault RLS backup visibility."
+        )
+
+    if (
+        not bool(
+            security_row.get("rls_enabled")
+        )
+        or not bool(
+            security_row.get("rls_forced")
+        )
+    ):
+        raise VaultReplicaError(
+            "vault_documents RLS contract is not enabled and forced."
+        )
+
+    if not (
+        bool(
+            security_row.get("role_bypassrls")
+        )
+        or bool(
+            security_row.get("role_superuser")
+        )
+    ):
+        raise VaultReplicaError(
+            "Vault backup database role cannot bypass tenant RLS; "
+            "cross-tenant recovery metadata would be incomplete."
+        )
+
+
+def collect_vault_database_snapshot(
+    database_url: str,
+) -> VaultDatabaseSnapshot:
+    normalized_url = normalize_database_url(
+        database_url
+    )
+    parsed = parse_database_url(
+        normalized_url
+    )
+    reject_pooled_neon_endpoint(
+        parsed["hostname"]
+    )
+
+    try:
+        with psycopg.connect(
+            normalized_url,
+            row_factory=dict_row,
+        ) as connection:
+            with connection.cursor() as cursor:
+                cursor.execute(
+                    "SET TRANSACTION ISOLATION LEVEL "
+                    "REPEATABLE READ READ ONLY"
+                )
+
+                cursor.execute(
+                    "SELECT current_database() AS database_name"
+                )
+                database_row = cursor.fetchone()
+                if not database_row:
+                    raise VaultReplicaError(
+                        "Unable to identify recovery database."
+                    )
+                database_name = _nonempty(
+                    database_row["database_name"],
+                    label="database_name",
+                )
+
+                cursor.execute(
+                    "SHOW server_version"
+                )
+                postgres_row = cursor.fetchone()
+                postgres_version = _nonempty(
+                    postgres_row["server_version"]
+                    if postgres_row
+                    else None,
+                    label="postgres_server_version",
+                )
+
+                cursor.execute(
+                    """
+                    SELECT version_num AS alembic_revision
+                    FROM alembic_version
+                    """
+                )
+                alembic_row = cursor.fetchone()
+                alembic_revision = _nonempty(
+                    alembic_row["alembic_revision"]
+                    if alembic_row
+                    else None,
+                    label="alembic_revision",
+                )
+
+                cursor.execute(
+                    """
+                    SELECT extversion AS postgis_version
+                    FROM pg_extension
+                    WHERE extname = 'postgis'
+                    """
+                )
+                postgis_row = cursor.fetchone()
+                postgis_version = _nonempty(
+                    postgis_row["postgis_version"]
+                    if postgis_row
+                    else None,
+                    label="postgis_version",
+                )
+
+                cursor.execute(
+                    """
+                    SELECT
+                        to_regclass(
+                            'public.vault_documents'
+                        ) AS vault_table
+                    """
+                )
+                table_row = cursor.fetchone()
+                if (
+                    not table_row
+                    or table_row["vault_table"] is None
+                ):
+                    raise VaultReplicaError(
+                        "vault_documents is not present in the target schema."
+                    )
+
+                cursor.execute(
+                    """
+                    SELECT
+                        c.relrowsecurity AS rls_enabled,
+                        c.relforcerowsecurity AS rls_forced,
+                        r.rolbypassrls AS role_bypassrls,
+                        r.rolsuper AS role_superuser
+                    FROM pg_class AS c
+                    JOIN pg_namespace AS n
+                      ON n.oid = c.relnamespace
+                    JOIN pg_roles AS r
+                      ON r.rolname = current_user
+                    WHERE n.nspname = 'public'
+                      AND c.relname = 'vault_documents'
+                    """
+                )
+
+                _assert_vault_backup_visibility(
+                    cursor.fetchone()
+                )
+
+                cursor.execute(
+                    """
+                    SELECT
+                        organization_id,
+                        public_id::text AS public_id,
+                        status,
+                        storage_backend,
+                        storage_bucket,
+                        object_key,
+                        storage_version_id,
+                        size_bytes,
+                        content_type,
+                        sha256
+                    FROM vault_documents
+                    ORDER BY organization_id, id
+                    """
+                )
+
+                documents = tuple(
+                    _document_from_row(row)
+                    for row in cursor.fetchall()
+                )
+
+    except VaultReplicaError:
+        raise
+    except psycopg.Error as exc:
+        raise VaultReplicaError(
+            "Unable to read Vault recovery metadata from PostgreSQL."
+        ) from exc
+
+    source_identity_sha256 = (
+        build_identity_fingerprint(
+            hostname=parsed["hostname"],
+            port=parsed["port"],
+            database_name=database_name,
+        )
+    )
+
+    return VaultDatabaseSnapshot(
+        database_name=database_name,
+        source_identity_sha256=(
+            source_identity_sha256
+        ),
+        postgres_server_version=(
+            postgres_version
+        ),
+        postgis_version=postgis_version,
+        alembic_revision=alembic_revision,
+        documents=documents,
+    )
+
+
+def _expected_primary_tenant_prefix(
+    *,
+    organization_id: int,
+    primary_key_prefix: str,
+) -> str:
+    normalized_prefix = (
+        str(primary_key_prefix or "")
+        .strip()
+        .strip("/")
+    )
+
+    if not normalized_prefix:
+        raise VaultReplicaError(
+            "Primary Vault key prefix is invalid."
+        )
+
+    return (
+        f"{normalized_prefix}/tenants/"
+        f"{organization_id}/objects/"
+    )
+
+
+def _replica_payload_key(
+    *,
+    organization_id: int,
+    sha256: str,
+    replica_key_prefix: str,
+) -> str:
+    normalized_prefix = (
+        str(replica_key_prefix or "")
+        .strip()
+        .strip("/")
+    )
+
+    if not normalized_prefix:
+        raise VaultReplicaError(
+            "Replica key prefix is invalid."
+        )
+
+    return (
+        f"{normalized_prefix}/tenants/"
+        f"{organization_id}/objects/sha256/"
+        f"{sha256[:2]}/{sha256}"
+    )
+
+
+def _verify_head(
+    *,
+    size_bytes: int,
+    content_type: str | None,
+    expected_size: int,
+    expected_content_type: str,
+    label: str,
+) -> None:
+    if int(size_bytes) != int(expected_size):
+        raise VaultReplicaError(
+            f"{label} size does not match PostgreSQL metadata."
+        )
+
+    if (
+        content_type is None
+        or not str(content_type).strip()
+    ):
+        raise VaultReplicaError(
+            f"{label} content type is missing."
+        )
+
+    observed_type = _canonical_content_type(
+        content_type
+    )
+
+    if observed_type != expected_content_type:
+        raise VaultReplicaError(
+            f"{label} content type does not match PostgreSQL metadata."
+        )
+
+
+def _stream_digest(
+    stream,
+    *,
+    spool=None,
+) -> tuple[int, str]:
+    digest = hashlib.sha256()
+    total = 0
+
+    while True:
+        chunk = stream.read(
+            1024 * 1024
+        )
+        if not chunk:
+            break
+
+        total += len(chunk)
+        digest.update(chunk)
+
+        if spool is not None:
+            spool.write(chunk)
+
+    return total, digest.hexdigest()
+
+
+def _verify_replica_object(
+    *,
+    replica_storage: ObjectStorageClient,
+    key: str,
+    version_id: str | None,
+    document: VaultReplicaDocument,
+) -> None:
+    try:
+        head = replica_storage.head_object(
+            key=key,
+            version_id=version_id,
+        )
+    except ObjectStorageNotFoundError as exc:
+        raise VaultReplicaError(
+            "Replica object disappeared during verification."
+        ) from exc
+    except ObjectStorageError as exc:
+        raise VaultReplicaError(
+            "Replica object verification failed."
+        ) from exc
+
+    _verify_head(
+        size_bytes=head.size_bytes,
+        content_type=head.content_type,
+        expected_size=document.size_bytes,
+        expected_content_type=(
+            document.content_type
+        ),
+        label="Replica object",
+    )
+
+    metadata_sha = str(
+        head.metadata.get(
+            "sha256",
+            "",
+        )
+    ).strip().lower()
+
+    if metadata_sha != document.sha256:
+        raise VaultReplicaError(
+            "Replica object SHA-256 metadata is inconsistent."
+        )
+
+    metadata_org = str(
+        head.metadata.get(
+            "organization-id",
+            "",
+        )
+    ).strip()
+
+    if metadata_org != str(
+        document.organization_id
+    ):
+        raise VaultReplicaError(
+            "Replica object tenant binding is inconsistent."
+        )
+
+    if (
+        version_id is not None
+        and head.version_id != version_id
+    ):
+        raise VaultReplicaError(
+            "Replica object version binding is inconsistent."
+        )
+
+    try:
+        with replica_storage.get_object_stream(
+            key=key,
+            version_id=version_id,
+        ) as stream:
+            _verify_head(
+                size_bytes=stream.head.size_bytes,
+                content_type=stream.head.content_type,
+                expected_size=document.size_bytes,
+                expected_content_type=(
+                    document.content_type
+                ),
+                label="Replica stream",
+            )
+
+            total, digest = _stream_digest(
+                stream
+            )
+    except ObjectStorageNotFoundError as exc:
+        raise VaultReplicaError(
+            "Replica object disappeared during full verification."
+        ) from exc
+    except ObjectStorageError as exc:
+        raise VaultReplicaError(
+            "Replica full-object verification failed."
+        ) from exc
+
+    if total != document.size_bytes:
+        raise VaultReplicaError(
+            "Replica object byte count is inconsistent."
+        )
+
+    if digest != document.sha256:
+        raise VaultReplicaError(
+            "Replica object full SHA-256 verification failed."
+        )
+
+
+def _ensure_replica_payload(
+    *,
+    replica_storage: ObjectStorageClient,
+    document: VaultReplicaDocument,
+    replica_key: str,
+    verified_spool,
+) -> tuple[str | None, str]:
+    try:
+        existing = replica_storage.head_object(
+            key=replica_key,
+        )
+    except ObjectStorageNotFoundError:
+        existing = None
+    except ObjectStorageError as exc:
+        raise VaultReplicaError(
+            "Unable to inspect replica object."
+        ) from exc
+
+    if existing is not None:
+        _verify_replica_object(
+            replica_storage=replica_storage,
+            key=replica_key,
+            version_id=existing.version_id,
+            document=document,
+        )
+        return (
+            existing.version_id,
+            "reused_verified",
+        )
+
+    verified_spool.seek(0)
+
+    try:
+        write_result = replica_storage.put_object(
+            key=replica_key,
+            body=verified_spool,
+            content_type=document.content_type,
+            content_length=document.size_bytes,
+            metadata={
+                "sha256": document.sha256,
+                "organization-id": str(
+                    document.organization_id
+                ),
+            },
+        )
+    except ObjectStorageError as exc:
+        raise VaultReplicaError(
+            "Unable to publish verified Vault recovery payload."
+        ) from exc
+
+    _verify_replica_object(
+        replica_storage=replica_storage,
+        key=replica_key,
+        version_id=write_result.version_id,
+        document=document,
+    )
+
+    return (
+        write_result.version_id,
+        "copied_verified",
+    )
+
+
+def _replicate_available_document(
+    *,
+    document: VaultReplicaDocument,
+    primary_storage: ObjectStorageClient,
+    replica_storage: ObjectStorageClient,
+    primary_settings: StorageSettings,
+    replica_key_prefix: str,
+) -> dict[str, Any]:
+    primary_bucket = _nonempty(
+        primary_settings.bucket_name,
+        label="primary bucket",
+    )
+
+    if document.storage_bucket != primary_bucket:
+        raise VaultReplicaError(
+            "Vault document storage bucket does not match the configured primary."
+        )
+
+    expected_prefix = (
+        _expected_primary_tenant_prefix(
+            organization_id=(
+                document.organization_id
+            ),
+            primary_key_prefix=(
+                primary_settings.normalized_key_prefix
+            ),
+        )
+    )
+
+    if not document.object_key.startswith(
+        expected_prefix
+    ):
+        raise VaultReplicaError(
+            "Vault document object key violates tenant binding."
+        )
+
+    try:
+        source_stream = (
+            primary_storage.get_object_stream(
+                key=document.object_key,
+                version_id=(
+                    document.storage_version_id
+                ),
+            )
+        )
+    except ObjectStorageNotFoundError as exc:
+        raise VaultReplicaError(
+            "Available Vault source object is missing."
+        ) from exc
+    except ObjectStorageError as exc:
+        raise VaultReplicaError(
+            "Unable to read primary Vault source object."
+        ) from exc
+
+    with source_stream:
+        _verify_head(
+            size_bytes=(
+                source_stream.head.size_bytes
+            ),
+            content_type=(
+                source_stream.head.content_type
+            ),
+            expected_size=document.size_bytes,
+            expected_content_type=(
+                document.content_type
+            ),
+            label="Primary Vault object",
+        )
+
+        if document.storage_version_id:
+            if (
+                source_stream.head.version_id
+                != document.storage_version_id
+            ):
+                raise VaultReplicaError(
+                    "Primary Vault exact-version verification failed."
+                )
+
+        with tempfile.TemporaryFile(
+            mode="w+b"
+        ) as spool:
+            total, digest = _stream_digest(
+                source_stream,
+                spool=spool,
+            )
+
+            if total != document.size_bytes:
+                raise VaultReplicaError(
+                    "Primary Vault object byte count is inconsistent."
+                )
+
+            if digest != document.sha256:
+                raise VaultReplicaError(
+                    "Primary Vault object SHA-256 does not match PostgreSQL."
+                )
+
+            replica_key = _replica_payload_key(
+                organization_id=(
+                    document.organization_id
+                ),
+                sha256=document.sha256,
+                replica_key_prefix=(
+                    replica_key_prefix
+                ),
+            )
+
+            replica_version_id, state = (
+                _ensure_replica_payload(
+                    replica_storage=(
+                        replica_storage
+                    ),
+                    document=document,
+                    replica_key=replica_key,
+                    verified_spool=spool,
+                )
+            )
+
+    return {
+        "replica_state": state,
+        "recovery_eligible": True,
+        "replica_key": replica_key,
+        "replica_version_id": (
+            replica_version_id
+        ),
+        "source_exact_version_verified": (
+            document.storage_version_id
+            is not None
+        ),
+    }
+
+
+def _base_manifest_entry(
+    document: VaultReplicaDocument,
+) -> dict[str, Any]:
+    return {
+        "organization_id": (
+            document.organization_id
+        ),
+        "public_id": document.public_id,
+        "status": document.status,
+        "storage_backend": (
+            document.storage_backend
+        ),
+        "storage_bucket": (
+            document.storage_bucket
+        ),
+        "object_key": document.object_key,
+        "storage_version_id": (
+            document.storage_version_id
+        ),
+        "size_bytes": document.size_bytes,
+        "content_type": (
+            document.content_type
+        ),
+        "sha256": document.sha256,
+    }
+
+
+def _verify_json_artifact(
+    *,
+    storage: ObjectStorageClient,
+    key: str,
+    version_id: str | None,
+    expected_bytes: bytes,
+    expected_sha256: str,
+    artifact_kind: str,
+) -> None:
+    try:
+        head = storage.head_object(
+            key=key,
+            version_id=version_id,
+        )
+    except ObjectStorageNotFoundError as exc:
+        raise VaultReplicaError(
+            f"{artifact_kind} disappeared during verification."
+        ) from exc
+    except ObjectStorageError as exc:
+        raise VaultReplicaError(
+            f"{artifact_kind} verification failed."
+        ) from exc
+
+    if head.size_bytes != len(
+        expected_bytes
+    ):
+        raise VaultReplicaError(
+            f"{artifact_kind} size verification failed."
+        )
+
+    if _canonical_content_type(
+        head.content_type or ""
+    ) != "application/json":
+        raise VaultReplicaError(
+            f"{artifact_kind} content type verification failed."
+        )
+
+    metadata_sha = str(
+        head.metadata.get(
+            "sha256",
+            "",
+        )
+    ).strip().lower()
+
+    if metadata_sha != expected_sha256:
+        raise VaultReplicaError(
+            f"{artifact_kind} metadata SHA-256 verification failed."
+        )
+
+    try:
+        with storage.get_object_stream(
+            key=key,
+            version_id=version_id,
+        ) as stream:
+            total, digest = _stream_digest(
+                stream
+            )
+    except ObjectStorageError as exc:
+        raise VaultReplicaError(
+            f"{artifact_kind} full verification failed."
+        ) from exc
+
+    if (
+        total != len(expected_bytes)
+        or digest != expected_sha256
+    ):
+        raise VaultReplicaError(
+            f"{artifact_kind} full SHA-256 verification failed."
+        )
+
+
+def _publish_immutable_json(
+    *,
+    storage: ObjectStorageClient,
+    key: str,
+    payload: dict[str, Any],
+    artifact_kind: str,
+) -> tuple[str, str | None]:
+    body = _canonical_json_bytes(
+        payload
+    )
+    digest = hashlib.sha256(
+        body
+    ).hexdigest()
+
+    try:
+        existing = storage.head_object(
+            key=key
+        )
+    except ObjectStorageNotFoundError:
+        existing = None
+    except ObjectStorageError as exc:
+        raise VaultReplicaError(
+            f"Unable to inspect {artifact_kind}."
+        ) from exc
+
+    if existing is not None:
+        _verify_json_artifact(
+            storage=storage,
+            key=key,
+            version_id=existing.version_id,
+            expected_bytes=body,
+            expected_sha256=digest,
+            artifact_kind=artifact_kind,
+        )
+        return digest, existing.version_id
+
+    try:
+        result = storage.put_object(
+            key=key,
+            body=body,
+            content_type="application/json",
+            content_length=len(body),
+            metadata={
+                "sha256": digest,
+                "artifact-kind": artifact_kind,
+            },
+        )
+    except ObjectStorageError as exc:
+        raise VaultReplicaError(
+            f"Unable to publish {artifact_kind}."
+        ) from exc
+
+    _verify_json_artifact(
+        storage=storage,
+        key=key,
+        version_id=result.version_id,
+        expected_bytes=body,
+        expected_sha256=digest,
+        artifact_kind=artifact_kind,
+    )
+
+    return digest, result.version_id
+
+
+def replicate_vault_snapshot(
+    *,
+    database_snapshot: VaultDatabaseSnapshot,
+    primary_storage: ObjectStorageClient,
+    replica_storage: ObjectStorageClient,
+    primary_settings: StorageSettings,
+    replica_settings: StorageSettings,
+    primary_domain: RecoveryDomain,
+    replica_domain: RecoveryDomain,
+    source_label: str,
+    release_commit: str,
+    snapshot_id: str,
+    now_utc: datetime,
+) -> dict[str, Any]:
+    assert_independent_domains(
+        primary=primary_domain,
+        replica=replica_domain,
+        primary_settings=primary_settings,
+        replica_settings=replica_settings,
+    )
+
+    normalized_source_label = _nonempty(
+        source_label,
+        label="source_label",
+    )
+    normalized_release = _release_commit(
+        release_commit
+    )
+    normalized_snapshot_id = _snapshot_id(
+        snapshot_id
+    )
+
+    active_now = now_utc.astimezone(
+        UTC
+    )
+
+    replica_prefix = (
+        replica_settings.normalized_key_prefix
+    )
+
+    entries: list[dict[str, Any]] = []
+    replica_keys: set[str] = set()
+    replicated_count = 0
+    state_only_count = 0
+
+    for raw_document in (
+        database_snapshot.documents
+    ):
+        document = _validate_document(
+            raw_document
+        )
+        entry = _base_manifest_entry(
+            document
+        )
+
+        if document.status == _REPLICABLE_STATUS:
+            recovery = (
+                _replicate_available_document(
+                    document=document,
+                    primary_storage=(
+                        primary_storage
+                    ),
+                    replica_storage=(
+                        replica_storage
+                    ),
+                    primary_settings=(
+                        primary_settings
+                    ),
+                    replica_key_prefix=(
+                        replica_prefix
+                    ),
+                )
+            )
+            entry.update(
+                recovery
+            )
+            replica_keys.add(
+                recovery["replica_key"]
+            )
+            replicated_count += 1
+        else:
+            entry.update(
+                {
+                    "replica_state": (
+                        "state_only_not_auto_recoverable"
+                    ),
+                    "recovery_eligible": False,
+                    "replica_key": None,
+                    "replica_version_id": None,
+                    "source_exact_version_verified": False,
+                }
+            )
+            state_only_count += 1
+
+        entries.append(entry)
+
+    manifest = {
+        "format_version": MANIFEST_FORMAT_VERSION,
+        "created_at_utc": _utc_iso(
+            active_now
+        ),
+        "snapshot_id": normalized_snapshot_id,
+        "source_label": (
+            normalized_source_label
+        ),
+        "release_commit": normalized_release,
+        "source_database": {
+            "database_name": (
+                database_snapshot.database_name
+            ),
+            "source_identity_sha256": (
+                database_snapshot.source_identity_sha256
+            ),
+            "postgres_server_version": (
+                database_snapshot.postgres_server_version
+            ),
+            "postgis_version": (
+                database_snapshot.postgis_version
+            ),
+            "alembic_revision": (
+                database_snapshot.alembic_revision
+            ),
+        },
+        "primary_storage": {
+            "provider_id": (
+                _normalize_domain_value(
+                    primary_domain.provider_id,
+                    label="primary provider_id",
+                )
+            ),
+            "failure_domain": (
+                _normalize_domain_value(
+                    primary_domain.failure_domain,
+                    label="primary failure_domain",
+                )
+            ),
+            "bucket_name": (
+                _nonempty(
+                    primary_settings.bucket_name,
+                    label="primary bucket",
+                )
+            ),
+            "key_prefix": (
+                primary_settings.normalized_key_prefix
+            ),
+        },
+        "replica_storage": {
+            "provider_id": (
+                _normalize_domain_value(
+                    replica_domain.provider_id,
+                    label="replica provider_id",
+                )
+            ),
+            "failure_domain": (
+                _normalize_domain_value(
+                    replica_domain.failure_domain,
+                    label="replica failure_domain",
+                )
+            ),
+            "bucket_name": (
+                _nonempty(
+                    replica_settings.bucket_name,
+                    label="replica bucket",
+                )
+            ),
+            "key_prefix": replica_prefix,
+        },
+        "document_count": len(entries),
+        "replicated_document_count": (
+            replicated_count
+        ),
+        "state_only_document_count": (
+            state_only_count
+        ),
+        "replica_object_count": len(
+            replica_keys
+        ),
+        "documents": entries,
+    }
+
+    manifest_key = (
+        f"{replica_prefix}/snapshots/"
+        f"{normalized_snapshot_id}/manifest.json"
+    )
+
+    manifest_sha256, manifest_version_id = (
+        _publish_immutable_json(
+            storage=replica_storage,
+            key=manifest_key,
+            payload=manifest,
+            artifact_kind=(
+                "vault-recovery-manifest"
+            ),
+        )
+    )
+
+    complete = {
+        "format_version": COMPLETE_FORMAT_VERSION,
+        "snapshot_id": normalized_snapshot_id,
+        "source_label": normalized_source_label,
+        "release_commit": normalized_release,
+        "published_at_utc": _utc_iso(
+            active_now
+        ),
+        "source_identity_sha256": (
+            database_snapshot.source_identity_sha256
+        ),
+        "alembic_revision": (
+            database_snapshot.alembic_revision
+        ),
+        "replica_provider_id": (
+            _normalize_domain_value(
+                replica_domain.provider_id,
+                label="replica provider_id",
+            )
+        ),
+        "replica_failure_domain": (
+            _normalize_domain_value(
+                replica_domain.failure_domain,
+                label="replica failure_domain",
+            )
+        ),
+        "manifest_key": manifest_key,
+        "manifest_sha256": (
+            manifest_sha256
+        ),
+        "manifest_version_id": (
+            manifest_version_id
+        ),
+        "document_count": len(entries),
+        "replicated_document_count": (
+            replicated_count
+        ),
+        "state_only_document_count": (
+            state_only_count
+        ),
+        "replica_object_count": len(
+            replica_keys
+        ),
+    }
+
+    complete_key = (
+        f"{replica_prefix}/snapshots/"
+        f"{normalized_snapshot_id}/complete.json"
+    )
+
+    complete_sha256, complete_version_id = (
+        _publish_immutable_json(
+            storage=replica_storage,
+            key=complete_key,
+            payload=complete,
+            artifact_kind=(
+                "vault-recovery-complete"
+            ),
+        )
+    )
+
+    return {
+        "format_version": RESULT_FORMAT_VERSION,
+        "result": "PASS",
+        "snapshot_id": normalized_snapshot_id,
+        "source_label": normalized_source_label,
+        "release_commit": normalized_release,
+        "source_identity_sha256": (
+            database_snapshot.source_identity_sha256
+        ),
+        "alembic_revision": (
+            database_snapshot.alembic_revision
+        ),
+        "document_count": len(entries),
+        "replicated_document_count": (
+            replicated_count
+        ),
+        "state_only_document_count": (
+            state_only_count
+        ),
+        "replica_object_count": len(
+            replica_keys
+        ),
+        "manifest_key": manifest_key,
+        "manifest_sha256": (
+            manifest_sha256
+        ),
+        "complete_key": complete_key,
+        "complete_sha256": (
+            complete_sha256
+        ),
+        "complete_version_id": (
+            complete_version_id
+        ),
+    }
+
+
+def _read_bool_env(
+    variable_name: str,
+    *,
+    default: bool,
+) -> bool:
+    raw = os.environ.get(
+        variable_name
+    )
+
+    if raw is None or not raw.strip():
+        return default
+
+    normalized = raw.strip().lower()
+
+    if normalized in {
+        "1",
+        "true",
+        "yes",
+        "on",
+    }:
+        return True
+
+    if normalized in {
+        "0",
+        "false",
+        "no",
+        "off",
+    }:
+        return False
+
+    raise VaultReplicaError(
+        f"{variable_name} must be boolean."
+    )
+
+
+def _env_optional(
+    variable_name: str,
+) -> str | None:
+    value = os.environ.get(
+        variable_name
+    )
+    if value is None:
+        return None
+    normalized = value.strip()
+    return normalized or None
+
+
+def _env_required(
+    variable_name: str,
+) -> str:
+    value = _env_optional(
+        variable_name
+    )
+    if value is None:
+        raise VaultReplicaError(
+            f"{variable_name} is required."
+        )
+    return value
+
+
+def _storage_from_environment(
+    *,
+    prefix: str,
+    default_key_prefix: str,
+) -> StorageSettings:
+    try:
+        settings = StorageSettings(
+            backend="s3",
+            bucket_name=_env_required(
+                f"{prefix}_BUCKET_NAME"
+            ),
+            region=(
+                _env_optional(
+                    f"{prefix}_REGION"
+                )
+                or "us-east-1"
+            ),
+            endpoint_url=_env_optional(
+                f"{prefix}_ENDPOINT_URL"
+            ),
+            access_key_id=_env_optional(
+                f"{prefix}_ACCESS_KEY_ID"
+            ),
+            secret_access_key=_env_optional(
+                f"{prefix}_SECRET_ACCESS_KEY"
+            ),
+            session_token=_env_optional(
+                f"{prefix}_SESSION_TOKEN"
+            ),
+            force_path_style=_read_bool_env(
+                f"{prefix}_FORCE_PATH_STYLE",
+                default=False,
+            ),
+            use_tls=_read_bool_env(
+                f"{prefix}_USE_TLS",
+                default=True,
+            ),
+            verify_tls=_read_bool_env(
+                f"{prefix}_VERIFY_TLS",
+                default=True,
+            ),
+            ca_bundle_path=_env_optional(
+                f"{prefix}_CA_BUNDLE_PATH"
+            ),
+            key_prefix=(
+                _env_optional(
+                    f"{prefix}_KEY_PREFIX"
+                )
+                or default_key_prefix
+            ),
+        )
+    except VaultReplicaError:
+        raise
+    except Exception as exc:
+        raise VaultReplicaError(
+            f"{prefix} storage configuration is invalid."
+        ) from exc
+
+    if (
+        not settings.use_tls
+        or not settings.verify_tls
+    ):
+        raise VaultReplicaError(
+            f"{prefix} recovery storage requires TLS verification."
+        )
+
+    return settings
+
+
+def _domain_from_environment(
+    *,
+    prefix: str,
+) -> RecoveryDomain:
+    return RecoveryDomain(
+        provider_id=_env_required(
+            f"{prefix}_PROVIDER_ID"
+        ),
+        failure_domain=_env_required(
+            f"{prefix}_FAILURE_DOMAIN"
+        ),
+    )
+
+
+def build_argument_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Create and verify an independent "
+            "tenant-scoped Vault recovery replica."
+        )
+    )
+
+    parser.add_argument(
+        "--source-label",
+        default="production",
+    )
+    parser.add_argument(
+        "--release-commit",
+        required=True,
+    )
+    parser.add_argument(
+        "--snapshot-id",
+        default=None,
+    )
+
+    return parser
+
+
+def main(
+    argv: list[str] | None = None,
+) -> int:
+    parser = build_argument_parser()
+    args = parser.parse_args(
+        argv
+    )
+
+    try:
+        database_url = _env_required(
+            "VAULT_BACKUP_DATABASE_URL"
+        )
+        database_url = normalize_database_url(
+            database_url
+        )
+
+        primary_settings = (
+            _storage_from_environment(
+                prefix="VAULT_PRIMARY",
+                default_key_prefix=(
+                    DEFAULT_PRIMARY_KEY_PREFIX
+                ),
+            )
+        )
+
+        replica_settings = (
+            _storage_from_environment(
+                prefix="VAULT_REPLICA",
+                default_key_prefix=(
+                    DEFAULT_REPLICA_KEY_PREFIX
+                ),
+            )
+        )
+
+        primary_domain = (
+            _domain_from_environment(
+                prefix="VAULT_PRIMARY"
+            )
+        )
+        replica_domain = (
+            _domain_from_environment(
+                prefix="VAULT_REPLICA"
+            )
+        )
+
+        assert_independent_domains(
+            primary=primary_domain,
+            replica=replica_domain,
+            primary_settings=primary_settings,
+            replica_settings=replica_settings,
+        )
+
+        primary_storage = (
+            Boto3S3ObjectStorage(
+                primary_settings
+            )
+        )
+        replica_storage = (
+            Boto3S3ObjectStorage(
+                replica_settings
+            )
+        )
+
+        if not primary_storage.health_check():
+            raise VaultReplicaError(
+                "Primary Vault storage readiness failed."
+            )
+
+        if not replica_storage.health_check():
+            raise VaultReplicaError(
+                "Independent Vault replica readiness failed."
+            )
+
+        database_snapshot = (
+            collect_vault_database_snapshot(
+                database_url
+            )
+        )
+
+        now_utc = datetime.now(
+            UTC
+        )
+
+        snapshot_id = (
+            args.snapshot_id
+            or utc_snapshot_id(
+                now_utc
+            )
+        )
+
+        result = replicate_vault_snapshot(
+            database_snapshot=(
+                database_snapshot
+            ),
+            primary_storage=(
+                primary_storage
+            ),
+            replica_storage=(
+                replica_storage
+            ),
+            primary_settings=(
+                primary_settings
+            ),
+            replica_settings=(
+                replica_settings
+            ),
+            primary_domain=(
+                primary_domain
+            ),
+            replica_domain=(
+                replica_domain
+            ),
+            source_label=(
+                args.source_label
+            ),
+            release_commit=(
+                args.release_commit
+            ),
+            snapshot_id=(
+                snapshot_id
+            ),
+            now_utc=now_utc,
+        )
+
+    except VaultReplicaError as exc:
+        print(
+            sanitize_cli_error_message(
+                str(exc)
+            ),
+            file=sys.stderr,
+        )
+        return 1
+    except BackupToolError as exc:
+        print(
+            sanitize_cli_error_message(
+                str(exc)
+            ),
+            file=sys.stderr,
+        )
+        return 1
+    except ObjectStorageError:
+        print(
+            "Vault recovery storage operation failed.",
+            file=sys.stderr,
+        )
+        return 1
+    except Exception:
+        print(
+            "Vault recovery replica operational failure.",
+            file=sys.stderr,
+        )
+        return 1
+
+    print(
+        json.dumps(
+            result,
+            sort_keys=True,
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(
+        main()
+    )

--- a/tests/test_disaster_recovery_p27a_unittest.py
+++ b/tests/test_disaster_recovery_p27a_unittest.py
@@ -225,3 +225,48 @@ def test_p27a_dr_runbook_records_p27a5_operational_acceptance():
         "is still required"
         not in dr
     )
+
+
+def test_p27a6_dr_runbook_defines_independent_vault_replica_contract():
+    dr = _dr_text()
+
+    for token in (
+        "14. P2.7A6 final disaster-recovery acceptance",
+        "P2.7A6A independent Vault recovery replica tooling",
+        "P2.7A6B real Vault provider-loss recovery drill",
+        "P2.7A6C >= 7-day provider history/PITR acceptance",
+        "P2.7A6D final DR evidence and go-live sign-off",
+        "VAULT_PRIMARY_PROVIDER_ID differs from VAULT_REPLICA_PROVIDER_ID",
+        "VAULT_PRIMARY_FAILURE_DOMAIN differs from VAULT_REPLICA_FAILURE_DOMAIN",
+        "VAULT_BACKUP_DATABASE_URL",
+        "repeatable-read, read-only transaction",
+        "state_only_not_auto_recoverable",
+        "<replica-prefix>/tenants/<organization_id>/objects/sha256/",
+        "complete.json is published LAST",
+        "full streamed SHA-256",
+        "treating the primary Vault provider as unavailable",
+        "production modified: NO",
+        ">= 7 days of provider history/PITR for go-live",
+        "P2.7A6 remains OPEN",
+    ):
+        assert token in dr
+
+
+def test_p27a6_dr_runbook_does_not_claim_operational_provider_loss_pass():
+    dr = _dr_text()
+
+    assert (
+        "Operational provisioning of the independent provider "
+        "and a real provider-loss drill remain required"
+        in dr
+    )
+
+    assert (
+        "P2.7A6B independent Vault provider-loss recovery PASS"
+        in dr
+    )
+
+    assert (
+        "P2.7A6 status:\n\nCLOSED"
+        not in dr
+    )

--- a/tests/test_vault_recovery_replica_p27a6_unittest.py
+++ b/tests/test_vault_recovery_replica_p27a6_unittest.py
@@ -1,0 +1,1004 @@
+from __future__ import annotations
+
+from dataclasses import replace
+from datetime import UTC, datetime
+import hashlib
+import io
+import json
+
+import pytest
+
+from litoral_trace.config.settings import (
+    StorageSettings,
+)
+from litoral_trace.storage import (
+    ObjectDeleteResult,
+    ObjectHead,
+    ObjectStorageNotFoundError,
+    ObjectStorageStream,
+    ObjectWriteResult,
+)
+from scripts.vault_recovery_replica import (
+    COMPLETE_FORMAT_VERSION,
+    MANIFEST_FORMAT_VERSION,
+    RESULT_FORMAT_VERSION,
+    RecoveryDomain,
+    VaultDatabaseSnapshot,
+    VaultReplicaDocument,
+    VaultReplicaError,
+    _assert_vault_backup_visibility,
+    assert_independent_domains,
+    replicate_vault_snapshot,
+)
+
+
+NOW = datetime(
+    2026,
+    8,
+    18,
+    16,
+    30,
+    0,
+    tzinfo=UTC,
+)
+SNAPSHOT_ID = "20260818T163000Z"
+RELEASE = (
+    "e05005666009c17f8a1bcb92ccfaff28092c5e36"
+)
+DB_IDENTITY = "d" * 64
+ALEMBIC = "018_example_p2_head"
+
+
+class _StoredObject:
+    def __init__(
+        self,
+        *,
+        data: bytes,
+        content_type: str,
+        metadata: dict[str, str],
+        version_id: str | None,
+    ):
+        self.data = bytes(data)
+        self.content_type = content_type
+        self.metadata = dict(
+            metadata
+        )
+        self.version_id = version_id
+
+
+class MemoryStorage:
+    def __init__(
+        self,
+        bucket_name: str,
+    ):
+        self.bucket_name = bucket_name
+        self._objects: dict[
+            str,
+            _StoredObject,
+        ] = {}
+        self._versions: dict[
+            tuple[str, str],
+            _StoredObject,
+        ] = {}
+        self._counter = 0
+        self.events: list[
+            tuple[str, str]
+        ] = []
+
+    def seed(
+        self,
+        *,
+        key: str,
+        data: bytes,
+        content_type: str,
+        metadata: dict[str, str] | None = None,
+        version_id: str | None = None,
+    ) -> None:
+        stored = _StoredObject(
+            data=data,
+            content_type=content_type,
+            metadata=metadata or {},
+            version_id=version_id,
+        )
+        self._objects[key] = stored
+
+        if version_id is not None:
+            self._versions[
+                (key, version_id)
+            ] = stored
+
+    def _resolve(
+        self,
+        *,
+        key: str,
+        version_id: str | None,
+    ) -> _StoredObject:
+        if version_id is not None:
+            stored = self._versions.get(
+                (key, version_id)
+            )
+        else:
+            stored = self._objects.get(
+                key
+            )
+
+        if stored is None:
+            raise ObjectStorageNotFoundError(
+                "memory"
+            )
+
+        return stored
+
+    def put_object(
+        self,
+        *,
+        key: str,
+        body,
+        content_type: str,
+        content_length: int,
+        metadata=None,
+    ) -> ObjectWriteResult:
+        if isinstance(
+            body,
+            bytes,
+        ):
+            payload = body
+        else:
+            payload = body.read()
+
+        if len(payload) != content_length:
+            raise AssertionError(
+                "test storage length mismatch"
+            )
+
+        self._counter += 1
+        version_id = (
+            f"replica-v{self._counter}"
+        )
+
+        self.seed(
+            key=key,
+            data=payload,
+            content_type=content_type,
+            metadata=dict(
+                metadata or {}
+            ),
+            version_id=version_id,
+        )
+
+        self.events.append(
+            ("put", key)
+        )
+
+        return ObjectWriteResult(
+            etag="etag",
+            version_id=version_id,
+        )
+
+    def head_object(
+        self,
+        *,
+        key: str,
+        version_id: str | None = None,
+    ) -> ObjectHead:
+        stored = self._resolve(
+            key=key,
+            version_id=version_id,
+        )
+
+        return ObjectHead(
+            size_bytes=len(
+                stored.data
+            ),
+            content_type=(
+                stored.content_type
+            ),
+            etag="etag",
+            version_id=(
+                stored.version_id
+            ),
+            metadata=(
+                stored.metadata
+            ),
+        )
+
+    def get_object_stream(
+        self,
+        *,
+        key: str,
+        version_id: str | None = None,
+    ) -> ObjectStorageStream:
+        stored = self._resolve(
+            key=key,
+            version_id=version_id,
+        )
+
+        return ObjectStorageStream(
+            body=io.BytesIO(
+                stored.data
+            ),
+            head=ObjectHead(
+                size_bytes=len(
+                    stored.data
+                ),
+                content_type=(
+                    stored.content_type
+                ),
+                etag="etag",
+                version_id=(
+                    stored.version_id
+                ),
+                metadata=(
+                    stored.metadata
+                ),
+            ),
+        )
+
+    def delete_object(
+        self,
+        *,
+        key: str,
+        version_id: str | None = None,
+    ) -> ObjectDeleteResult:
+        raise AssertionError(
+            "replica tests must never delete"
+        )
+
+    def object_exists(
+        self,
+        *,
+        key: str,
+        version_id: str | None = None,
+    ) -> bool:
+        try:
+            self._resolve(
+                key=key,
+                version_id=version_id,
+            )
+        except ObjectStorageNotFoundError:
+            return False
+
+        return True
+
+    def health_check(self) -> bool:
+        return True
+
+    def bytes_for(
+        self,
+        key: str,
+    ) -> bytes:
+        return self._resolve(
+            key=key,
+            version_id=None,
+        ).data
+
+
+class MisreportingVersionStorage(
+    MemoryStorage
+):
+    def get_object_stream(
+        self,
+        *,
+        key: str,
+        version_id: str | None = None,
+    ) -> ObjectStorageStream:
+        stream = super().get_object_stream(
+            key=key,
+            version_id=version_id,
+        )
+
+        return ObjectStorageStream(
+            body=io.BytesIO(
+                stream.read()
+            ),
+            head=replace(
+                stream.head,
+                version_id="wrong-version",
+            ),
+        )
+
+
+def _settings(
+    *,
+    bucket: str,
+    key_prefix: str,
+    endpoint: str,
+) -> StorageSettings:
+    return StorageSettings(
+        backend="s3",
+        bucket_name=bucket,
+        region="test-1",
+        endpoint_url=endpoint,
+        force_path_style=True,
+        use_tls=True,
+        verify_tls=True,
+        key_prefix=key_prefix,
+    )
+
+
+def _primary_settings() -> StorageSettings:
+    return _settings(
+        bucket="primary-vault",
+        key_prefix="vault",
+        endpoint="https://primary.example",
+    )
+
+
+def _replica_settings() -> StorageSettings:
+    return _settings(
+        bucket="independent-recovery",
+        key_prefix=(
+            "litoral-trace/vault-recovery"
+        ),
+        endpoint="https://replica.example",
+    )
+
+
+def _primary_domain() -> RecoveryDomain:
+    return RecoveryDomain(
+        provider_id="primary-provider",
+        failure_domain="primary-provider-global",
+    )
+
+
+def _replica_domain() -> RecoveryDomain:
+    return RecoveryDomain(
+        provider_id="secondary-provider",
+        failure_domain="secondary-provider-global",
+    )
+
+
+def _document(
+    *,
+    data: bytes = b"vault-evidence",
+    organization_id: int = 7,
+    status: str = "available",
+    object_key: str = (
+        "vault/tenants/7/objects/opaque-1"
+    ),
+    storage_bucket: str = "primary-vault",
+    storage_version_id: str | None = (
+        "source-v1"
+    ),
+    sha256: str | None = None,
+) -> VaultReplicaDocument:
+    return VaultReplicaDocument(
+        organization_id=organization_id,
+        public_id=(
+            "11111111-1111-4111-8111-111111111111"
+        ),
+        status=status,
+        storage_backend="s3",
+        storage_bucket=storage_bucket,
+        object_key=object_key,
+        storage_version_id=(
+            storage_version_id
+        ),
+        size_bytes=len(data),
+        content_type="application/pdf",
+        sha256=(
+            sha256
+            or hashlib.sha256(
+                data
+            ).hexdigest()
+        ),
+    )
+
+
+def _snapshot(
+    *documents: VaultReplicaDocument,
+) -> VaultDatabaseSnapshot:
+    return VaultDatabaseSnapshot(
+        database_name="neondb",
+        source_identity_sha256=(
+            DB_IDENTITY
+        ),
+        postgres_server_version="17.10",
+        postgis_version="3.5.0",
+        alembic_revision=ALEMBIC,
+        documents=tuple(
+            documents
+        ),
+    )
+
+
+def _run(
+    *,
+    document: VaultReplicaDocument,
+    primary: MemoryStorage,
+    replica: MemoryStorage,
+):
+    return replicate_vault_snapshot(
+        database_snapshot=_snapshot(
+            document
+        ),
+        primary_storage=primary,
+        replica_storage=replica,
+        primary_settings=(
+            _primary_settings()
+        ),
+        replica_settings=(
+            _replica_settings()
+        ),
+        primary_domain=(
+            _primary_domain()
+        ),
+        replica_domain=(
+            _replica_domain()
+        ),
+        source_label="production",
+        release_commit=RELEASE,
+        snapshot_id=SNAPSHOT_ID,
+        now_utc=NOW,
+    )
+
+
+def test_p27a6a_available_object_is_verified_and_replicated():
+    data = b"vault-evidence"
+    document = _document(
+        data=data
+    )
+
+    primary = MemoryStorage(
+        "primary-vault"
+    )
+    primary.seed(
+        key=document.object_key,
+        data=data,
+        content_type=document.content_type,
+        metadata={},
+        version_id="source-v1",
+    )
+
+    replica = MemoryStorage(
+        "independent-recovery"
+    )
+
+    result = _run(
+        document=document,
+        primary=primary,
+        replica=replica,
+    )
+
+    assert result["result"] == "PASS"
+    assert (
+        result["format_version"]
+        == RESULT_FORMAT_VERSION
+    )
+    assert (
+        result[
+            "replicated_document_count"
+        ]
+        == 1
+    )
+    assert (
+        result["replica_object_count"]
+        == 1
+    )
+
+    manifest = json.loads(
+        replica.bytes_for(
+            result["manifest_key"]
+        )
+    )
+
+    assert (
+        manifest["format_version"]
+        == MANIFEST_FORMAT_VERSION
+    )
+    assert (
+        manifest["source_database"][
+            "source_identity_sha256"
+        ]
+        == DB_IDENTITY
+    )
+
+    entry = manifest[
+        "documents"
+    ][0]
+
+    assert (
+        entry["replica_state"]
+        == "copied_verified"
+    )
+    assert (
+        entry[
+            "source_exact_version_verified"
+        ]
+        is True
+    )
+    assert (
+        entry["storage_version_id"]
+        == "source-v1"
+    )
+    assert (
+        replica.bytes_for(
+            entry["replica_key"]
+        )
+        == data
+    )
+
+
+def test_p27a6a_complete_marker_is_published_last():
+    data = b"vault-evidence"
+    document = _document(
+        data=data
+    )
+
+    primary = MemoryStorage(
+        "primary-vault"
+    )
+    primary.seed(
+        key=document.object_key,
+        data=data,
+        content_type=document.content_type,
+        version_id="source-v1",
+    )
+
+    replica = MemoryStorage(
+        "independent-recovery"
+    )
+
+    result = _run(
+        document=document,
+        primary=primary,
+        replica=replica,
+    )
+
+    assert (
+        replica.events[-1]
+        == (
+            "put",
+            result["complete_key"],
+        )
+    )
+
+    complete = json.loads(
+        replica.bytes_for(
+            result["complete_key"]
+        )
+    )
+
+    assert (
+        complete["format_version"]
+        == COMPLETE_FORMAT_VERSION
+    )
+    assert (
+        complete["manifest_sha256"]
+        == result["manifest_sha256"]
+    )
+
+
+@pytest.mark.parametrize(
+    "status",
+    [
+        "pending_upload",
+        "upload_failed",
+        "delete_pending",
+        "delete_failed",
+        "deleted",
+    ],
+)
+def test_p27a6a_non_available_states_are_not_auto_recovered(
+    status,
+):
+    document = _document(
+        status=status
+    )
+
+    primary = MemoryStorage(
+        "primary-vault"
+    )
+    replica = MemoryStorage(
+        "independent-recovery"
+    )
+
+    result = _run(
+        document=document,
+        primary=primary,
+        replica=replica,
+    )
+
+    assert (
+        result[
+            "replicated_document_count"
+        ]
+        == 0
+    )
+    assert (
+        result[
+            "state_only_document_count"
+        ]
+        == 1
+    )
+
+    manifest = json.loads(
+        replica.bytes_for(
+            result["manifest_key"]
+        )
+    )
+    entry = manifest[
+        "documents"
+    ][0]
+
+    assert (
+        entry["recovery_eligible"]
+        is False
+    )
+    assert (
+        entry["replica_key"]
+        is None
+    )
+    assert (
+        entry["replica_state"]
+        == "state_only_not_auto_recoverable"
+    )
+
+
+def test_p27a6a_rejects_cross_tenant_primary_key():
+    data = b"vault-evidence"
+    document = _document(
+        data=data,
+        object_key=(
+            "vault/tenants/8/objects/opaque-1"
+        ),
+    )
+
+    primary = MemoryStorage(
+        "primary-vault"
+    )
+    primary.seed(
+        key=document.object_key,
+        data=data,
+        content_type=document.content_type,
+        version_id="source-v1",
+    )
+
+    replica = MemoryStorage(
+        "independent-recovery"
+    )
+
+    with pytest.raises(
+        VaultReplicaError,
+        match="tenant binding",
+    ):
+        _run(
+            document=document,
+            primary=primary,
+            replica=replica,
+        )
+
+
+def test_p27a6a_rejects_primary_sha256_mismatch():
+    expected = b"vault-evidence"
+    actual = b"vault-evidencf"
+
+    assert len(expected) == len(
+        actual
+    )
+
+    document = _document(
+        data=expected
+    )
+
+    primary = MemoryStorage(
+        "primary-vault"
+    )
+    primary.seed(
+        key=document.object_key,
+        data=actual,
+        content_type=document.content_type,
+        version_id="source-v1",
+    )
+
+    replica = MemoryStorage(
+        "independent-recovery"
+    )
+
+    with pytest.raises(
+        VaultReplicaError,
+        match="SHA-256",
+    ):
+        _run(
+            document=document,
+            primary=primary,
+            replica=replica,
+        )
+
+
+def test_p27a6a_rejects_exact_source_version_mismatch():
+    data = b"vault-evidence"
+    document = _document(
+        data=data
+    )
+
+    primary = (
+        MisreportingVersionStorage(
+            "primary-vault"
+        )
+    )
+    primary.seed(
+        key=document.object_key,
+        data=data,
+        content_type=document.content_type,
+        version_id="source-v1",
+    )
+
+    replica = MemoryStorage(
+        "independent-recovery"
+    )
+
+    with pytest.raises(
+        VaultReplicaError,
+        match="exact-version",
+    ):
+        _run(
+            document=document,
+            primary=primary,
+            replica=replica,
+        )
+
+
+def test_p27a6a_rejects_corrupt_existing_replica_without_overwrite():
+    data = b"vault-evidence"
+    document = _document(
+        data=data
+    )
+
+    primary = MemoryStorage(
+        "primary-vault"
+    )
+    primary.seed(
+        key=document.object_key,
+        data=data,
+        content_type=document.content_type,
+        version_id="source-v1",
+    )
+
+    replica = MemoryStorage(
+        "independent-recovery"
+    )
+
+    replica_key = (
+        "litoral-trace/vault-recovery/"
+        "tenants/7/objects/sha256/"
+        f"{document.sha256[:2]}/"
+        f"{document.sha256}"
+    )
+
+    corrupt = b"fault-evidence"
+    assert len(corrupt) == len(data)
+
+    replica.seed(
+        key=replica_key,
+        data=corrupt,
+        content_type=document.content_type,
+        metadata={
+            "sha256": document.sha256,
+            "organization-id": "7",
+        },
+        version_id="existing-v1",
+    )
+
+    with pytest.raises(
+        VaultReplicaError,
+        match="full SHA-256",
+    ):
+        _run(
+            document=document,
+            primary=primary,
+            replica=replica,
+        )
+
+    assert (
+        ("put", replica_key)
+        not in replica.events
+    )
+
+
+def test_p27a6a_rejects_wrong_primary_bucket_binding():
+    data = b"vault-evidence"
+    document = _document(
+        data=data,
+        storage_bucket="other-bucket",
+    )
+
+    primary = MemoryStorage(
+        "primary-vault"
+    )
+    replica = MemoryStorage(
+        "independent-recovery"
+    )
+
+    with pytest.raises(
+        VaultReplicaError,
+        match="storage bucket",
+    ):
+        _run(
+            document=document,
+            primary=primary,
+            replica=replica,
+        )
+
+
+def test_p27a6a_rejects_same_provider():
+    with pytest.raises(
+        VaultReplicaError,
+        match="different storage providers",
+    ):
+        assert_independent_domains(
+            primary=RecoveryDomain(
+                provider_id="aws",
+                failure_domain="aws-global",
+            ),
+            replica=RecoveryDomain(
+                provider_id="aws",
+                failure_domain="other",
+            ),
+            primary_settings=(
+                _primary_settings()
+            ),
+            replica_settings=(
+                _replica_settings()
+            ),
+        )
+
+
+def test_p27a6a_rejects_same_failure_domain():
+    with pytest.raises(
+        VaultReplicaError,
+        match="different failure domains",
+    ):
+        assert_independent_domains(
+            primary=RecoveryDomain(
+                provider_id="provider-a",
+                failure_domain="shared-domain",
+            ),
+            replica=RecoveryDomain(
+                provider_id="provider-b",
+                failure_domain="shared-domain",
+            ),
+            primary_settings=(
+                _primary_settings()
+            ),
+            replica_settings=(
+                _replica_settings()
+            ),
+        )
+
+
+def test_p27a6a_reuses_verified_content_addressed_payload():
+    data = b"vault-evidence"
+    document = _document(
+        data=data
+    )
+
+    primary = MemoryStorage(
+        "primary-vault"
+    )
+    primary.seed(
+        key=document.object_key,
+        data=data,
+        content_type=document.content_type,
+        version_id="source-v1",
+    )
+
+    replica = MemoryStorage(
+        "independent-recovery"
+    )
+
+    first = _run(
+        document=document,
+        primary=primary,
+        replica=replica,
+    )
+
+    payload_puts_before = [
+        event
+        for event in replica.events
+        if "/objects/sha256/" in event[1]
+    ]
+
+    assert len(
+        payload_puts_before
+    ) == 1
+
+    # Same verified payload under another snapshot.
+    second = replicate_vault_snapshot(
+        database_snapshot=_snapshot(
+            document
+        ),
+        primary_storage=primary,
+        replica_storage=replica,
+        primary_settings=(
+            _primary_settings()
+        ),
+        replica_settings=(
+            _replica_settings()
+        ),
+        primary_domain=(
+            _primary_domain()
+        ),
+        replica_domain=(
+            _replica_domain()
+        ),
+        source_label="production",
+        release_commit=RELEASE,
+        snapshot_id="20260818T164500Z",
+        now_utc=NOW,
+    )
+
+    payload_puts_after = [
+        event
+        for event in replica.events
+        if "/objects/sha256/" in event[1]
+    ]
+
+    assert len(
+        payload_puts_after
+    ) == 1
+    assert (
+        first["replica_object_count"]
+        == 1
+    )
+    assert (
+        second["replica_object_count"]
+        == 1
+    )
+
+
+def test_p27a6a_rejects_missing_primary_content_type():
+    data = b"vault-evidence"
+    document = _document(
+        data=data
+    )
+
+    primary = MemoryStorage(
+        "primary-vault"
+    )
+    primary.seed(
+        key=document.object_key,
+        data=data,
+        content_type=None,
+        version_id="source-v1",
+    )
+
+    replica = MemoryStorage(
+        "independent-recovery"
+    )
+
+    with pytest.raises(
+        VaultReplicaError,
+        match="content type is missing",
+    ):
+        _run(
+            document=document,
+            primary=primary,
+            replica=replica,
+        )
+
+
+def test_p27a6a_rejects_backup_role_without_rls_bypass():
+    with pytest.raises(
+        VaultReplicaError,
+        match="cannot bypass tenant RLS",
+    ):
+        _assert_vault_backup_visibility(
+            {
+                "rls_enabled": True,
+                "rls_forced": True,
+                "role_bypassrls": False,
+                "role_superuser": False,
+            }
+        )
+
+
+def test_p27a6a_accepts_verified_cross_tenant_backup_visibility():
+    _assert_vault_backup_visibility(
+        {
+            "rls_enabled": True,
+            "rls_forced": True,
+            "role_bypassrls": True,
+            "role_superuser": False,
+        }
+    )


### PR DESCRIPTION
## P2.7A6A — Independent Vault recovery replica

Adds fail-closed S3-compatible Vault recovery replica tooling for final DR acceptance.

### Scope
- create `scripts/vault_recovery_replica.py`
- create `tests/test_vault_recovery_replica_p27a6_unittest.py`
- update `DISASTER_RECOVERY_RUNBOOK.md`
- update `tests/test_disaster_recovery_p27a_unittest.py`

### Security / DR properties
- distinct provider and failure-domain enforcement
- repeatable-read read-only PostgreSQL metadata snapshot
- explicit forced-RLS/BYPASSRLS visibility gate to prevent false empty snapshots
- exact source version verification when persisted
- tenant-bound object keys
- full SHA-256 verification before and after replication
- mandatory content-type verification
- content-addressed tenant-scoped replica objects
- corrupt existing replica objects fail closed and are not silently overwritten
- lifecycle states other than `available` are recorded but not auto-recovered
- `complete.json` published last after remote verification
- no application runtime, Alembic, AWS, Neon, Render, or production changes

### Validation
Targeted Vault/DR regression passed locally: 105 tests, with 2 unrelated Starlette deprecation warnings.

Base: `p2-enterprise-production`
Head: `p27a6-final-dr-acceptance`
Expected head SHA: `6b0ce5862f0ecd114322df16f73319023bf8ae05`