### PR TITLE
feat(dr): add Vault provider-loss recovery drill P2.7A6B

### DIFF
--- a/DISASTER_RECOVERY_RUNBOOK.md
+++ b/DISASTER_RECOVERY_RUNBOOK.md
@@ -813,13 +813,147 @@ Credentials remain environment/secret-store inputs only.
 
 TLS and certificate verification are mandatory for the operational CLI path.
 
-P2.7A6B acceptance requirement
+P2.7A6B provider-loss recovery drill
 
 P2.7A6B must prove recovery while treating the primary Vault provider as unavailable.
 
-The recovery candidate must come from the independent replica, not from a same-provider primary version.
+P2.7A6B code status:
 
-The drill must use an isolated recovery target first and must verify:
+IMPLEMENTED - provider-loss recovery verifier/materializer is present and unit-tested.
+
+Operational provider-loss execution against a real independent storage provider remains required before P2.7A6B can be operationally closed.
+
+Provider-loss execution boundary
+
+The drill deliberately does not instantiate, query, HEAD, GET, PUT, or DELETE the primary Vault provider.
+
+The CLI requires:
+
+--primary-unavailable
+
+The execution environment must not contain VAULT_PRIMARY_* configuration.
+
+Only VAULT_REPLICA_* read credentials are required.
+
+This makes the independent replica the sole source of recovered object bytes during the drill.
+
+Recovery evidence binding
+
+The operator pins:
+
+- complete.json object key
+- complete.json SHA-256
+- complete.json version ID when the provider exposes one
+- expected snapshot ID
+- expected source label
+- expected release commit
+- expected Alembic revision
+- replica provider ID
+- replica failure domain
+- replica bucket/prefix
+
+complete.json binds manifest.json by:
+
+- manifest_key
+- manifest_sha256
+- manifest_version_id when present
+- source identity
+- release commit
+- Alembic revision
+- lifecycle/object counts
+
+The drill then verifies manifest.json and every recovery-eligible object before materialization.
+
+Isolated recovery target
+
+The recovery target is a new local filesystem directory created solely for the drill.
+
+The final target path MUST NOT already exist.
+
+Recovery occurs first in a hidden partial directory.
+
+The partial directory is atomically promoted to the requested final target only after the complete snapshot passes verification.
+
+Any failed recovery removes the partial target and does not emit a PASS recovery directory.
+
+Recovered layout:
+
+<target>/tenants/<organization_id>/documents/<public_id>/metadata.json
+
+For available documents:
+
+<target>/tenants/<organization_id>/documents/<public_id>/payload.<verified-extension>
+
+For non-available lifecycle states, metadata.json is materialized but no payload is created.
+
+This preserves lifecycle semantics and prevents deleted/pending/failed documents from being resurrected automatically.
+
+Replica payload verification
+
+For each available document the drill verifies:
+
+- tenant-scoped content-addressed replica key
+- public_id uniqueness
+- exact replica version when the manifest contains one
+- object size
+- content type
+- organization-id object metadata
+- SHA-256 object metadata
+- full streamed SHA-256
+- recovered byte count
+
+Application compatibility
+
+After cryptographic recovery, the recovered payload is re-opened through the canonical Vault upload validator using its persisted content type.
+
+PDF, JSON, and XLSX structural validation therefore execute again against the recovered bytes.
+
+A byte-identical object that is no longer valid Vault evidence fails the drill.
+
+Read-only recovery property
+
+The drill uses only HEAD/GET operations against the independent replica.
+
+No replica PUT or DELETE operation is part of the recovery path.
+
+The primary provider is not configured.
+
+PostgreSQL is not contacted.
+
+Production is not modified.
+
+Successful output
+
+A successful isolated recovery emits:
+
+recovery_index.json
+
+and a sanitized result containing:
+
+- result: PASS
+- verification_status: PASS
+- provider_loss_mode: primary_unavailable
+- primary_access_attempted: false
+- replica_read_only: true
+- production_modified: false
+- snapshot ID
+- release commit
+- Alembic revision
+- complete SHA-256
+- manifest SHA-256
+- recovered document count
+- state-only document count
+- recovered bytes
+- elapsed_seconds
+- recovery_index_sha256
+
+Operational acceptance requirement
+
+P2.7A6B must still prove recovery while treating the real primary Vault provider as unavailable.
+
+The operational recovery candidate must come from the independent provider provisioned for P2.7A6A, not from a same-provider primary version.
+
+The real drill requires at least one recovery-eligible object and must verify:
 
 - tenant binding
 - public document binding
@@ -831,6 +965,8 @@ The drill must use an isolated recovery target first and must verify:
 - complete-marker binding
 - application-compatible recovered bytes
 - elapsed recovery/verification time
+- primary access attempted: NO
+- replica writes performed: NO
 - production modified: NO
 
 P2.7A6C acceptance requirement

--- a/scripts/vault_provider_loss_drill.py
+++ b/scripts/vault_provider_loss_drill.py
@@ -1,0 +1,2485 @@
+from __future__ import annotations
+
+import argparse
+from dataclasses import dataclass
+import hashlib
+import json
+import os
+from pathlib import Path
+import re
+import shutil
+import sys
+import time
+from typing import Any, Mapping
+from uuid import UUID, uuid4
+
+from litoral_trace.config.settings import StorageSettings
+from litoral_trace.services.vault import (
+    VaultValidationError,
+    validate_vault_upload,
+)
+from litoral_trace.storage import (
+    Boto3S3ObjectStorage,
+    ObjectStorageClient,
+    ObjectStorageError,
+    ObjectStorageNotFoundError,
+)
+from scripts.postgres_logical_backup import (
+    sanitize_cli_error_message,
+)
+from scripts.vault_recovery_replica import (
+    COMPLETE_FORMAT_VERSION,
+    DEFAULT_REPLICA_KEY_PREFIX,
+    MANIFEST_FORMAT_VERSION,
+    RecoveryDomain,
+)
+
+
+DRILL_FORMAT_VERSION = "p27a6.vault-provider-loss-drill.v1"
+INDEX_FORMAT_VERSION = "p27a6.vault-provider-loss-index.v1"
+
+_KNOWN_STATUSES = frozenset(
+    {
+        "pending_upload",
+        "available",
+        "upload_failed",
+        "delete_pending",
+        "delete_failed",
+        "deleted",
+    }
+)
+
+_RECOVERABLE_REPLICA_STATES = frozenset(
+    {
+        "copied_verified",
+        "reused_verified",
+    }
+)
+
+_CONTENT_TYPE_EXTENSION = {
+    "application/pdf": ".pdf",
+    "application/json": ".json",
+    (
+        "application/"
+        "vnd.openxmlformats-officedocument."
+        "spreadsheetml.sheet"
+    ): ".xlsx",
+}
+
+_SHA256_RE = re.compile(r"^[0-9a-f]{64}$")
+_COMMIT_RE = re.compile(r"^[0-9a-fA-F]{7,64}$")
+_SNAPSHOT_RE = re.compile(r"^\d{8}T\d{6}Z$")
+
+_PRIMARY_ENV_PREFIX = "VAULT_PRIMARY_"
+
+
+class VaultProviderLossDrillError(RuntimeError):
+    """Fail-closed Vault provider-loss recovery-drill failure."""
+
+
+@dataclass(frozen=True)
+class DrillDocument:
+    organization_id: int
+    public_id: str
+    status: str
+
+    storage_backend: str
+    storage_bucket: str
+    object_key: str
+    storage_version_id: str | None
+
+    size_bytes: int
+    content_type: str
+    sha256: str
+
+    recovery_eligible: bool
+    replica_state: str
+    replica_key: str | None
+    replica_version_id: str | None
+
+    source_exact_version_verified: bool
+
+
+@dataclass(frozen=True)
+class ValidatedSnapshot:
+    snapshot_id: str
+    source_label: str
+    release_commit: str
+    source_identity_sha256: str
+    alembic_revision: str
+
+    document_count: int
+    replicated_document_count: int
+    state_only_document_count: int
+    replica_object_count: int
+
+    manifest_key: str
+    manifest_sha256: str
+    documents: tuple[DrillDocument, ...]
+
+
+def _nonempty(
+    value: object,
+    *,
+    label: str,
+) -> str:
+    normalized = str(
+        value if value is not None else ""
+    ).strip()
+
+    if not normalized:
+        raise VaultProviderLossDrillError(
+            f"{label} must not be empty."
+        )
+
+    return normalized
+
+
+def _optional_string(
+    value: object,
+) -> str | None:
+    if value is None:
+        return None
+
+    normalized = str(value).strip()
+    return normalized or None
+
+
+def _sha256(
+    value: object,
+    *,
+    label: str,
+) -> str:
+    normalized = _nonempty(
+        value,
+        label=label,
+    ).lower()
+
+    if not _SHA256_RE.fullmatch(
+        normalized
+    ):
+        raise VaultProviderLossDrillError(
+            f"{label} must be a canonical SHA-256."
+        )
+
+    return normalized
+
+
+def _snapshot_id(
+    value: object,
+) -> str:
+    normalized = _nonempty(
+        value,
+        label="snapshot_id",
+    )
+
+    if not _SNAPSHOT_RE.fullmatch(
+        normalized
+    ):
+        raise VaultProviderLossDrillError(
+            "snapshot_id must use YYYYMMDDTHHMMSSZ."
+        )
+
+    return normalized
+
+
+def _release_commit(
+    value: object,
+) -> str:
+    normalized = _nonempty(
+        value,
+        label="release_commit",
+    ).lower()
+
+    if not _COMMIT_RE.fullmatch(
+        normalized
+    ):
+        raise VaultProviderLossDrillError(
+            "release_commit is invalid."
+        )
+
+    return normalized
+
+
+def _canonical_content_type(
+    value: object,
+) -> str:
+    normalized = _nonempty(
+        value,
+        label="content_type",
+    )
+
+    return normalized.split(
+        ";",
+        1,
+    )[0].strip().lower()
+
+
+def _canonical_json_bytes(
+    payload: dict[str, Any],
+) -> bytes:
+    return (
+        json.dumps(
+            payload,
+            indent=2,
+            sort_keys=True,
+            ensure_ascii=True,
+        )
+        + "\n"
+    ).encode("utf-8")
+
+
+def _canonical_key(
+    value: object,
+    *,
+    label: str,
+) -> str:
+    key = _nonempty(
+        value,
+        label=label,
+    )
+
+    if (
+        key.startswith("/")
+        or "\\" in key
+        or any(
+            ord(character) < 32
+            for character in key
+        )
+        or any(
+            segment in {
+                "",
+                ".",
+                "..",
+            }
+            for segment in key.split("/")
+        )
+    ):
+        raise VaultProviderLossDrillError(
+            f"{label} is not canonical."
+        )
+
+    return key
+
+
+def _positive_int(
+    value: object,
+    *,
+    label: str,
+) -> int:
+    try:
+        normalized = int(value)
+    except (
+        TypeError,
+        ValueError,
+    ) as exc:
+        raise VaultProviderLossDrillError(
+            f"{label} is invalid."
+        ) from exc
+
+    if normalized <= 0:
+        raise VaultProviderLossDrillError(
+            f"{label} must be positive."
+        )
+
+    return normalized
+
+
+def _nonnegative_int(
+    value: object,
+    *,
+    label: str,
+) -> int:
+    try:
+        normalized = int(value)
+    except (
+        TypeError,
+        ValueError,
+    ) as exc:
+        raise VaultProviderLossDrillError(
+            f"{label} is invalid."
+        ) from exc
+
+    if normalized < 0:
+        raise VaultProviderLossDrillError(
+            f"{label} must not be negative."
+        )
+
+    return normalized
+
+
+def _uuid(
+    value: object,
+    *,
+    label: str,
+) -> str:
+    try:
+        return str(
+            UUID(
+                _nonempty(
+                    value,
+                    label=label,
+                )
+            )
+        )
+    except (
+        ValueError,
+        AttributeError,
+    ) as exc:
+        raise VaultProviderLossDrillError(
+            f"{label} is invalid."
+        ) from exc
+
+
+def _domain_value(
+    value: object,
+    *,
+    label: str,
+) -> str:
+    normalized = _nonempty(
+        value,
+        label=label,
+    ).lower()
+
+    if any(
+        ord(character) < 32
+        for character in normalized
+    ):
+        raise VaultProviderLossDrillError(
+            f"{label} contains control characters."
+        )
+
+    return normalized
+
+
+def _env_optional(
+    variable_name: str,
+) -> str | None:
+    value = os.environ.get(
+        variable_name
+    )
+
+    if value is None:
+        return None
+
+    normalized = value.strip()
+    return normalized or None
+
+
+def _env_required(
+    variable_name: str,
+) -> str:
+    value = _env_optional(
+        variable_name
+    )
+
+    if value is None:
+        raise VaultProviderLossDrillError(
+            f"{variable_name} is required."
+        )
+
+    return value
+
+
+def _read_bool_env(
+    variable_name: str,
+    *,
+    default: bool,
+) -> bool:
+    raw = os.environ.get(
+        variable_name
+    )
+
+    if raw is None or not raw.strip():
+        return default
+
+    normalized = raw.strip().lower()
+
+    if normalized in {
+        "1",
+        "true",
+        "yes",
+        "on",
+    }:
+        return True
+
+    if normalized in {
+        "0",
+        "false",
+        "no",
+        "off",
+    }:
+        return False
+
+    raise VaultProviderLossDrillError(
+        f"{variable_name} must be boolean."
+    )
+
+
+def _replica_settings_from_environment() -> StorageSettings:
+    try:
+        settings = StorageSettings(
+            backend="s3",
+            bucket_name=_env_required(
+                "VAULT_REPLICA_BUCKET_NAME"
+            ),
+            region=(
+                _env_optional(
+                    "VAULT_REPLICA_REGION"
+                )
+                or "us-east-1"
+            ),
+            endpoint_url=_env_optional(
+                "VAULT_REPLICA_ENDPOINT_URL"
+            ),
+            access_key_id=_env_optional(
+                "VAULT_REPLICA_ACCESS_KEY_ID"
+            ),
+            secret_access_key=_env_optional(
+                "VAULT_REPLICA_SECRET_ACCESS_KEY"
+            ),
+            session_token=_env_optional(
+                "VAULT_REPLICA_SESSION_TOKEN"
+            ),
+            force_path_style=_read_bool_env(
+                "VAULT_REPLICA_FORCE_PATH_STYLE",
+                default=False,
+            ),
+            use_tls=_read_bool_env(
+                "VAULT_REPLICA_USE_TLS",
+                default=True,
+            ),
+            verify_tls=_read_bool_env(
+                "VAULT_REPLICA_VERIFY_TLS",
+                default=True,
+            ),
+            ca_bundle_path=_env_optional(
+                "VAULT_REPLICA_CA_BUNDLE_PATH"
+            ),
+            key_prefix=(
+                _env_optional(
+                    "VAULT_REPLICA_KEY_PREFIX"
+                )
+                or DEFAULT_REPLICA_KEY_PREFIX
+            ),
+        )
+    except VaultProviderLossDrillError:
+        raise
+    except Exception as exc:
+        raise VaultProviderLossDrillError(
+            "VAULT_REPLICA storage configuration is invalid."
+        ) from exc
+
+    if (
+        not settings.use_tls
+        or not settings.verify_tls
+    ):
+        raise VaultProviderLossDrillError(
+            "Replica recovery access requires TLS verification."
+        )
+
+    return settings
+
+
+def _replica_domain_from_environment() -> RecoveryDomain:
+    return RecoveryDomain(
+        provider_id=_env_required(
+            "VAULT_REPLICA_PROVIDER_ID"
+        ),
+        failure_domain=_env_required(
+            "VAULT_REPLICA_FAILURE_DOMAIN"
+        ),
+    )
+
+
+def assert_primary_provider_not_configured(
+    environment: Mapping[str, str] | None = None,
+) -> None:
+    source = (
+        os.environ
+        if environment is None
+        else environment
+    )
+
+    configured = sorted(
+        name
+        for name, value in source.items()
+        if (
+            name.startswith(
+                _PRIMARY_ENV_PREFIX
+            )
+            and str(value).strip()
+        )
+    )
+
+    if configured:
+        raise VaultProviderLossDrillError(
+            "Primary Vault configuration is present during "
+            "provider-loss mode."
+        )
+
+
+def _verify_json_artifact(
+    *,
+    storage: ObjectStorageClient,
+    key: str,
+    version_id: str | None,
+    expected_sha256: str,
+    artifact_kind: str,
+) -> tuple[
+    dict[str, Any],
+    str,
+    str | None,
+]:
+    canonical_key = _canonical_key(
+        key,
+        label=f"{artifact_kind} key",
+    )
+    expected_digest = _sha256(
+        expected_sha256,
+        label=f"{artifact_kind} expected SHA-256",
+    )
+
+    try:
+        head = storage.head_object(
+            key=canonical_key,
+            version_id=version_id,
+        )
+    except ObjectStorageNotFoundError as exc:
+        raise VaultProviderLossDrillError(
+            f"{artifact_kind} is missing."
+        ) from exc
+    except ObjectStorageError as exc:
+        raise VaultProviderLossDrillError(
+            f"{artifact_kind} HEAD verification failed."
+        ) from exc
+
+    if (
+        version_id is not None
+        and head.version_id != version_id
+    ):
+        raise VaultProviderLossDrillError(
+            f"{artifact_kind} version binding failed."
+        )
+
+    if (
+        head.content_type is None
+        or _canonical_content_type(
+            head.content_type
+        )
+        != "application/json"
+    ):
+        raise VaultProviderLossDrillError(
+            f"{artifact_kind} content type is invalid."
+        )
+
+    metadata_digest = str(
+        head.metadata.get(
+            "sha256",
+            "",
+        )
+    ).strip().lower()
+
+    if metadata_digest != expected_digest:
+        raise VaultProviderLossDrillError(
+            f"{artifact_kind} metadata SHA-256 binding failed."
+        )
+
+    digest = hashlib.sha256()
+    body = bytearray()
+    total = 0
+
+    try:
+        with storage.get_object_stream(
+            key=canonical_key,
+            version_id=version_id,
+        ) as stream:
+            if (
+                version_id is not None
+                and stream.head.version_id
+                != version_id
+            ):
+                raise VaultProviderLossDrillError(
+                    f"{artifact_kind} stream version binding failed."
+                )
+
+            if (
+                stream.head.content_type is None
+                or _canonical_content_type(
+                    stream.head.content_type
+                )
+                != "application/json"
+            ):
+                raise VaultProviderLossDrillError(
+                    f"{artifact_kind} stream content type is invalid."
+                )
+
+            while True:
+                chunk = stream.read(
+                    1024 * 1024
+                )
+
+                if not chunk:
+                    break
+
+                total += len(chunk)
+                digest.update(chunk)
+                body.extend(chunk)
+
+    except VaultProviderLossDrillError:
+        raise
+    except ObjectStorageError as exc:
+        raise VaultProviderLossDrillError(
+            f"{artifact_kind} full read failed."
+        ) from exc
+
+    observed_digest = (
+        digest.hexdigest()
+    )
+
+    if observed_digest != expected_digest:
+        raise VaultProviderLossDrillError(
+            f"{artifact_kind} full SHA-256 verification failed."
+        )
+
+    if head.size_bytes != total:
+        raise VaultProviderLossDrillError(
+            f"{artifact_kind} size verification failed."
+        )
+
+    try:
+        payload = json.loads(
+            bytes(body).decode(
+                "utf-8"
+            )
+        )
+    except (
+        UnicodeDecodeError,
+        json.JSONDecodeError,
+    ) as exc:
+        raise VaultProviderLossDrillError(
+            f"{artifact_kind} JSON is invalid."
+        ) from exc
+
+    if not isinstance(
+        payload,
+        dict,
+    ):
+        raise VaultProviderLossDrillError(
+            f"{artifact_kind} must contain a JSON object."
+        )
+
+    return (
+        payload,
+        observed_digest,
+        head.version_id,
+    )
+
+
+def _validate_complete_marker(
+    *,
+    payload: dict[str, Any],
+    complete_key: str,
+    expected_snapshot_id: str,
+    expected_source_label: str,
+    expected_release_commit: str,
+    expected_alembic_revision: str,
+    replica_settings: StorageSettings,
+    replica_domain: RecoveryDomain,
+) -> dict[str, Any]:
+    if (
+        payload.get(
+            "format_version"
+        )
+        != COMPLETE_FORMAT_VERSION
+    ):
+        raise VaultProviderLossDrillError(
+            "Complete marker format version is invalid."
+        )
+
+    snapshot = _snapshot_id(
+        payload.get(
+            "snapshot_id"
+        )
+    )
+
+    expected_snapshot = _snapshot_id(
+        expected_snapshot_id
+    )
+
+    if snapshot != expected_snapshot:
+        raise VaultProviderLossDrillError(
+            "Complete marker snapshot binding failed."
+        )
+
+    source_label = _nonempty(
+        payload.get(
+            "source_label"
+        ),
+        label="complete source_label",
+    )
+
+    if source_label != _nonempty(
+        expected_source_label,
+        label="expected source_label",
+    ):
+        raise VaultProviderLossDrillError(
+            "Complete marker source-label binding failed."
+        )
+
+    release_commit = _release_commit(
+        payload.get(
+            "release_commit"
+        )
+    )
+
+    if release_commit != _release_commit(
+        expected_release_commit
+    ):
+        raise VaultProviderLossDrillError(
+            "Complete marker release binding failed."
+        )
+
+    alembic_revision = _nonempty(
+        payload.get(
+            "alembic_revision"
+        ),
+        label="complete alembic_revision",
+    )
+
+    if alembic_revision != _nonempty(
+        expected_alembic_revision,
+        label="expected alembic_revision",
+    ):
+        raise VaultProviderLossDrillError(
+            "Complete marker Alembic binding failed."
+        )
+
+    source_identity = _sha256(
+        payload.get(
+            "source_identity_sha256"
+        ),
+        label="complete source_identity_sha256",
+    )
+
+    expected_provider = _domain_value(
+        replica_domain.provider_id,
+        label="configured replica provider_id",
+    )
+    expected_failure = _domain_value(
+        replica_domain.failure_domain,
+        label="configured replica failure_domain",
+    )
+
+    if (
+        _domain_value(
+            payload.get(
+                "replica_provider_id"
+            ),
+            label="complete replica_provider_id",
+        )
+        != expected_provider
+    ):
+        raise VaultProviderLossDrillError(
+            "Complete marker replica-provider binding failed."
+        )
+
+    if (
+        _domain_value(
+            payload.get(
+                "replica_failure_domain"
+            ),
+            label="complete replica_failure_domain",
+        )
+        != expected_failure
+    ):
+        raise VaultProviderLossDrillError(
+            "Complete marker replica failure-domain binding failed."
+        )
+
+    prefix = (
+        replica_settings.normalized_key_prefix
+    )
+
+    canonical_complete_key = (
+        _canonical_key(
+            complete_key,
+            label="complete key",
+        )
+    )
+
+    expected_complete_key = (
+        f"{prefix}/snapshots/"
+        f"{snapshot}/complete.json"
+    )
+
+    if (
+        canonical_complete_key
+        != expected_complete_key
+    ):
+        raise VaultProviderLossDrillError(
+            "Complete marker key is outside the bound snapshot."
+        )
+
+    manifest_key = _canonical_key(
+        payload.get(
+            "manifest_key"
+        ),
+        label="manifest_key",
+    )
+
+    expected_manifest_key = (
+        f"{prefix}/snapshots/"
+        f"{snapshot}/manifest.json"
+    )
+
+    if (
+        manifest_key
+        != expected_manifest_key
+    ):
+        raise VaultProviderLossDrillError(
+            "Manifest key is outside the bound snapshot."
+        )
+
+    manifest_sha256 = _sha256(
+        payload.get(
+            "manifest_sha256"
+        ),
+        label="manifest_sha256",
+    )
+
+    manifest_version_id = (
+        _optional_string(
+            payload.get(
+                "manifest_version_id"
+            )
+        )
+    )
+
+    document_count = _nonnegative_int(
+        payload.get(
+            "document_count"
+        ),
+        label="document_count",
+    )
+
+    replicated_count = _nonnegative_int(
+        payload.get(
+            "replicated_document_count"
+        ),
+        label="replicated_document_count",
+    )
+
+    state_only_count = _nonnegative_int(
+        payload.get(
+            "state_only_document_count"
+        ),
+        label="state_only_document_count",
+    )
+
+    replica_object_count = (
+        _nonnegative_int(
+            payload.get(
+                "replica_object_count"
+            ),
+            label="replica_object_count",
+        )
+    )
+
+    if (
+        document_count
+        != replicated_count
+        + state_only_count
+    ):
+        raise VaultProviderLossDrillError(
+            "Complete marker document counts are inconsistent."
+        )
+
+    if replicated_count == 0:
+        if replica_object_count != 0:
+            raise VaultProviderLossDrillError(
+                "Complete marker replica object count is inconsistent."
+            )
+    elif not (
+        1
+        <= replica_object_count
+        <= replicated_count
+    ):
+        raise VaultProviderLossDrillError(
+            "Complete marker replica object count is inconsistent."
+        )
+
+    return {
+        "snapshot_id": snapshot,
+        "source_label": source_label,
+        "release_commit": release_commit,
+        "source_identity_sha256": (
+            source_identity
+        ),
+        "alembic_revision": (
+            alembic_revision
+        ),
+        "manifest_key": manifest_key,
+        "manifest_sha256": (
+            manifest_sha256
+        ),
+        "manifest_version_id": (
+            manifest_version_id
+        ),
+        "document_count": (
+            document_count
+        ),
+        "replicated_document_count": (
+            replicated_count
+        ),
+        "state_only_document_count": (
+            state_only_count
+        ),
+        "replica_object_count": (
+            replica_object_count
+        ),
+    }
+
+
+def _validate_document_entry(
+    *,
+    raw: dict[str, Any],
+    primary_bucket: str,
+    primary_key_prefix: str,
+    replica_key_prefix: str,
+) -> DrillDocument:
+    organization_id = _positive_int(
+        raw.get(
+            "organization_id"
+        ),
+        label="document organization_id",
+    )
+
+    public_id = _uuid(
+        raw.get(
+            "public_id"
+        ),
+        label="document public_id",
+    )
+
+    status = _nonempty(
+        raw.get(
+            "status"
+        ),
+        label="document status",
+    )
+
+    if status not in _KNOWN_STATUSES:
+        raise VaultProviderLossDrillError(
+            "Manifest contains an unsupported Vault lifecycle state."
+        )
+
+    storage_backend = _nonempty(
+        raw.get(
+            "storage_backend"
+        ),
+        label="document storage_backend",
+    ).lower()
+
+    if storage_backend != "s3":
+        raise VaultProviderLossDrillError(
+            "Manifest source storage backend is unsupported."
+        )
+
+    storage_bucket = _nonempty(
+        raw.get(
+            "storage_bucket"
+        ),
+        label="document storage_bucket",
+    )
+
+    if storage_bucket != primary_bucket:
+        raise VaultProviderLossDrillError(
+            "Manifest document storage bucket does not match "
+            "bound primary storage."
+        )
+
+    object_key = _canonical_key(
+        raw.get(
+            "object_key"
+        ),
+        label="document object_key",
+    )
+
+    source_prefix = (
+        f"{primary_key_prefix}/tenants/"
+        f"{organization_id}/objects/"
+    )
+
+    if not object_key.startswith(
+        source_prefix
+    ):
+        raise VaultProviderLossDrillError(
+            "Manifest source object violates tenant binding."
+        )
+
+    storage_version_id = (
+        _optional_string(
+            raw.get(
+                "storage_version_id"
+            )
+        )
+    )
+
+    size_bytes = _positive_int(
+        raw.get(
+            "size_bytes"
+        ),
+        label="document size_bytes",
+    )
+
+    content_type = (
+        _canonical_content_type(
+            raw.get(
+                "content_type"
+            )
+        )
+    )
+
+    digest = _sha256(
+        raw.get(
+            "sha256"
+        ),
+        label="document sha256",
+    )
+
+    recovery_eligible = raw.get(
+        "recovery_eligible"
+    )
+
+    if not isinstance(
+        recovery_eligible,
+        bool,
+    ):
+        raise VaultProviderLossDrillError(
+            "Manifest recovery_eligible must be boolean."
+        )
+
+    replica_state = _nonempty(
+        raw.get(
+            "replica_state"
+        ),
+        label="document replica_state",
+    )
+
+    replica_key = _optional_string(
+        raw.get(
+            "replica_key"
+        )
+    )
+
+    replica_version_id = (
+        _optional_string(
+            raw.get(
+                "replica_version_id"
+            )
+        )
+    )
+
+    source_exact_verified = raw.get(
+        "source_exact_version_verified"
+    )
+
+    if not isinstance(
+        source_exact_verified,
+        bool,
+    ):
+        raise VaultProviderLossDrillError(
+            "Manifest source_exact_version_verified must be boolean."
+        )
+
+    if status == "available":
+        if not recovery_eligible:
+            raise VaultProviderLossDrillError(
+                "Available document is not marked recovery eligible."
+            )
+
+        if (
+            replica_state
+            not in _RECOVERABLE_REPLICA_STATES
+        ):
+            raise VaultProviderLossDrillError(
+                "Available document has an invalid replica state."
+            )
+
+        if replica_key is None:
+            raise VaultProviderLossDrillError(
+                "Available document is missing replica key."
+            )
+
+        canonical_replica_key = (
+            _canonical_key(
+                replica_key,
+                label="document replica_key",
+            )
+        )
+
+        expected_replica_key = (
+            f"{replica_key_prefix}/tenants/"
+            f"{organization_id}/objects/sha256/"
+            f"{digest[:2]}/{digest}"
+        )
+
+        if (
+            canonical_replica_key
+            != expected_replica_key
+        ):
+            raise VaultProviderLossDrillError(
+                "Replica object violates tenant/content-address binding."
+            )
+
+        if (
+            source_exact_verified
+            != (
+                storage_version_id
+                is not None
+            )
+        ):
+            raise VaultProviderLossDrillError(
+                "Manifest source exact-version state is inconsistent."
+            )
+
+        replica_key = (
+            canonical_replica_key
+        )
+
+    else:
+        if recovery_eligible:
+            raise VaultProviderLossDrillError(
+                "Non-available document must not be recovery eligible."
+            )
+
+        if (
+            replica_state
+            != "state_only_not_auto_recoverable"
+        ):
+            raise VaultProviderLossDrillError(
+                "Non-available lifecycle state is inconsistent."
+            )
+
+        if (
+            replica_key is not None
+            or replica_version_id
+            is not None
+        ):
+            raise VaultProviderLossDrillError(
+                "Non-available document unexpectedly references recovery bytes."
+            )
+
+        if source_exact_verified:
+            raise VaultProviderLossDrillError(
+                "Non-available document has invalid exact-version state."
+            )
+
+    return DrillDocument(
+        organization_id=(
+            organization_id
+        ),
+        public_id=public_id,
+        status=status,
+        storage_backend=(
+            storage_backend
+        ),
+        storage_bucket=(
+            storage_bucket
+        ),
+        object_key=object_key,
+        storage_version_id=(
+            storage_version_id
+        ),
+        size_bytes=size_bytes,
+        content_type=content_type,
+        sha256=digest,
+        recovery_eligible=(
+            recovery_eligible
+        ),
+        replica_state=replica_state,
+        replica_key=replica_key,
+        replica_version_id=(
+            replica_version_id
+        ),
+        source_exact_version_verified=(
+            source_exact_verified
+        ),
+    )
+
+
+def _validate_manifest(
+    *,
+    payload: dict[str, Any],
+    complete: dict[str, Any],
+    replica_settings: StorageSettings,
+    replica_domain: RecoveryDomain,
+) -> ValidatedSnapshot:
+    if (
+        payload.get(
+            "format_version"
+        )
+        != MANIFEST_FORMAT_VERSION
+    ):
+        raise VaultProviderLossDrillError(
+            "Manifest format version is invalid."
+        )
+
+    if (
+        _snapshot_id(
+            payload.get(
+                "snapshot_id"
+            )
+        )
+        != complete["snapshot_id"]
+    ):
+        raise VaultProviderLossDrillError(
+            "Manifest snapshot binding failed."
+        )
+
+    if (
+        _nonempty(
+            payload.get(
+                "source_label"
+            ),
+            label="manifest source_label",
+        )
+        != complete["source_label"]
+    ):
+        raise VaultProviderLossDrillError(
+            "Manifest source-label binding failed."
+        )
+
+    if (
+        _release_commit(
+            payload.get(
+                "release_commit"
+            )
+        )
+        != complete["release_commit"]
+    ):
+        raise VaultProviderLossDrillError(
+            "Manifest release binding failed."
+        )
+
+    source_database = payload.get(
+        "source_database"
+    )
+
+    if not isinstance(
+        source_database,
+        dict,
+    ):
+        raise VaultProviderLossDrillError(
+            "Manifest source_database is invalid."
+        )
+
+    if (
+        _sha256(
+            source_database.get(
+                "source_identity_sha256"
+            ),
+            label="manifest source identity",
+        )
+        != complete[
+            "source_identity_sha256"
+        ]
+    ):
+        raise VaultProviderLossDrillError(
+            "Manifest source-identity binding failed."
+        )
+
+    if (
+        _nonempty(
+            source_database.get(
+                "alembic_revision"
+            ),
+            label="manifest alembic_revision",
+        )
+        != complete[
+            "alembic_revision"
+        ]
+    ):
+        raise VaultProviderLossDrillError(
+            "Manifest Alembic binding failed."
+        )
+
+    primary_storage = payload.get(
+        "primary_storage"
+    )
+    replica_storage = payload.get(
+        "replica_storage"
+    )
+
+    if not isinstance(
+        primary_storage,
+        dict,
+    ) or not isinstance(
+        replica_storage,
+        dict,
+    ):
+        raise VaultProviderLossDrillError(
+            "Manifest storage-domain metadata is invalid."
+        )
+
+    primary_provider = _domain_value(
+        primary_storage.get(
+            "provider_id"
+        ),
+        label="manifest primary provider_id",
+    )
+    primary_failure = _domain_value(
+        primary_storage.get(
+            "failure_domain"
+        ),
+        label="manifest primary failure_domain",
+    )
+
+    replica_provider = _domain_value(
+        replica_storage.get(
+            "provider_id"
+        ),
+        label="manifest replica provider_id",
+    )
+    replica_failure = _domain_value(
+        replica_storage.get(
+            "failure_domain"
+        ),
+        label="manifest replica failure_domain",
+    )
+
+    if (
+        primary_provider
+        == replica_provider
+    ):
+        raise VaultProviderLossDrillError(
+            "Manifest does not represent an independent storage provider."
+        )
+
+    if (
+        primary_failure
+        == replica_failure
+    ):
+        raise VaultProviderLossDrillError(
+            "Manifest does not represent an independent failure domain."
+        )
+
+    configured_provider = (
+        _domain_value(
+            replica_domain.provider_id,
+            label="configured replica provider_id",
+        )
+    )
+    configured_failure = (
+        _domain_value(
+            replica_domain.failure_domain,
+            label="configured replica failure_domain",
+        )
+    )
+
+    if (
+        replica_provider
+        != configured_provider
+        or replica_failure
+        != configured_failure
+    ):
+        raise VaultProviderLossDrillError(
+            "Manifest replica-domain binding failed."
+        )
+
+    primary_bucket = _nonempty(
+        primary_storage.get(
+            "bucket_name"
+        ),
+        label="manifest primary bucket",
+    )
+
+    configured_bucket = _nonempty(
+        replica_settings.bucket_name,
+        label="configured replica bucket",
+    )
+
+    manifest_bucket = _nonempty(
+        replica_storage.get(
+            "bucket_name"
+        ),
+        label="manifest replica bucket",
+    )
+
+    if manifest_bucket != configured_bucket:
+        raise VaultProviderLossDrillError(
+            "Manifest replica-bucket binding failed."
+        )
+
+    replica_prefix = (
+        replica_settings.normalized_key_prefix
+    )
+
+    if (
+        _nonempty(
+            replica_storage.get(
+                "key_prefix"
+            ),
+            label="manifest replica key_prefix",
+        )
+        != replica_prefix
+    ):
+        raise VaultProviderLossDrillError(
+            "Manifest replica-prefix binding failed."
+        )
+
+    primary_prefix = _nonempty(
+        primary_storage.get(
+            "key_prefix"
+        ),
+        label="manifest primary key_prefix",
+    ).strip("/")
+
+    document_count = _nonnegative_int(
+        payload.get(
+            "document_count"
+        ),
+        label="manifest document_count",
+    )
+
+    replicated_count = _nonnegative_int(
+        payload.get(
+            "replicated_document_count"
+        ),
+        label="manifest replicated_document_count",
+    )
+
+    state_only_count = _nonnegative_int(
+        payload.get(
+            "state_only_document_count"
+        ),
+        label="manifest state_only_document_count",
+    )
+
+    replica_object_count = (
+        _nonnegative_int(
+            payload.get(
+                "replica_object_count"
+            ),
+            label="manifest replica_object_count",
+        )
+    )
+
+    for key, observed in (
+        (
+            "document_count",
+            document_count,
+        ),
+        (
+            "replicated_document_count",
+            replicated_count,
+        ),
+        (
+            "state_only_document_count",
+            state_only_count,
+        ),
+        (
+            "replica_object_count",
+            replica_object_count,
+        ),
+    ):
+        if observed != complete[key]:
+            raise VaultProviderLossDrillError(
+                f"Manifest {key} does not match complete marker."
+            )
+
+    raw_documents = payload.get(
+        "documents"
+    )
+
+    if not isinstance(
+        raw_documents,
+        list,
+    ):
+        raise VaultProviderLossDrillError(
+            "Manifest documents collection is invalid."
+        )
+
+    if len(
+        raw_documents
+    ) != document_count:
+        raise VaultProviderLossDrillError(
+            "Manifest document count does not match collection."
+        )
+
+    documents: list[
+        DrillDocument
+    ] = []
+    public_ids: set[str] = set()
+    available_count = 0
+    state_count = 0
+    replica_keys: set[str] = set()
+
+    for raw_document in raw_documents:
+        if not isinstance(
+            raw_document,
+            dict,
+        ):
+            raise VaultProviderLossDrillError(
+                "Manifest document entry is invalid."
+            )
+
+        document = (
+            _validate_document_entry(
+                raw=raw_document,
+                primary_bucket=(
+                    primary_bucket
+                ),
+                primary_key_prefix=(
+                    primary_prefix
+                ),
+                replica_key_prefix=(
+                    replica_prefix
+                ),
+            )
+        )
+
+        if document.public_id in public_ids:
+            raise VaultProviderLossDrillError(
+                "Manifest contains duplicate public document binding."
+            )
+
+        public_ids.add(
+            document.public_id
+        )
+
+        if document.status == "available":
+            available_count += 1
+
+            assert (
+                document.replica_key
+                is not None
+            )
+
+            replica_keys.add(
+                document.replica_key
+            )
+        else:
+            state_count += 1
+
+        documents.append(
+            document
+        )
+
+    if (
+        available_count
+        != replicated_count
+        or state_count
+        != state_only_count
+        or len(
+            replica_keys
+        )
+        != replica_object_count
+    ):
+        raise VaultProviderLossDrillError(
+            "Manifest lifecycle/replica counts are inconsistent."
+        )
+
+    return ValidatedSnapshot(
+        snapshot_id=complete[
+            "snapshot_id"
+        ],
+        source_label=complete[
+            "source_label"
+        ],
+        release_commit=complete[
+            "release_commit"
+        ],
+        source_identity_sha256=complete[
+            "source_identity_sha256"
+        ],
+        alembic_revision=complete[
+            "alembic_revision"
+        ],
+        document_count=(
+            document_count
+        ),
+        replicated_document_count=(
+            replicated_count
+        ),
+        state_only_document_count=(
+            state_only_count
+        ),
+        replica_object_count=(
+            replica_object_count
+        ),
+        manifest_key=complete[
+            "manifest_key"
+        ],
+        manifest_sha256=complete[
+            "manifest_sha256"
+        ],
+        documents=tuple(
+            documents
+        ),
+    )
+
+
+def _verify_replica_payload_to_file(
+    *,
+    storage: ObjectStorageClient,
+    document: DrillDocument,
+    destination: Path,
+) -> int:
+    if (
+        not document.recovery_eligible
+        or document.replica_key is None
+    ):
+        raise VaultProviderLossDrillError(
+            "Attempted byte recovery for a non-recoverable document."
+        )
+
+    try:
+        head = storage.head_object(
+            key=document.replica_key,
+            version_id=(
+                document.replica_version_id
+            ),
+        )
+    except ObjectStorageNotFoundError as exc:
+        raise VaultProviderLossDrillError(
+            "Replica recovery payload is missing."
+        ) from exc
+    except ObjectStorageError as exc:
+        raise VaultProviderLossDrillError(
+            "Replica recovery payload HEAD failed."
+        ) from exc
+
+    if (
+        document.replica_version_id
+        is not None
+        and head.version_id
+        != document.replica_version_id
+    ):
+        raise VaultProviderLossDrillError(
+            "Replica payload version binding failed."
+        )
+
+    if head.size_bytes != document.size_bytes:
+        raise VaultProviderLossDrillError(
+            "Replica payload size binding failed."
+        )
+
+    if (
+        head.content_type is None
+        or _canonical_content_type(
+            head.content_type
+        )
+        != document.content_type
+    ):
+        raise VaultProviderLossDrillError(
+            "Replica payload content-type binding failed."
+        )
+
+    metadata_sha = str(
+        head.metadata.get(
+            "sha256",
+            "",
+        )
+    ).strip().lower()
+
+    if metadata_sha != document.sha256:
+        raise VaultProviderLossDrillError(
+            "Replica payload SHA-256 metadata binding failed."
+        )
+
+    metadata_org = str(
+        head.metadata.get(
+            "organization-id",
+            "",
+        )
+    ).strip()
+
+    if metadata_org != str(
+        document.organization_id
+    ):
+        raise VaultProviderLossDrillError(
+            "Replica payload tenant metadata binding failed."
+        )
+
+    destination.parent.mkdir(
+        parents=True,
+        exist_ok=False,
+    )
+
+    digest = hashlib.sha256()
+    total = 0
+
+    try:
+        with storage.get_object_stream(
+            key=document.replica_key,
+            version_id=(
+                document.replica_version_id
+            ),
+        ) as stream:
+            if (
+                document.replica_version_id
+                is not None
+                and stream.head.version_id
+                != document.replica_version_id
+            ):
+                raise VaultProviderLossDrillError(
+                    "Replica payload stream version binding failed."
+                )
+
+            if (
+                stream.head.content_type
+                is None
+                or _canonical_content_type(
+                    stream.head.content_type
+                )
+                != document.content_type
+            ):
+                raise VaultProviderLossDrillError(
+                    "Replica payload stream content-type binding failed."
+                )
+
+            with destination.open(
+                "xb"
+            ) as output:
+                while True:
+                    chunk = stream.read(
+                        1024 * 1024
+                    )
+
+                    if not chunk:
+                        break
+
+                    total += len(chunk)
+                    digest.update(chunk)
+                    output.write(chunk)
+
+    except VaultProviderLossDrillError:
+        destination.unlink(
+            missing_ok=True
+        )
+        raise
+    except ObjectStorageError as exc:
+        destination.unlink(
+            missing_ok=True
+        )
+        raise VaultProviderLossDrillError(
+            "Replica payload full recovery failed."
+        ) from exc
+    except OSError as exc:
+        destination.unlink(
+            missing_ok=True
+        )
+        raise VaultProviderLossDrillError(
+            "Isolated recovery-target write failed."
+        ) from exc
+
+    if total != document.size_bytes:
+        destination.unlink(
+            missing_ok=True
+        )
+        raise VaultProviderLossDrillError(
+            "Recovered byte count does not match manifest."
+        )
+
+    if (
+        digest.hexdigest()
+        != document.sha256
+    ):
+        destination.unlink(
+            missing_ok=True
+        )
+        raise VaultProviderLossDrillError(
+            "Recovered payload full SHA-256 verification failed."
+        )
+
+    return total
+
+
+def _validate_application_compatibility(
+    *,
+    document: DrillDocument,
+    payload_path: Path,
+) -> None:
+    extension = _CONTENT_TYPE_EXTENSION.get(
+        document.content_type
+    )
+
+    if extension is None:
+        raise VaultProviderLossDrillError(
+            "Recovered payload uses a content type unsupported by the Vault runtime."
+        )
+
+    try:
+        payload = payload_path.read_bytes()
+    except OSError as exc:
+        raise VaultProviderLossDrillError(
+            "Recovered payload cannot be reopened for application validation."
+        ) from exc
+
+    try:
+        validation_settings = (
+            StorageSettings(
+                max_upload_bytes=(
+                    document.size_bytes
+                ),
+                allowed_content_types=(
+                    document.content_type,
+                ),
+            )
+        )
+
+        validated = validate_vault_upload(
+            filename=(
+                f"{document.public_id}"
+                f"{extension}"
+            ),
+            document_type=(
+                "OTHER_EVIDENCE"
+            ),
+            content_type=(
+                document.content_type
+            ),
+            content=payload,
+            settings=(
+                validation_settings
+            ),
+        )
+    except (
+        VaultValidationError,
+        ValueError,
+    ) as exc:
+        raise VaultProviderLossDrillError(
+            "Recovered bytes are not application-compatible Vault evidence."
+        ) from exc
+
+    if (
+        validated.size_bytes
+        != document.size_bytes
+        or validated.sha256
+        != document.sha256
+        or validated.content_type
+        != document.content_type
+    ):
+        raise VaultProviderLossDrillError(
+            "Application validation changed the recovered evidence identity."
+        )
+
+
+def _metadata_for_document(
+    *,
+    document: DrillDocument,
+    payload_relative_path: str | None,
+) -> dict[str, Any]:
+    return {
+        "organization_id": (
+            document.organization_id
+        ),
+        "public_id": (
+            document.public_id
+        ),
+        "status": (
+            document.status
+        ),
+        "storage_backend": (
+            document.storage_backend
+        ),
+        "storage_bucket": (
+            document.storage_bucket
+        ),
+        "object_key": (
+            document.object_key
+        ),
+        "storage_version_id": (
+            document.storage_version_id
+        ),
+        "size_bytes": (
+            document.size_bytes
+        ),
+        "content_type": (
+            document.content_type
+        ),
+        "sha256": (
+            document.sha256
+        ),
+        "recovery_eligible": (
+            document.recovery_eligible
+        ),
+        "replica_state": (
+            document.replica_state
+        ),
+        "replica_key": (
+            document.replica_key
+        ),
+        "replica_version_id": (
+            document.replica_version_id
+        ),
+        "payload_relative_path": (
+            payload_relative_path
+        ),
+    }
+
+
+def _write_json_file(
+    path: Path,
+    payload: dict[str, Any],
+) -> str:
+    body = _canonical_json_bytes(
+        payload
+    )
+
+    path.write_bytes(
+        body
+    )
+
+    return hashlib.sha256(
+        body
+    ).hexdigest()
+
+
+def run_provider_loss_drill(
+    *,
+    replica_storage: ObjectStorageClient,
+    replica_settings: StorageSettings,
+    replica_domain: RecoveryDomain,
+    complete_key: str,
+    complete_version_id: str | None,
+    expected_complete_sha256: str,
+    expected_snapshot_id: str,
+    expected_source_label: str,
+    expected_release_commit: str,
+    expected_alembic_revision: str,
+    output_directory: Path,
+    operator: str,
+) -> dict[str, Any]:
+    started = time.perf_counter()
+
+    final_output = (
+        output_directory.resolve()
+    )
+
+    if final_output.exists():
+        raise VaultProviderLossDrillError(
+            "Isolated recovery target already exists."
+        )
+
+    final_output.parent.mkdir(
+        parents=True,
+        exist_ok=True,
+    )
+
+    partial_output = (
+        final_output.parent
+        / (
+            f".{final_output.name}."
+            f"partial-{uuid4().hex}"
+        )
+    )
+
+    complete_sha = _sha256(
+        expected_complete_sha256,
+        label="expected complete SHA-256",
+    )
+
+    complete_payload, observed_complete_sha, _ = (
+        _verify_json_artifact(
+            storage=replica_storage,
+            key=complete_key,
+            version_id=(
+                complete_version_id
+            ),
+            expected_sha256=(
+                complete_sha
+            ),
+            artifact_kind=(
+                "complete marker"
+            ),
+        )
+    )
+
+    complete = (
+        _validate_complete_marker(
+            payload=complete_payload,
+            complete_key=complete_key,
+            expected_snapshot_id=(
+                expected_snapshot_id
+            ),
+            expected_source_label=(
+                expected_source_label
+            ),
+            expected_release_commit=(
+                expected_release_commit
+            ),
+            expected_alembic_revision=(
+                expected_alembic_revision
+            ),
+            replica_settings=(
+                replica_settings
+            ),
+            replica_domain=(
+                replica_domain
+            ),
+        )
+    )
+
+    manifest_payload, observed_manifest_sha, _ = (
+        _verify_json_artifact(
+            storage=replica_storage,
+            key=complete[
+                "manifest_key"
+            ],
+            version_id=complete[
+                "manifest_version_id"
+            ],
+            expected_sha256=complete[
+                "manifest_sha256"
+            ],
+            artifact_kind=(
+                "recovery manifest"
+            ),
+        )
+    )
+
+    snapshot = _validate_manifest(
+        payload=manifest_payload,
+        complete=complete,
+        replica_settings=(
+            replica_settings
+        ),
+        replica_domain=(
+            replica_domain
+        ),
+    )
+
+    if (
+        snapshot.replicated_document_count <= 0
+        or snapshot.replica_object_count <= 0
+    ):
+        raise VaultProviderLossDrillError(
+            "Provider-loss drill requires at least one "
+            "recovery-eligible Vault object."
+        )
+
+    recovered_count = 0
+    state_only_count = 0
+    recovered_bytes = 0
+    index_documents: list[
+        dict[str, Any]
+    ] = []
+
+    try:
+        partial_output.mkdir(
+            parents=False,
+            exist_ok=False,
+        )
+
+        for document in (
+            snapshot.documents
+        ):
+            document_directory = (
+                partial_output
+                / "tenants"
+                / str(
+                    document.organization_id
+                )
+                / "documents"
+                / document.public_id
+            )
+
+            payload_relative_path: (
+                str | None
+            ) = None
+
+            if document.status == "available":
+                extension = (
+                    _CONTENT_TYPE_EXTENSION.get(
+                        document.content_type
+                    )
+                )
+
+                if extension is None:
+                    raise VaultProviderLossDrillError(
+                        "Available recovery evidence has an unsupported Vault content type."
+                    )
+
+                payload_path = (
+                    document_directory
+                    / f"payload{extension}"
+                )
+
+                recovered_bytes += (
+                    _verify_replica_payload_to_file(
+                        storage=(
+                            replica_storage
+                        ),
+                        document=document,
+                        destination=(
+                            payload_path
+                        ),
+                    )
+                )
+
+                _validate_application_compatibility(
+                    document=document,
+                    payload_path=(
+                        payload_path
+                    ),
+                )
+
+                payload_relative_path = (
+                    payload_path.relative_to(
+                        partial_output
+                    ).as_posix()
+                )
+
+                recovered_count += 1
+
+            else:
+                document_directory.mkdir(
+                    parents=True,
+                    exist_ok=False,
+                )
+                state_only_count += 1
+
+            metadata = (
+                _metadata_for_document(
+                    document=document,
+                    payload_relative_path=(
+                        payload_relative_path
+                    ),
+                )
+            )
+
+            _write_json_file(
+                document_directory
+                / "metadata.json",
+                metadata,
+            )
+
+            index_documents.append(
+                metadata
+            )
+
+        if (
+            recovered_count
+            != snapshot.replicated_document_count
+            or state_only_count
+            != snapshot.state_only_document_count
+        ):
+            raise VaultProviderLossDrillError(
+                "Recovered lifecycle counts do not match bound snapshot."
+            )
+
+        elapsed_seconds = round(
+            time.perf_counter()
+            - started,
+            6,
+        )
+
+        index_payload = {
+            "format_version": (
+                INDEX_FORMAT_VERSION
+            ),
+            "result": "PASS",
+            "provider_loss_mode": (
+                "primary_unavailable"
+            ),
+            "primary_access_attempted": (
+                False
+            ),
+            "replica_read_only": True,
+            "production_modified": False,
+            "operator": _nonempty(
+                operator,
+                label="operator",
+            ),
+            "snapshot_id": (
+                snapshot.snapshot_id
+            ),
+            "source_label": (
+                snapshot.source_label
+            ),
+            "release_commit": (
+                snapshot.release_commit
+            ),
+            "source_identity_sha256": (
+                snapshot.source_identity_sha256
+            ),
+            "alembic_revision": (
+                snapshot.alembic_revision
+            ),
+            "complete_key": (
+                _canonical_key(
+                    complete_key,
+                    label="complete key",
+                )
+            ),
+            "complete_sha256": (
+                observed_complete_sha
+            ),
+            "manifest_key": (
+                snapshot.manifest_key
+            ),
+            "manifest_sha256": (
+                observed_manifest_sha
+            ),
+            "document_count": (
+                snapshot.document_count
+            ),
+            "recovered_document_count": (
+                recovered_count
+            ),
+            "state_only_document_count": (
+                state_only_count
+            ),
+            "replica_object_count": (
+                snapshot.replica_object_count
+            ),
+            "recovered_bytes": (
+                recovered_bytes
+            ),
+            "elapsed_seconds": (
+                elapsed_seconds
+            ),
+            "documents": (
+                index_documents
+            ),
+        }
+
+        index_sha256 = _write_json_file(
+            partial_output
+            / "recovery_index.json",
+            index_payload,
+        )
+
+        partial_output.replace(
+            final_output
+        )
+
+    except Exception:
+        shutil.rmtree(
+            partial_output,
+            ignore_errors=True,
+        )
+        raise
+
+    return {
+        "format_version": (
+            DRILL_FORMAT_VERSION
+        ),
+        "result": "PASS",
+        "verification_status": (
+            "PASS"
+        ),
+        "provider_loss_mode": (
+            "primary_unavailable"
+        ),
+        "primary_access_attempted": (
+            False
+        ),
+        "replica_read_only": True,
+        "production_modified": False,
+        "snapshot_id": (
+            snapshot.snapshot_id
+        ),
+        "source_label": (
+            snapshot.source_label
+        ),
+        "release_commit": (
+            snapshot.release_commit
+        ),
+        "source_identity_sha256": (
+            snapshot.source_identity_sha256
+        ),
+        "alembic_revision": (
+            snapshot.alembic_revision
+        ),
+        "complete_sha256": (
+            observed_complete_sha
+        ),
+        "manifest_sha256": (
+            observed_manifest_sha
+        ),
+        "document_count": (
+            snapshot.document_count
+        ),
+        "recovered_document_count": (
+            recovered_count
+        ),
+        "state_only_document_count": (
+            state_only_count
+        ),
+        "recovered_bytes": (
+            recovered_bytes
+        ),
+        "elapsed_seconds": (
+            elapsed_seconds
+        ),
+        "recovery_index_sha256": (
+            index_sha256
+        ),
+        "output_directory": str(
+            final_output
+        ),
+    }
+
+
+def build_argument_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Recover and verify a Vault snapshot "
+            "from the independent replica while "
+            "the primary provider is treated as unavailable."
+        )
+    )
+
+    parser.add_argument(
+        "--complete-key",
+        required=True,
+    )
+    parser.add_argument(
+        "--complete-version-id",
+        default=None,
+    )
+    parser.add_argument(
+        "--complete-sha256",
+        required=True,
+    )
+    parser.add_argument(
+        "--expected-snapshot-id",
+        required=True,
+    )
+    parser.add_argument(
+        "--expected-source-label",
+        required=True,
+    )
+    parser.add_argument(
+        "--expected-release-commit",
+        required=True,
+    )
+    parser.add_argument(
+        "--expected-alembic-revision",
+        required=True,
+    )
+    parser.add_argument(
+        "--output-dir",
+        required=True,
+    )
+    parser.add_argument(
+        "--operator",
+        required=True,
+    )
+    parser.add_argument(
+        "--primary-unavailable",
+        action="store_true",
+    )
+
+    return parser
+
+
+def main(
+    argv: list[str] | None = None,
+) -> int:
+    parser = (
+        build_argument_parser()
+    )
+    args = parser.parse_args(
+        argv
+    )
+
+    try:
+        if not args.primary_unavailable:
+            raise VaultProviderLossDrillError(
+                "--primary-unavailable is required for P2.7A6B."
+            )
+
+        assert_primary_provider_not_configured()
+
+        replica_settings = (
+            _replica_settings_from_environment()
+        )
+
+        replica_domain = (
+            _replica_domain_from_environment()
+        )
+
+        replica_storage = (
+            Boto3S3ObjectStorage(
+                replica_settings
+            )
+        )
+
+        if not replica_storage.health_check():
+            raise VaultProviderLossDrillError(
+                "Independent Vault replica readiness failed."
+            )
+
+        result = run_provider_loss_drill(
+            replica_storage=(
+                replica_storage
+            ),
+            replica_settings=(
+                replica_settings
+            ),
+            replica_domain=(
+                replica_domain
+            ),
+            complete_key=(
+                args.complete_key
+            ),
+            complete_version_id=(
+                args.complete_version_id
+            ),
+            expected_complete_sha256=(
+                args.complete_sha256
+            ),
+            expected_snapshot_id=(
+                args.expected_snapshot_id
+            ),
+            expected_source_label=(
+                args.expected_source_label
+            ),
+            expected_release_commit=(
+                args.expected_release_commit
+            ),
+            expected_alembic_revision=(
+                args.expected_alembic_revision
+            ),
+            output_directory=Path(
+                args.output_dir
+            ),
+            operator=args.operator,
+        )
+
+    except (
+        VaultProviderLossDrillError,
+        ObjectStorageError,
+    ) as exc:
+        print(
+            sanitize_cli_error_message(
+                str(exc)
+            ),
+            file=sys.stderr,
+        )
+        return 1
+    except Exception:
+        print(
+            "Vault provider-loss drill operational failure.",
+            file=sys.stderr,
+        )
+        return 1
+
+    print(
+        json.dumps(
+            result,
+            sort_keys=True,
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(
+        main()
+    )

--- a/tests/test_disaster_recovery_p27a_unittest.py
+++ b/tests/test_disaster_recovery_p27a_unittest.py
@@ -270,3 +270,46 @@ def test_p27a6_dr_runbook_does_not_claim_operational_provider_loss_pass():
         "P2.7A6 status:\n\nCLOSED"
         not in dr
     )
+
+
+def test_p27a6b_dr_runbook_defines_provider_loss_execution_contract():
+    dr = _dr_text()
+
+    for token in (
+        "P2.7A6B provider-loss recovery drill",
+        "P2.7A6B code status:",
+        "IMPLEMENTED - provider-loss recovery verifier/materializer is present and unit-tested.",
+        "--primary-unavailable",
+        "must not contain VAULT_PRIMARY_* configuration",
+        "Only VAULT_REPLICA_* read credentials are required.",
+        "complete.json SHA-256",
+        "manifest_version_id when present",
+        "hidden partial directory",
+        "atomically promoted",
+        "<target>/tenants/<organization_id>/documents/<public_id>/metadata.json",
+        "no payload is created",
+        "full streamed SHA-256",
+        "canonical Vault upload validator",
+        "The drill uses only HEAD/GET operations",
+        "PostgreSQL is not contacted.",
+        "production_modified: false",
+        "primary access attempted: NO",
+        "replica writes performed: NO",
+        "production modified: NO",
+    ):
+        assert token in dr
+
+
+def test_p27a6b_dr_runbook_does_not_claim_operational_provider_loss_closed():
+    dr = _dr_text()
+
+    assert (
+        "Operational provider-loss execution against a real "
+        "independent storage provider remains required"
+        in dr
+    )
+
+    assert (
+        "P2.7A6B is CLOSED"
+        not in dr
+    )

--- a/tests/test_vault_provider_loss_drill_p27a6_unittest.py
+++ b/tests/test_vault_provider_loss_drill_p27a6_unittest.py
@@ -1,0 +1,1470 @@
+from __future__ import annotations
+
+from copy import deepcopy
+import hashlib
+import io
+import json
+from pathlib import Path
+
+import pytest
+
+from litoral_trace.config.settings import (
+    StorageSettings,
+)
+from litoral_trace.storage import (
+    ObjectDeleteResult,
+    ObjectHead,
+    ObjectStorageNotFoundError,
+    ObjectStorageStream,
+    ObjectWriteResult,
+)
+from scripts.vault_provider_loss_drill import (
+    DRILL_FORMAT_VERSION,
+    VaultProviderLossDrillError,
+    assert_primary_provider_not_configured,
+    run_provider_loss_drill,
+)
+from scripts.vault_recovery_replica import (
+    COMPLETE_FORMAT_VERSION,
+    MANIFEST_FORMAT_VERSION,
+    RecoveryDomain,
+)
+
+
+SNAPSHOT_ID = "20260818T170000Z"
+RELEASE = (
+    "556ac5c7f49247b52862827fe3af912cc557c18b"
+)
+ALEMBIC = "018_add_batch_evidence_links"
+SOURCE_IDENTITY = "a" * 64
+
+REPLICA_PREFIX = (
+    "litoral-trace/vault-recovery"
+)
+REPLICA_BUCKET = (
+    "independent-vault-recovery"
+)
+
+PUBLIC_ID = (
+    "11111111-1111-4111-8111-111111111111"
+)
+
+STATE_PUBLIC_ID = (
+    "22222222-2222-4222-8222-222222222222"
+)
+
+PDF = (
+    b"%PDF-1.4\n"
+    b"1 0 obj\n"
+    b"<<>>\n"
+    b"endobj\n"
+    b"%%EOF\n"
+)
+
+
+class _StoredObject:
+    def __init__(
+        self,
+        *,
+        data: bytes,
+        content_type: str | None,
+        metadata: dict[str, str],
+        version_id: str | None,
+    ):
+        self.data = bytes(data)
+        self.content_type = (
+            content_type
+        )
+        self.metadata = dict(
+            metadata
+        )
+        self.version_id = (
+            version_id
+        )
+
+
+class ReadOnlyMemoryStorage:
+    def __init__(self):
+        self._objects: dict[
+            str,
+            _StoredObject,
+        ] = {}
+        self._versions: dict[
+            tuple[str, str],
+            _StoredObject,
+        ] = {}
+        self.reads: list[
+            tuple[str, str]
+        ] = []
+
+    def seed(
+        self,
+        *,
+        key: str,
+        data: bytes,
+        content_type: str | None,
+        metadata: dict[str, str],
+        version_id: str | None,
+    ) -> None:
+        stored = _StoredObject(
+            data=data,
+            content_type=(
+                content_type
+            ),
+            metadata=metadata,
+            version_id=(
+                version_id
+            ),
+        )
+
+        self._objects[
+            key
+        ] = stored
+
+        if version_id is not None:
+            self._versions[
+                (
+                    key,
+                    version_id,
+                )
+            ] = stored
+
+    def _resolve(
+        self,
+        *,
+        key: str,
+        version_id: str | None,
+    ) -> _StoredObject:
+        if version_id is None:
+            stored = (
+                self._objects.get(
+                    key
+                )
+            )
+        else:
+            stored = (
+                self._versions.get(
+                    (
+                        key,
+                        version_id,
+                    )
+                )
+            )
+
+        if stored is None:
+            raise ObjectStorageNotFoundError(
+                "memory"
+            )
+
+        return stored
+
+    def head_object(
+        self,
+        *,
+        key: str,
+        version_id: str | None = None,
+    ) -> ObjectHead:
+        stored = self._resolve(
+            key=key,
+            version_id=version_id,
+        )
+
+        self.reads.append(
+            ("head", key)
+        )
+
+        return ObjectHead(
+            size_bytes=len(
+                stored.data
+            ),
+            content_type=(
+                stored.content_type
+            ),
+            etag="etag",
+            version_id=(
+                stored.version_id
+            ),
+            metadata=(
+                stored.metadata
+            ),
+        )
+
+    def get_object_stream(
+        self,
+        *,
+        key: str,
+        version_id: str | None = None,
+    ) -> ObjectStorageStream:
+        stored = self._resolve(
+            key=key,
+            version_id=version_id,
+        )
+
+        self.reads.append(
+            ("get", key)
+        )
+
+        return ObjectStorageStream(
+            body=io.BytesIO(
+                stored.data
+            ),
+            head=ObjectHead(
+                size_bytes=len(
+                    stored.data
+                ),
+                content_type=(
+                    stored.content_type
+                ),
+                etag="etag",
+                version_id=(
+                    stored.version_id
+                ),
+                metadata=(
+                    stored.metadata
+                ),
+            ),
+        )
+
+    def put_object(
+        self,
+        *,
+        key: str,
+        body,
+        content_type: str,
+        content_length: int,
+        metadata=None,
+    ) -> ObjectWriteResult:
+        raise AssertionError(
+            "Provider-loss drill must never write to replica storage."
+        )
+
+    def delete_object(
+        self,
+        *,
+        key: str,
+        version_id: str | None = None,
+    ) -> ObjectDeleteResult:
+        raise AssertionError(
+            "Provider-loss drill must never delete replica objects."
+        )
+
+    def object_exists(
+        self,
+        *,
+        key: str,
+        version_id: str | None = None,
+    ) -> bool:
+        try:
+            self._resolve(
+                key=key,
+                version_id=version_id,
+            )
+        except ObjectStorageNotFoundError:
+            return False
+
+        return True
+
+    def health_check(
+        self,
+    ) -> bool:
+        return True
+
+
+def _canonical_json(
+    payload,
+) -> bytes:
+    return (
+        json.dumps(
+            payload,
+            indent=2,
+            sort_keys=True,
+            ensure_ascii=True,
+        )
+        + "\n"
+    ).encode("utf-8")
+
+
+def _sha(
+    data: bytes,
+) -> str:
+    return hashlib.sha256(
+        data
+    ).hexdigest()
+
+
+def _settings() -> StorageSettings:
+    return StorageSettings(
+        backend="s3",
+        bucket_name=(
+            REPLICA_BUCKET
+        ),
+        region="test-1",
+        endpoint_url=(
+            "https://replica.example"
+        ),
+        force_path_style=True,
+        use_tls=True,
+        verify_tls=True,
+        key_prefix=(
+            REPLICA_PREFIX
+        ),
+    )
+
+
+def _domain() -> RecoveryDomain:
+    return RecoveryDomain(
+        provider_id=(
+            "secondary-provider"
+        ),
+        failure_domain=(
+            "secondary-provider-global"
+        ),
+    )
+
+
+def _base_manifest(
+    *,
+    data: bytes = PDF,
+    content_type: str = (
+        "application/pdf"
+    ),
+    status: str = "available",
+):
+    digest = _sha(
+        data
+    )
+
+    replica_key = (
+        f"{REPLICA_PREFIX}/tenants/"
+        f"7/objects/sha256/"
+        f"{digest[:2]}/{digest}"
+    )
+
+    if status == "available":
+        document = {
+            "organization_id": 7,
+            "public_id": PUBLIC_ID,
+            "status": "available",
+            "storage_backend": "s3",
+            "storage_bucket": (
+                "primary-vault"
+            ),
+            "object_key": (
+                "vault/tenants/7/"
+                "objects/source-object"
+            ),
+            "storage_version_id": (
+                "source-v1"
+            ),
+            "size_bytes": len(
+                data
+            ),
+            "content_type": (
+                content_type
+            ),
+            "sha256": digest,
+            "replica_state": (
+                "copied_verified"
+            ),
+            "recovery_eligible": True,
+            "replica_key": (
+                replica_key
+            ),
+            "replica_version_id": (
+                "replica-payload-v1"
+            ),
+            "source_exact_version_verified": (
+                True
+            ),
+        }
+
+        replicated = 1
+        state_only = 0
+        object_count = 1
+
+    else:
+        document = {
+            "organization_id": 7,
+            "public_id": PUBLIC_ID,
+            "status": status,
+            "storage_backend": "s3",
+            "storage_bucket": (
+                "primary-vault"
+            ),
+            "object_key": (
+                "vault/tenants/7/"
+                "objects/source-object"
+            ),
+            "storage_version_id": (
+                "source-v1"
+            ),
+            "size_bytes": len(
+                data
+            ),
+            "content_type": (
+                content_type
+            ),
+            "sha256": digest,
+            "replica_state": (
+                "state_only_not_auto_recoverable"
+            ),
+            "recovery_eligible": False,
+            "replica_key": None,
+            "replica_version_id": None,
+            "source_exact_version_verified": (
+                False
+            ),
+        }
+
+        replicated = 0
+        state_only = 1
+        object_count = 0
+
+    manifest = {
+        "format_version": (
+            MANIFEST_FORMAT_VERSION
+        ),
+        "created_at_utc": (
+            "2026-08-18T17:00:00Z"
+        ),
+        "snapshot_id": (
+            SNAPSHOT_ID
+        ),
+        "source_label": (
+            "p2-release-candidate"
+        ),
+        "release_commit": (
+            RELEASE
+        ),
+        "source_database": {
+            "database_name": (
+                "neondb"
+            ),
+            "source_identity_sha256": (
+                SOURCE_IDENTITY
+            ),
+            "postgres_server_version": (
+                "17.10"
+            ),
+            "postgis_version": (
+                "3.5.0"
+            ),
+            "alembic_revision": (
+                ALEMBIC
+            ),
+        },
+        "primary_storage": {
+            "provider_id": (
+                "primary-provider"
+            ),
+            "failure_domain": (
+                "primary-provider-global"
+            ),
+            "bucket_name": (
+                "primary-vault"
+            ),
+            "key_prefix": "vault",
+        },
+        "replica_storage": {
+            "provider_id": (
+                "secondary-provider"
+            ),
+            "failure_domain": (
+                "secondary-provider-global"
+            ),
+            "bucket_name": (
+                REPLICA_BUCKET
+            ),
+            "key_prefix": (
+                REPLICA_PREFIX
+            ),
+        },
+        "document_count": 1,
+        "replicated_document_count": (
+            replicated
+        ),
+        "state_only_document_count": (
+            state_only
+        ),
+        "replica_object_count": (
+            object_count
+        ),
+        "documents": [
+            document
+        ],
+    }
+
+    return (
+        manifest,
+        document,
+    )
+
+
+def _seed_snapshot(
+    *,
+    manifest=None,
+    payload: bytes = PDF,
+    payload_content_type: (
+        str | None
+    ) = "application/pdf",
+):
+    storage = (
+        ReadOnlyMemoryStorage()
+    )
+
+    if manifest is None:
+        manifest, document = (
+            _base_manifest(
+                data=payload,
+            )
+        )
+    else:
+        document = (
+            manifest[
+                "documents"
+            ][0]
+        )
+
+    manifest_key = (
+        f"{REPLICA_PREFIX}/snapshots/"
+        f"{SNAPSHOT_ID}/manifest.json"
+    )
+
+    complete_key = (
+        f"{REPLICA_PREFIX}/snapshots/"
+        f"{SNAPSHOT_ID}/complete.json"
+    )
+
+    manifest_bytes = (
+        _canonical_json(
+            manifest
+        )
+    )
+    manifest_sha = _sha(
+        manifest_bytes
+    )
+
+    storage.seed(
+        key=manifest_key,
+        data=manifest_bytes,
+        content_type=(
+            "application/json"
+        ),
+        metadata={
+            "sha256": (
+                manifest_sha
+            ),
+            "artifact-kind": (
+                "vault-recovery-manifest"
+            ),
+        },
+        version_id=(
+            "manifest-v1"
+        ),
+    )
+
+    complete = {
+        "format_version": (
+            COMPLETE_FORMAT_VERSION
+        ),
+        "snapshot_id": (
+            SNAPSHOT_ID
+        ),
+        "source_label": (
+            "p2-release-candidate"
+        ),
+        "release_commit": (
+            RELEASE
+        ),
+        "published_at_utc": (
+            "2026-08-18T17:00:00Z"
+        ),
+        "source_identity_sha256": (
+            SOURCE_IDENTITY
+        ),
+        "alembic_revision": (
+            ALEMBIC
+        ),
+        "replica_provider_id": (
+            "secondary-provider"
+        ),
+        "replica_failure_domain": (
+            "secondary-provider-global"
+        ),
+        "manifest_key": (
+            manifest_key
+        ),
+        "manifest_sha256": (
+            manifest_sha
+        ),
+        "manifest_version_id": (
+            "manifest-v1"
+        ),
+        "document_count": (
+            manifest[
+                "document_count"
+            ]
+        ),
+        "replicated_document_count": (
+            manifest[
+                "replicated_document_count"
+            ]
+        ),
+        "state_only_document_count": (
+            manifest[
+                "state_only_document_count"
+            ]
+        ),
+        "replica_object_count": (
+            manifest[
+                "replica_object_count"
+            ]
+        ),
+    }
+
+    complete_bytes = (
+        _canonical_json(
+            complete
+        )
+    )
+    complete_sha = _sha(
+        complete_bytes
+    )
+
+    storage.seed(
+        key=complete_key,
+        data=complete_bytes,
+        content_type=(
+            "application/json"
+        ),
+        metadata={
+            "sha256": (
+                complete_sha
+            ),
+            "artifact-kind": (
+                "vault-recovery-complete"
+            ),
+        },
+        version_id=(
+            "complete-v1"
+        ),
+    )
+
+    if (
+        document[
+            "status"
+        ]
+        == "available"
+    ):
+        storage.seed(
+            key=document[
+                "replica_key"
+            ],
+            data=payload,
+            content_type=(
+                payload_content_type
+            ),
+            metadata={
+                "sha256": (
+                    document[
+                        "sha256"
+                    ]
+                ),
+                "organization-id": (
+                    str(
+                        document[
+                            "organization_id"
+                        ]
+                    )
+                ),
+            },
+            version_id=(
+                document[
+                    "replica_version_id"
+                ]
+            ),
+        )
+
+    return {
+        "storage": storage,
+        "complete_key": (
+            complete_key
+        ),
+        "complete_sha": (
+            complete_sha
+        ),
+        "complete": complete,
+        "manifest": manifest,
+        "document": document,
+    }
+
+
+def _run(
+    *,
+    seeded,
+    output: Path,
+):
+    return run_provider_loss_drill(
+        replica_storage=(
+            seeded["storage"]
+        ),
+        replica_settings=(
+            _settings()
+        ),
+        replica_domain=(
+            _domain()
+        ),
+        complete_key=(
+            seeded[
+                "complete_key"
+            ]
+        ),
+        complete_version_id=(
+            "complete-v1"
+        ),
+        expected_complete_sha256=(
+            seeded[
+                "complete_sha"
+            ]
+        ),
+        expected_snapshot_id=(
+            SNAPSHOT_ID
+        ),
+        expected_source_label=(
+            "p2-release-candidate"
+        ),
+        expected_release_commit=(
+            RELEASE
+        ),
+        expected_alembic_revision=(
+            ALEMBIC
+        ),
+        output_directory=output,
+        operator="Jose Lezcano",
+    )
+
+
+def test_p27a6b_recovers_verified_bytes_without_primary_access(
+    tmp_path,
+):
+    seeded = _seed_snapshot()
+
+    output = (
+        tmp_path
+        / "isolated-recovery"
+    )
+
+    result = _run(
+        seeded=seeded,
+        output=output,
+    )
+
+    assert (
+        result["result"]
+        == "PASS"
+    )
+    assert (
+        result[
+            "format_version"
+        ]
+        == DRILL_FORMAT_VERSION
+    )
+    assert (
+        result[
+            "primary_access_attempted"
+        ]
+        is False
+    )
+    assert (
+        result[
+            "replica_read_only"
+        ]
+        is True
+    )
+    assert (
+        result[
+            "production_modified"
+        ]
+        is False
+    )
+    assert (
+        result[
+            "recovered_document_count"
+        ]
+        == 1
+    )
+    assert (
+        result[
+            "state_only_document_count"
+        ]
+        == 0
+    )
+    assert (
+        result[
+            "recovered_bytes"
+        ]
+        == len(PDF)
+    )
+
+    payload_path = (
+        output
+        / "tenants"
+        / "7"
+        / "documents"
+        / PUBLIC_ID
+        / "payload.pdf"
+    )
+
+    assert (
+        payload_path.read_bytes()
+        == PDF
+    )
+
+    index = json.loads(
+        (
+            output
+            / "recovery_index.json"
+        ).read_text(
+            encoding="utf-8"
+        )
+    )
+
+    assert (
+        index[
+            "provider_loss_mode"
+        ]
+        == "primary_unavailable"
+    )
+
+
+def test_p27a6b_rejects_wrong_complete_sha256(
+    tmp_path,
+):
+    seeded = _seed_snapshot()
+
+    with pytest.raises(
+        VaultProviderLossDrillError,
+        match="complete marker metadata SHA-256 binding failed|complete marker full SHA-256",
+    ):
+        run_provider_loss_drill(
+            replica_storage=(
+                seeded["storage"]
+            ),
+            replica_settings=(
+                _settings()
+            ),
+            replica_domain=(
+                _domain()
+            ),
+            complete_key=(
+                seeded[
+                    "complete_key"
+                ]
+            ),
+            complete_version_id=(
+                "complete-v1"
+            ),
+            expected_complete_sha256=(
+                "0" * 64
+            ),
+            expected_snapshot_id=(
+                SNAPSHOT_ID
+            ),
+            expected_source_label=(
+                "p2-release-candidate"
+            ),
+            expected_release_commit=(
+                RELEASE
+            ),
+            expected_alembic_revision=(
+                ALEMBIC
+            ),
+            output_directory=(
+                tmp_path
+                / "recovery"
+            ),
+            operator="Jose Lezcano",
+        )
+
+
+def test_p27a6b_rejects_manifest_tamper(
+    tmp_path,
+):
+    seeded = _seed_snapshot()
+
+    key = (
+        seeded[
+            "complete"
+        ][
+            "manifest_key"
+        ]
+    )
+
+    original = (
+        seeded[
+            "storage"
+        ]._objects[
+            key
+        ]
+    )
+
+    corrupt = (
+        original.data
+        + b" "
+    )
+
+    seeded[
+        "storage"
+    ].seed(
+        key=key,
+        data=corrupt,
+        content_type=(
+            "application/json"
+        ),
+        metadata={
+            "sha256": _sha(
+                corrupt
+            ),
+        },
+        version_id=(
+            "manifest-v1"
+        ),
+    )
+
+    with pytest.raises(
+        VaultProviderLossDrillError,
+        match="recovery manifest metadata SHA-256 binding failed|recovery manifest full SHA-256",
+    ):
+        _run(
+            seeded=seeded,
+            output=(
+                tmp_path
+                / "recovery"
+            ),
+        )
+
+
+def test_p27a6b_rejects_cross_tenant_replica_key(
+    tmp_path,
+):
+    manifest, document = (
+        _base_manifest()
+    )
+
+    document[
+        "replica_key"
+    ] = (
+        document[
+            "replica_key"
+        ].replace(
+            "/tenants/7/",
+            "/tenants/8/",
+        )
+    )
+
+    seeded = _seed_snapshot(
+        manifest=manifest,
+    )
+
+    with pytest.raises(
+        VaultProviderLossDrillError,
+        match="tenant/content-address binding",
+    ):
+        _run(
+            seeded=seeded,
+            output=(
+                tmp_path
+                / "recovery"
+            ),
+        )
+
+
+def test_p27a6b_rejects_primary_source_cross_tenant_binding(
+    tmp_path,
+):
+    manifest, document = (
+        _base_manifest()
+    )
+
+    document[
+        "object_key"
+    ] = (
+        "vault/tenants/8/"
+        "objects/source-object"
+    )
+
+    seeded = _seed_snapshot(
+        manifest=manifest,
+    )
+
+    with pytest.raises(
+        VaultProviderLossDrillError,
+        match="source object violates tenant binding",
+    ):
+        _run(
+            seeded=seeded,
+            output=(
+                tmp_path
+                / "recovery"
+            ),
+        )
+
+
+def test_p27a6b_rejects_corrupt_replica_payload(
+    tmp_path,
+):
+    seeded = _seed_snapshot()
+
+    document = (
+        seeded[
+            "document"
+        ]
+    )
+
+    corrupt = bytearray(
+        PDF
+    )
+    corrupt[6] = (
+        ord("9")
+        if corrupt[6]
+        != ord("9")
+        else ord("8")
+    )
+    corrupt = bytes(
+        corrupt
+    )
+
+    assert len(
+        corrupt
+    ) == len(
+        PDF
+    )
+
+    seeded[
+        "storage"
+    ].seed(
+        key=document[
+            "replica_key"
+        ],
+        data=corrupt,
+        content_type=(
+            "application/pdf"
+        ),
+        metadata={
+            "sha256": (
+                document[
+                    "sha256"
+                ]
+            ),
+            "organization-id": "7",
+        },
+        version_id=(
+            "replica-payload-v1"
+        ),
+    )
+
+    output = (
+        tmp_path
+        / "recovery"
+    )
+
+    with pytest.raises(
+        VaultProviderLossDrillError,
+        match="full SHA-256",
+    ):
+        _run(
+            seeded=seeded,
+            output=output,
+        )
+
+    assert not output.exists()
+
+
+def test_p27a6b_rejects_replica_content_type_mismatch(
+    tmp_path,
+):
+    seeded = _seed_snapshot(
+        payload_content_type=(
+            "application/json"
+        )
+    )
+
+    with pytest.raises(
+        VaultProviderLossDrillError,
+        match="content-type binding",
+    ):
+        _run(
+            seeded=seeded,
+            output=(
+                tmp_path
+                / "recovery"
+            ),
+        )
+
+
+def test_p27a6b_rejects_non_application_compatible_bytes(
+    tmp_path,
+):
+    invalid_pdf = (
+        b"NOT-A-PDF"
+    )
+
+    manifest, document = (
+        _base_manifest(
+            data=invalid_pdf,
+            content_type=(
+                "application/pdf"
+            ),
+        )
+    )
+
+    seeded = _seed_snapshot(
+        manifest=manifest,
+        payload=invalid_pdf,
+        payload_content_type=(
+            "application/pdf"
+        ),
+    )
+
+    output = (
+        tmp_path
+        / "recovery"
+    )
+
+    with pytest.raises(
+        VaultProviderLossDrillError,
+        match="not application-compatible",
+    ):
+        _run(
+            seeded=seeded,
+            output=output,
+        )
+
+    assert not output.exists()
+
+
+@pytest.mark.parametrize(
+    "status",
+    [
+        "pending_upload",
+        "upload_failed",
+        "delete_pending",
+        "delete_failed",
+        "deleted",
+    ],
+)
+def test_p27a6b_state_only_documents_are_not_resurrected(
+    tmp_path,
+    status,
+):
+    manifest, _ = (
+        _base_manifest()
+    )
+
+    _, state_document = (
+        _base_manifest(
+            status=status
+        )
+    )
+
+    state_document = deepcopy(
+        state_document
+    )
+
+    state_document[
+        "public_id"
+    ] = STATE_PUBLIC_ID
+
+    state_document[
+        "object_key"
+    ] = (
+        "vault/tenants/7/"
+        "objects/state-only-object"
+    )
+
+    manifest[
+        "documents"
+    ].append(
+        state_document
+    )
+
+    manifest[
+        "document_count"
+    ] = 2
+
+    manifest[
+        "state_only_document_count"
+    ] = 1
+
+    # One available object remains the real provider-loss payload.
+    assert (
+        manifest[
+            "replicated_document_count"
+        ]
+        == 1
+    )
+
+    assert (
+        manifest[
+            "replica_object_count"
+        ]
+        == 1
+    )
+
+    seeded = _seed_snapshot(
+        manifest=manifest,
+    )
+
+    output = (
+        tmp_path
+        / "recovery"
+    )
+
+    result = _run(
+        seeded=seeded,
+        output=output,
+    )
+
+    assert (
+        result[
+            "recovered_document_count"
+        ]
+        == 1
+    )
+
+    assert (
+        result[
+            "state_only_document_count"
+        ]
+        == 1
+    )
+
+    document_directory = (
+        output
+        / "tenants"
+        / "7"
+        / "documents"
+        / STATE_PUBLIC_ID
+    )
+
+    assert (
+        document_directory
+        / "metadata.json"
+    ).exists()
+
+    assert not list(
+        document_directory.glob(
+            "payload.*"
+        )
+    )
+
+
+def test_p27a6b_rejects_snapshot_without_recoverable_payload(
+    tmp_path,
+):
+    manifest, _ = (
+        _base_manifest(
+            status="deleted"
+        )
+    )
+
+    seeded = _seed_snapshot(
+        manifest=manifest,
+    )
+
+    with pytest.raises(
+        VaultProviderLossDrillError,
+        match="at least one recovery-eligible Vault object",
+    ):
+        _run(
+            seeded=seeded,
+            output=(
+                tmp_path
+                / "recovery"
+            ),
+        )
+
+
+def test_p27a6b_rejects_document_primary_bucket_mismatch(
+    tmp_path,
+):
+    manifest, document = (
+        _base_manifest()
+    )
+
+    document[
+        "storage_bucket"
+    ] = "unexpected-primary-bucket"
+
+    seeded = _seed_snapshot(
+        manifest=manifest,
+    )
+
+    with pytest.raises(
+        VaultProviderLossDrillError,
+        match="storage bucket does not match bound primary storage",
+    ):
+        _run(
+            seeded=seeded,
+            output=(
+                tmp_path
+                / "recovery"
+            ),
+        )
+
+
+def test_p27a6b_rejects_existing_isolated_target(
+    tmp_path,
+):
+    seeded = _seed_snapshot()
+
+    output = (
+        tmp_path
+        / "recovery"
+    )
+    output.mkdir()
+
+    with pytest.raises(
+        VaultProviderLossDrillError,
+        match="already exists",
+    ):
+        _run(
+            seeded=seeded,
+            output=output,
+        )
+
+
+def test_p27a6b_rejects_primary_configuration_in_provider_loss_mode():
+    with pytest.raises(
+        VaultProviderLossDrillError,
+        match="Primary Vault configuration is present",
+    ):
+        assert_primary_provider_not_configured(
+            {
+                "VAULT_PRIMARY_BUCKET_NAME": (
+                    "primary-vault"
+                ),
+                "VAULT_REPLICA_BUCKET_NAME": (
+                    "secondary"
+                ),
+            }
+        )
+
+
+def test_p27a6b_accepts_environment_without_primary_configuration():
+    assert_primary_provider_not_configured(
+        {
+            "VAULT_REPLICA_BUCKET_NAME": (
+                "secondary"
+            ),
+            "VAULT_REPLICA_PROVIDER_ID": (
+                "secondary-provider"
+            ),
+        }
+    )
+
+
+def test_p27a6b_rejects_replica_provider_identity_mismatch(
+    tmp_path,
+):
+    seeded = _seed_snapshot()
+
+    wrong_domain = RecoveryDomain(
+        provider_id=(
+            "different-provider"
+        ),
+        failure_domain=(
+            "secondary-provider-global"
+        ),
+    )
+
+    with pytest.raises(
+        VaultProviderLossDrillError,
+        match="replica-provider binding",
+    ):
+        run_provider_loss_drill(
+            replica_storage=(
+                seeded["storage"]
+            ),
+            replica_settings=(
+                _settings()
+            ),
+            replica_domain=(
+                wrong_domain
+            ),
+            complete_key=(
+                seeded[
+                    "complete_key"
+                ]
+            ),
+            complete_version_id=(
+                "complete-v1"
+            ),
+            expected_complete_sha256=(
+                seeded[
+                    "complete_sha"
+                ]
+            ),
+            expected_snapshot_id=(
+                SNAPSHOT_ID
+            ),
+            expected_source_label=(
+                "p2-release-candidate"
+            ),
+            expected_release_commit=(
+                RELEASE
+            ),
+            expected_alembic_revision=(
+                ALEMBIC
+            ),
+            output_directory=(
+                tmp_path
+                / "recovery"
+            ),
+            operator="Jose Lezcano",
+        )
+
+
+def test_p27a6b_rejects_duplicate_public_document_binding(
+    tmp_path,
+):
+    manifest, document = (
+        _base_manifest()
+    )
+
+    second = deepcopy(
+        document
+    )
+
+    manifest[
+        "documents"
+    ].append(
+        second
+    )
+    manifest[
+        "document_count"
+    ] = 2
+    manifest[
+        "replicated_document_count"
+    ] = 2
+
+    # Both documents intentionally share the same CAS object.
+    manifest[
+        "replica_object_count"
+    ] = 1
+
+    seeded = _seed_snapshot(
+        manifest=manifest,
+    )
+
+    with pytest.raises(
+        VaultProviderLossDrillError,
+        match="duplicate public document binding",
+    ):
+        _run(
+            seeded=seeded,
+            output=(
+                tmp_path
+                / "recovery"
+            ),
+        )


### PR DESCRIPTION
## P2.7A6B — Vault provider-loss recovery drill

Adds a fail-closed recovery verifier/materializer that restores Vault evidence from an independent replica while the primary provider is treated as unavailable.

### Scope
- create `scripts/vault_provider_loss_drill.py`
- create `tests/test_vault_provider_loss_drill_p27a6_unittest.py`
- update `DISASTER_RECOVERY_RUNBOOK.md`
- update `tests/test_disaster_recovery_p27a_unittest.py`

### DR / security properties
- requires explicit `--primary-unavailable`
- rejects any `VAULT_PRIMARY_*` configuration during drill execution
- reads only from the replica; no replica PUT/DELETE path
- pins complete marker SHA/version/snapshot/source/release/Alembic identity
- verifies manifest SHA/version/domain/bucket/prefix/count bindings
- validates primary tenant/key/bucket metadata from the signed manifest without contacting primary
- requires at least one recovery-eligible object for PASS
- verifies exact replica version when present, MIME, size, tenant metadata and full SHA-256
- re-validates recovered PDF/JSON/XLSX with the canonical Vault validator
- materializes into a new isolated filesystem target via partial-directory promotion
- state-only lifecycle entries are preserved without resurrecting payloads
- emits measured recovery evidence with `production_modified: false`

### Validation
Targeted Vault/DR regression passed locally: 127 tests, with 2 unrelated Starlette deprecation warnings.

Base: `p2-enterprise-production`
Head: `p27a6b-vault-provider-loss-drill`
Expected head SHA: `3a8072d62c5e4dd425b5513ecd79d4da99c49c7b`