### PR TITLE
feat(security): close V1 auth ingress hardening gates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ on:
   push:
     branches:
       - p2-enterprise-production
+      - p2-v1-closure
   workflow_dispatch:
 
 permissions:
@@ -102,3 +103,24 @@ jobs:
           POSTGRES_PASSWORD: ci-placeholder-postgres-password
           POSTGRES_DB: appdb
         run: docker compose -f docker-compose.prod.yml config --quiet
+
+      - name: Validate production Nginx configuration
+        shell: bash
+        run: |
+          set -euo pipefail
+          CERT_DIR="$RUNNER_TEMP/litoral-trace-nginx-certs"
+          mkdir -p "$CERT_DIR"
+          openssl req \
+            -x509 \
+            -nodes \
+            -newkey rsa:2048 \
+            -keyout "$CERT_DIR/privkey.pem" \
+            -out "$CERT_DIR/fullchain.pem" \
+            -subj "/CN=litoraltrace.com" \
+            -days 1 \
+            >/dev/null 2>&1
+          docker run --rm \
+            -v "$PWD/nginx/nginx.conf:/etc/nginx/nginx.conf:ro" \
+            -v "$CERT_DIR:/etc/nginx/certs:ro" \
+            nginx:1.25-alpine \
+            nginx -t

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -120,6 +120,7 @@ jobs:
             -days 1 \
             >/dev/null 2>&1
           docker run --rm \
+            --add-host app:127.0.0.1 \
             -v "$PWD/nginx/nginx.conf:/etc/nginx/nginx.conf:ro" \
             -v "$CERT_DIR:/etc/nginx/certs:ro" \
             nginx:1.25-alpine \

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -5,6 +5,27 @@ events {
 http {
     include /etc/nginx/mime.types;
     default_type application/octet-stream;
+    server_tokens off;
+
+    # Authentication abuse protection.
+    # Empty map keys are not accounted by limit_req, so only the explicit
+    # POST authentication endpoints consume rate-limit capacity.
+    map "$request_method:$uri" $auth_login_limit_key {
+        default "";
+        "POST:/login" $binary_remote_addr;
+        "POST:/api/v1/auth/login" $binary_remote_addr;
+    }
+
+    map "$request_method:$uri" $auth_refresh_limit_key {
+        default "";
+        "POST:/api/v1/auth/refresh" $binary_remote_addr;
+    }
+
+    # Per-client-IP limits at the public ingress. The FastAPI application is
+    # not published directly by docker-compose.prod.yml, so production auth
+    # traffic must cross this enforcement point.
+    limit_req_zone $auth_login_limit_key zone=auth_login_per_ip:10m rate=10r/m;
+    limit_req_zone $auth_refresh_limit_key zone=auth_refresh_per_ip:10m rate=60r/m;
 
     # Compresion Gzip
     gzip on;
@@ -29,11 +50,23 @@ http {
         ssl_certificate_key /etc/nginx/certs/privkey.pem;
         ssl_protocols TLSv1.2 TLSv1.3;
 
-        # Headers de Seguridad B2B
+        # Authentication rate limiting. Login allows a small burst for shared
+        # corporate/NAT clients while sustained abuse is rejected with 429.
+        limit_req zone=auth_login_per_ip burst=5 nodelay;
+        limit_req zone=auth_refresh_per_ip burst=30 nodelay;
+        limit_req_status 429;
+
+        # Browser/security hardening for the public B2B surface.
         add_header X-Frame-Options "SAMEORIGIN" always;
         add_header X-Content-Type-Options "nosniff" always;
-        add_header X-XSS-Protection "1; mode=block" always;
+        add_header X-XSS-Protection "0" always;
         add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
+        add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+        add_header Permissions-Policy "camera=(), microphone=(), geolocation=(), payment=(), usb=()" always;
+        add_header Cross-Origin-Opener-Policy "same-origin" always;
+        add_header Cross-Origin-Resource-Policy "same-origin" always;
+        add_header X-Permitted-Cross-Domain-Policies "none" always;
+        add_header Content-Security-Policy "default-src 'self'; base-uri 'self'; form-action 'self'; frame-ancestors 'self'; object-src 'none'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self' data:; connect-src 'self'; media-src 'self'; worker-src 'self' blob:; manifest-src 'self'; upgrade-insecure-requests" always;
 
         location /docs {
             proxy_pass http://fastapi_backend/docs;

--- a/tests/test_v1_security_ingress_unittest.py
+++ b/tests/test_v1_security_ingress_unittest.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+NGINX_CONFIG = ROOT / "nginx" / "nginx.conf"
+CI_WORKFLOW = ROOT / ".github" / "workflows" / "ci.yml"
+
+
+def _nginx_text() -> str:
+    return NGINX_CONFIG.read_text(encoding="utf-8")
+
+
+def _ci_text() -> str:
+    return CI_WORKFLOW.read_text(encoding="utf-8")
+
+
+def test_login_rate_limit_covers_browser_and_api_post_routes() -> None:
+    nginx = _nginx_text()
+
+    for token in (
+        'map "$request_method:$uri" $auth_login_limit_key',
+        '"POST:/login" $binary_remote_addr;',
+        '"POST:/api/v1/auth/login" $binary_remote_addr;',
+        "zone=auth_login_per_ip:10m rate=10r/m",
+        "limit_req zone=auth_login_per_ip burst=5 nodelay;",
+        "limit_req_status 429;",
+    ):
+        assert token in nginx
+
+
+def test_refresh_rate_limit_covers_refresh_post_route() -> None:
+    nginx = _nginx_text()
+
+    for token in (
+        'map "$request_method:$uri" $auth_refresh_limit_key',
+        '"POST:/api/v1/auth/refresh" $binary_remote_addr;',
+        "zone=auth_refresh_per_ip:10m rate=60r/m",
+        "limit_req zone=auth_refresh_per_ip burst=30 nodelay;",
+        "limit_req_status 429;",
+    ):
+        assert token in nginx
+
+
+def test_browser_security_headers_include_csp_and_modern_baseline() -> None:
+    nginx = _nginx_text()
+
+    required_headers = (
+        'add_header X-Frame-Options "SAMEORIGIN" always;',
+        'add_header X-Content-Type-Options "nosniff" always;',
+        'add_header X-XSS-Protection "0" always;',
+        'add_header Referrer-Policy "strict-origin-when-cross-origin" always;',
+        'add_header Permissions-Policy "camera=(), microphone=(), geolocation=(), payment=(), usb=()" always;',
+        'add_header Cross-Origin-Opener-Policy "same-origin" always;',
+        'add_header Cross-Origin-Resource-Policy "same-origin" always;',
+        'add_header X-Permitted-Cross-Domain-Policies "none" always;',
+        "add_header Content-Security-Policy ",
+    )
+
+    for token in required_headers:
+        assert token in nginx
+
+    for directive in (
+        "default-src 'self'",
+        "base-uri 'self'",
+        "form-action 'self'",
+        "frame-ancestors 'self'",
+        "object-src 'none'",
+        "connect-src 'self'",
+        "upgrade-insecure-requests",
+    ):
+        assert directive in nginx
+
+    assert 'X-XSS-Protection "1; mode=block"' not in nginx
+
+
+def test_ci_runs_on_v1_closure_and_syntax_checks_nginx() -> None:
+    workflow = _ci_text()
+
+    assert "- p2-v1-closure" in workflow
+    assert "Validate production Nginx configuration" in workflow
+    assert "nginx:1.25-alpine" in workflow
+    assert "nginx -t" in workflow


### PR DESCRIPTION
V1 closure security tranche.

Changes:
- adds per-client ingress rate limiting for browser/API login and API refresh
- returns HTTP 429 for sustained auth abuse
- replaces obsolete X-XSS behavior with modern browser hardening headers
- adds Content-Security-Policy baseline compatible with current inline Vault UI scripts
- enables CI on p2-v1-closure
- validates production Nginx syntax in CI with ephemeral test certificates
- adds regression tests for rate-limit and security-header contracts

Safety:
- no database migration
- no production deployment
- no secret changes
- no external-service writes

Closure gates targeted: 04, 05, 06, and CI-path evidence for 07.