### PR TITLE
feat(obs): add V1 operational alerting stack

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -142,6 +142,13 @@ STORAGE_ALLOWED_CONTENT_TYPES=application/pdf,application/json,application/vnd.o
 # Observability
 # ----------------------------------------------------------------------------
 # SENTRY_DSN=
+#
+# The internal Alertmanager receiver opens/closes sanitized GitHub incident
+# issues. Use a fine-grained token restricted to the selected repository with
+# Metadata: read and Issues: read/write only. Never paste that token into Git.
+# OPS_ALERT_GITHUB_TOKEN=<load-from-deployment-secret-store>
+OPS_ALERT_GITHUB_REPOSITORY=Jose34345/litoral_trace
+OPS_ALERT_GITHUB_ASSIGNEE=Jose34345
 
 # ----------------------------------------------------------------------------
 # Durable satellite worker

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,7 +84,7 @@ jobs:
 
   production-build:
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    timeout-minutes: 25
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -102,6 +102,7 @@ jobs:
           POSTGRES_USER: postgres
           POSTGRES_PASSWORD: ci-placeholder-postgres-password
           POSTGRES_DB: appdb
+          OPS_ALERT_GITHUB_TOKEN: ci-placeholder-ops-token
         run: docker compose -f docker-compose.prod.yml config --quiet
 
       - name: Validate production Nginx configuration
@@ -125,3 +126,29 @@ jobs:
             -v "$CERT_DIR:/etc/nginx/certs:ro" \
             nginx:1.25-alpine \
             nginx -t
+
+      - name: Validate Prometheus configuration and alert rules
+        shell: bash
+        run: |
+          set -euo pipefail
+          docker run --rm \
+            --entrypoint /bin/promtool \
+            -v "$PWD/monitoring/prometheus.yml:/etc/prometheus/prometheus.yml:ro" \
+            -v "$PWD/monitoring/alert_rules.yml:/etc/prometheus/alert_rules.yml:ro" \
+            prom/prometheus:v3.13.1 \
+            check config /etc/prometheus/prometheus.yml
+          docker run --rm \
+            --entrypoint /bin/promtool \
+            -v "$PWD/monitoring/alert_rules.yml:/etc/prometheus/alert_rules.yml:ro" \
+            prom/prometheus:v3.13.1 \
+            check rules /etc/prometheus/alert_rules.yml
+
+      - name: Validate Alertmanager configuration
+        shell: bash
+        run: |
+          set -euo pipefail
+          docker run --rm \
+            --entrypoint /bin/amtool \
+            -v "$PWD/monitoring/alertmanager.yml:/etc/alertmanager/alertmanager.yml:ro" \
+            prom/alertmanager:v0.33.1 \
+            check-config /etc/alertmanager/alertmanager.yml

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -116,6 +116,81 @@ services:
       retries: 3
     stop_grace_period: 60s
 
+  ops-alert-receiver:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    restart: always
+    command:
+      [
+        "uvicorn",
+        "litoral_trace.observability.ops_alert_receiver:app",
+        "--host",
+        "0.0.0.0",
+        "--port",
+        "9110",
+      ]
+    environment:
+      OPS_ALERT_GITHUB_TOKEN: ${OPS_ALERT_GITHUB_TOKEN:?OPS_ALERT_GITHUB_TOKEN is required}
+      OPS_ALERT_GITHUB_REPOSITORY: ${OPS_ALERT_GITHUB_REPOSITORY:-Jose34345/litoral_trace}
+      OPS_ALERT_GITHUB_ASSIGNEE: ${OPS_ALERT_GITHUB_ASSIGNEE:-Jose34345}
+    networks:
+      - litoral_prod_network
+    expose:
+      - "9110"
+    healthcheck:
+      test:
+        [
+          "CMD",
+          "curl",
+          "-fsS",
+          "http://127.0.0.1:9110/health",
+        ]
+      interval: 30s
+      timeout: 5s
+      start_period: 5s
+      retries: 3
+
+  alertmanager:
+    image: prom/alertmanager:v0.33.1
+    restart: always
+    command:
+      - --config.file=/etc/alertmanager/alertmanager.yml
+      - --storage.path=/alertmanager
+    volumes:
+      - ./monitoring/alertmanager.yml:/etc/alertmanager/alertmanager.yml:ro
+      - alertmanager_data:/alertmanager
+    depends_on:
+      ops-alert-receiver:
+        condition: service_healthy
+    networks:
+      - litoral_prod_network
+    expose:
+      - "9093"
+
+  prometheus:
+    image: prom/prometheus:v3.13.1
+    restart: always
+    command:
+      - --config.file=/etc/prometheus/prometheus.yml
+      - --storage.tsdb.path=/prometheus
+      - --storage.tsdb.retention.time=15d
+    volumes:
+      - ./monitoring/prometheus.yml:/etc/prometheus/prometheus.yml:ro
+      - ./monitoring/alert_rules.yml:/etc/prometheus/alert_rules.yml:ro
+      - prometheus_data:/prometheus
+    depends_on:
+      app:
+        condition: service_healthy
+      worker:
+        condition: service_healthy
+      alertmanager:
+        condition: service_started
+    networks:
+      - litoral_prod_network
+    expose:
+      - "9090"
+
   db:
     image: postgis/postgis:15-3.3-alpine
     container_name: litoral_trace_db
@@ -156,6 +231,8 @@ services:
 
 volumes:
   postgres_prod_data:
+  prometheus_data:
+  alertmanager_data:
 
 networks:
   litoral_prod_network:

--- a/main.py
+++ b/main.py
@@ -33,6 +33,7 @@ from fastapi.responses import (
     RedirectResponse,
 )
 from fastapi.staticfiles import StaticFiles
+from prometheus_client import CONTENT_TYPE_LATEST
 from sqlalchemy import text
 
 from litoral_trace.config import (
@@ -68,6 +69,10 @@ from litoral_trace.auth.sessions import (
 )
 from litoral_trace.db.engine import (
     get_db_session,
+)
+from litoral_trace.observability.api_metrics import (
+    ApiMetricsMiddleware,
+    api_metrics,
 )
 from litoral_trace.storage.readiness import (
     is_vault_storage_ready,
@@ -118,6 +123,9 @@ app = FastAPI(
 
 app.add_middleware(
     CookieApiCsrfMiddleware
+)
+app.add_middleware(
+    ApiMetricsMiddleware
 )
 
 
@@ -620,6 +628,41 @@ async def logout_submit_view(
 # ---------------------------------------------------------------------------
 
 
+def _runtime_dependency_readiness() -> dict[str, bool]:
+    database_ready = False
+    vault_ready = False
+
+    try:
+        session = get_db_session()
+    except Exception:
+        session = None
+
+    if session is not None:
+        try:
+            session.execute(text("SELECT 1"))
+            database_ready = True
+        except Exception:
+            try:
+                session.rollback()
+            except Exception:
+                pass
+        finally:
+            try:
+                session.close()
+            except Exception:
+                pass
+
+    try:
+        vault_ready = bool(is_vault_storage_ready())
+    except Exception:
+        vault_ready = False
+
+    return {
+        "database": database_ready,
+        "vault": vault_ready,
+    }
+
+
 @app.get(
     "/health",
     tags=["Infraestructura"],
@@ -646,50 +689,8 @@ async def health_check() -> JSONResponse:
 async def readiness_check() -> JSONResponse:
     """Fail closed when a required runtime dependency is unavailable."""
 
-    try:
-        session = get_db_session()
-    except Exception:
-        session = None
-
-    if session is None:
-        return JSONResponse(
-            status_code=(
-                status.HTTP_503_SERVICE_UNAVAILABLE
-            ),
-            content={
-                "status": "unavailable"
-            },
-        )
-
-    try:
-        session.execute(
-            text(
-                "SELECT 1"
-            )
-        )
-
-    except Exception:
-        try:
-            session.rollback()
-        except Exception:
-            pass
-
-        return JSONResponse(
-            status_code=(
-                status.HTTP_503_SERVICE_UNAVAILABLE
-            ),
-            content={
-                "status": "unavailable"
-            },
-        )
-
-    finally:
-        try:
-            session.close()
-        except Exception:
-            pass
-
-    if not is_vault_storage_ready():
+    dependencies = _runtime_dependency_readiness()
+    if not all(dependencies.values()):
         return JSONResponse(
             status_code=(
                 status.HTTP_503_SERVICE_UNAVAILABLE
@@ -706,6 +707,25 @@ async def readiness_check() -> JSONResponse:
         content={
             "status": "ready"
         },
+    )
+
+
+@app.get(
+    "/internal/metrics",
+    include_in_schema=False,
+)
+async def internal_metrics() -> Response:
+    """Expose sanitized Prometheus metrics only to the private service network."""
+
+    dependencies = _runtime_dependency_readiness()
+    api_metrics.set_dependency_readiness(
+        database=dependencies["database"],
+        vault=dependencies["vault"],
+    )
+    return Response(
+        content=api_metrics.render(),
+        status_code=status.HTTP_200_OK,
+        headers={"Content-Type": CONTENT_TYPE_LATEST},
     )
 
 

--- a/main.py
+++ b/main.py
@@ -628,7 +628,12 @@ async def logout_submit_view(
 # ---------------------------------------------------------------------------
 
 
-def _runtime_dependency_readiness() -> dict[str, bool]:
+def _runtime_dependency_readiness(
+    *,
+    probe_vault_if_database_unavailable: bool = False,
+) -> dict[str, bool]:
+    """Probe required dependencies while preserving /ready short-circuiting."""
+
     database_ready = False
     vault_ready = False
 
@@ -652,10 +657,11 @@ def _runtime_dependency_readiness() -> dict[str, bool]:
             except Exception:
                 pass
 
-    try:
-        vault_ready = bool(is_vault_storage_ready())
-    except Exception:
-        vault_ready = False
+    if database_ready or probe_vault_if_database_unavailable:
+        try:
+            vault_ready = bool(is_vault_storage_ready())
+        except Exception:
+            vault_ready = False
 
     return {
         "database": database_ready,
@@ -717,7 +723,9 @@ async def readiness_check() -> JSONResponse:
 async def internal_metrics() -> Response:
     """Expose sanitized Prometheus metrics only to the private service network."""
 
-    dependencies = _runtime_dependency_readiness()
+    dependencies = _runtime_dependency_readiness(
+        probe_vault_if_database_unavailable=True,
+    )
     api_metrics.set_dependency_readiness(
         database=dependencies["database"],
         vault=dependencies["vault"],

--- a/monitoring/alert_rules.yml
+++ b/monitoring/alert_rules.yml
@@ -1,0 +1,119 @@
+groups:
+  - name: litoral-trace-v1-runtime
+    rules:
+      - alert: LitoralTraceAppMetricsDown
+        expr: up{job="litoral-trace-app"} == 0
+        for: 2m
+        labels:
+          severity: critical
+          service: litoral-trace
+          component: app
+        annotations:
+          summary: Litoral Trace application metrics are unreachable
+          description: The application metrics endpoint has been unreachable for at least two minutes.
+
+      - alert: LitoralTraceReadinessUnavailable
+        expr: min(litoral_trace_dependency_ready) < 1
+        for: 2m
+        labels:
+          severity: critical
+          service: litoral-trace
+          component: readiness
+        annotations:
+          summary: Litoral Trace runtime readiness is unavailable
+          description: At least one required runtime dependency is not ready.
+
+      - alert: LitoralTraceVaultUnavailable
+        expr: litoral_trace_dependency_ready{dependency="vault"} == 0
+        for: 2m
+        labels:
+          severity: critical
+          service: litoral-trace
+          component: vault
+        annotations:
+          summary: Litoral Trace Vault storage is unavailable
+          description: The private Vault object-storage readiness probe is failing.
+
+      - alert: LitoralTraceDatabaseUnavailable
+        expr: litoral_trace_dependency_ready{dependency="database"} == 0
+        for: 2m
+        labels:
+          severity: critical
+          service: litoral-trace
+          component: database
+        annotations:
+          summary: Litoral Trace PostgreSQL is unavailable
+          description: The application database readiness probe is failing.
+
+      - alert: LitoralTraceSatelliteWorkerDown
+        expr: up{job="litoral-trace-worker"} == 0
+        for: 2m
+        labels:
+          severity: critical
+          service: litoral-trace
+          component: satellite-worker
+        annotations:
+          summary: Satellite worker metrics are unreachable
+          description: The satellite worker metrics endpoint has been unreachable for at least two minutes.
+
+      - alert: LitoralTraceSatelliteQueueBacklog
+        expr: litoral_trace_satellite_jobs_oldest_ready_age_seconds > 300
+        for: 5m
+        labels:
+          severity: warning
+          service: litoral-trace
+          component: satellite-queue
+        annotations:
+          summary: Satellite queue has an old ready job
+          description: The oldest ready satellite job has waited more than five minutes.
+
+      - alert: LitoralTraceSatelliteStaleJobs
+        expr: (litoral_trace_satellite_jobs_running_stale > 0) or (litoral_trace_satellite_jobs_running_invalid > 0)
+        for: 2m
+        labels:
+          severity: critical
+          service: litoral-trace
+          component: satellite-queue
+        annotations:
+          summary: Satellite queue contains stale or invalid running jobs
+          description: One or more running jobs are stale or violate the active lease contract.
+
+      - alert: LitoralTraceSatelliteHeartbeatFailure
+        expr: sum(increase(litoral_trace_satellite_heartbeat_failures_total[5m])) > 0
+        labels:
+          severity: critical
+          service: litoral-trace
+          component: satellite-worker
+        annotations:
+          summary: Satellite worker heartbeat failure detected
+          description: At least one worker heartbeat failure occurred during the last five minutes.
+
+      - alert: LitoralTraceSatelliteLeaseLost
+        expr: sum(increase(litoral_trace_satellite_jobs_lease_lost_total[5m])) > 0
+        labels:
+          severity: critical
+          service: litoral-trace
+          component: satellite-worker
+        annotations:
+          summary: Satellite worker lease loss detected
+          description: At least one satellite job lost its execution lease during the last five minutes.
+
+      - alert: LitoralTraceApi5xxSpike
+        expr: sum(increase(litoral_trace_http_requests_total{status_class="5xx"}[5m])) >= 3
+        labels:
+          severity: critical
+          service: litoral-trace
+          component: api
+        annotations:
+          summary: Litoral Trace API is returning repeated 5xx responses
+          description: Three or more server-error responses were observed during the last five minutes.
+
+      - alert: LitoralTraceAuthAnomalySpike
+        expr: sum(increase(litoral_trace_auth_anomalies_total[5m])) >= 10
+        labels:
+          severity: warning
+          service: litoral-trace
+          component: authentication
+        annotations:
+          summary: Authentication anomaly rate is elevated
+          description: Ten or more rejected login or refresh responses occurred during the last five minutes.

--- a/monitoring/alertmanager.yml
+++ b/monitoring/alertmanager.yml
@@ -1,0 +1,16 @@
+route:
+  receiver: litoral-trace-ops
+  group_by:
+    - alertname
+    - service
+    - component
+  group_wait: 15s
+  group_interval: 5m
+  repeat_interval: 4h
+
+receivers:
+  - name: litoral-trace-ops
+    webhook_configs:
+      - url: http://ops-alert-receiver:9110/alertmanager
+        send_resolved: true
+        timeout: 10s

--- a/monitoring/prometheus.yml
+++ b/monitoring/prometheus.yml
@@ -1,0 +1,25 @@
+global:
+  scrape_interval: 60s
+  evaluation_interval: 30s
+
+rule_files:
+  - /etc/prometheus/alert_rules.yml
+
+alerting:
+  alertmanagers:
+    - static_configs:
+        - targets:
+            - alertmanager:9093
+
+scrape_configs:
+  - job_name: litoral-trace-app
+    metrics_path: /internal/metrics
+    static_configs:
+      - targets:
+          - app:8000
+
+  - job_name: litoral-trace-worker
+    metrics_path: /metrics
+    static_configs:
+      - targets:
+          - worker:9108

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -68,6 +68,12 @@ http {
         add_header X-Permitted-Cross-Domain-Policies "none" always;
         add_header Content-Security-Policy "default-src 'self'; base-uri 'self'; form-action 'self'; frame-ancestors 'self'; object-src 'none'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self' data:; connect-src 'self'; media-src 'self'; worker-src 'self' blob:; manifest-src 'self'; upgrade-insecure-requests" always;
 
+        # Metrics are scraped directly over the private Docker network.
+        # Never proxy the internal operational surface to the public Internet.
+        location ^~ /internal/ {
+            return 404;
+        }
+
         location /docs {
             proxy_pass http://fastapi_backend/docs;
             proxy_set_header Host $host;

--- a/src/litoral_trace/observability/api_metrics.py
+++ b/src/litoral_trace/observability/api_metrics.py
@@ -1,0 +1,155 @@
+"""Low-cardinality Prometheus metrics for the FastAPI/web runtime."""
+from __future__ import annotations
+
+import time
+from typing import Any
+
+from prometheus_client import (
+    CollectorRegistry,
+    Counter,
+    Gauge,
+    Histogram,
+    generate_latest,
+)
+
+
+_AUTH_STATUS_OUTCOMES = {
+    400: "bad_request",
+    401: "unauthorized",
+    403: "forbidden",
+    429: "rate_limited",
+}
+
+
+def classify_http_surface(path: str) -> str:
+    """Map request paths into a bounded label set."""
+    normalized = (path or "/").split("?", 1)[0]
+    if normalized in {"/login", "/api/v1/auth/login"}:
+        return "auth_login"
+    if normalized == "/api/v1/auth/refresh":
+        return "auth_refresh"
+    if normalized.startswith("/api/v1/auth/"):
+        return "auth"
+    if normalized in {"/health", "/ready"}:
+        return "infra"
+    if normalized.startswith("/internal/"):
+        return "internal"
+    if normalized.startswith("/api/v1/"):
+        return "api"
+    if normalized.startswith("/static/"):
+        return "static"
+    return "web"
+
+
+def status_class(status_code: int) -> str:
+    normalized = max(100, min(int(status_code), 599))
+    return f"{normalized // 100}xx"
+
+
+class ApiMetrics:
+    """Process-local API metrics with bounded, non-business labels."""
+
+    def __init__(self, registry: CollectorRegistry | None = None) -> None:
+        self.registry = registry or CollectorRegistry()
+        self.http_requests = Counter(
+            "litoral_trace_http_requests_total",
+            "HTTP responses emitted by the Litoral Trace runtime.",
+            ("method", "surface", "status_class"),
+            registry=self.registry,
+        )
+        self.http_request_duration = Histogram(
+            "litoral_trace_http_request_duration_seconds",
+            "HTTP request duration by bounded surface.",
+            ("method", "surface"),
+            buckets=(0.01, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10, 30),
+            registry=self.registry,
+        )
+        self.auth_anomalies = Counter(
+            "litoral_trace_auth_anomalies_total",
+            "Authentication responses requiring operator attention.",
+            ("flow", "outcome"),
+            registry=self.registry,
+        )
+        self.dependency_ready = Gauge(
+            "litoral_trace_dependency_ready",
+            "Required runtime dependency readiness (1 ready, 0 unavailable).",
+            ("dependency",),
+            registry=self.registry,
+        )
+        self.set_dependency_readiness(database=False, vault=False)
+
+    def record_http_response(
+        self,
+        *,
+        method: str,
+        path: str,
+        status_code: int,
+        duration_seconds: float,
+    ) -> None:
+        normalized_method = (method or "UNKNOWN").upper()
+        surface = classify_http_surface(path)
+        normalized_status_class = status_class(status_code)
+        self.http_requests.labels(
+            method=normalized_method,
+            surface=surface,
+            status_class=normalized_status_class,
+        ).inc()
+        self.http_request_duration.labels(
+            method=normalized_method,
+            surface=surface,
+        ).observe(max(float(duration_seconds), 0.0))
+        outcome = _AUTH_STATUS_OUTCOMES.get(int(status_code))
+        if outcome and surface in {"auth_login", "auth_refresh"}:
+            flow = "login" if surface == "auth_login" else "refresh"
+            self.auth_anomalies.labels(flow=flow, outcome=outcome).inc()
+
+    def set_dependency_readiness(self, *, database: bool, vault: bool) -> None:
+        self.dependency_ready.labels(dependency="database").set(
+            1.0 if database else 0.0
+        )
+        self.dependency_ready.labels(dependency="vault").set(
+            1.0 if vault else 0.0
+        )
+
+    def render(self) -> bytes:
+        return generate_latest(self.registry)
+
+
+api_metrics = ApiMetrics()
+
+
+class ApiMetricsMiddleware:
+    """ASGI middleware that records responses without raw URL labels."""
+
+    def __init__(self, app: Any, metrics: ApiMetrics | None = None) -> None:
+        self.app = app
+        self.metrics = metrics or api_metrics
+
+    async def __call__(self, scope, receive, send) -> None:
+        if scope.get("type") != "http":
+            await self.app(scope, receive, send)
+            return
+        started = time.perf_counter()
+        response_status = 500
+        response_started = False
+
+        async def _send(message) -> None:
+            nonlocal response_status, response_started
+            if message.get("type") == "http.response.start":
+                response_status = int(message.get("status", 500))
+                response_started = True
+            await send(message)
+
+        try:
+            await self.app(scope, receive, _send)
+        except Exception:
+            if not response_started:
+                response_status = 500
+            raise
+        finally:
+            self.metrics.record_http_response(
+                method=str(scope.get("method", "UNKNOWN")),
+                path=str(scope.get("path", "/")),
+                status_code=response_status,
+                duration_seconds=time.perf_counter() - started,
+            )

--- a/src/litoral_trace/observability/ops_alert_receiver.py
+++ b/src/litoral_trace/observability/ops_alert_receiver.py
@@ -1,0 +1,206 @@
+"""Internal Alertmanager webhook receiver that opens/closes GitHub incidents."""
+from __future__ import annotations
+
+import json
+import os
+import re
+from typing import Any
+from urllib import error as urlerror
+from urllib import request as urlrequest
+
+from fastapi import FastAPI, HTTPException, status
+from pydantic import BaseModel
+
+
+_REPOSITORY_RE = re.compile(r"^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$")
+_ALLOWED_LABEL_KEYS = ("alertname", "severity", "service", "component")
+_ALLOWED_ANNOTATION_KEYS = ("summary", "description")
+_MARKER_PREFIX = "<!-- litoral-trace-alert:"
+
+
+class AlertmanagerAlert(BaseModel):
+    status: str
+    labels: dict[str, str] = {}
+    annotations: dict[str, str] = {}
+    startsAt: str | None = None
+    endsAt: str | None = None
+    fingerprint: str | None = None
+
+
+class AlertmanagerPayload(BaseModel):
+    status: str
+    alerts: list[AlertmanagerAlert]
+
+
+def _clean_text(value: Any, *, limit: int = 500) -> str:
+    normalized = str(value or "").replace("\r", " ").replace("\n", " ").strip()
+    return normalized[:limit]
+
+
+def _config() -> tuple[str, str, str | None]:
+    token = os.environ.get("OPS_ALERT_GITHUB_TOKEN", "").strip()
+    repository = os.environ.get("OPS_ALERT_GITHUB_REPOSITORY", "").strip()
+    assignee = os.environ.get("OPS_ALERT_GITHUB_ASSIGNEE", "").strip() or None
+    if not token:
+        raise RuntimeError("OPS_ALERT_GITHUB_TOKEN is required.")
+    if not _REPOSITORY_RE.fullmatch(repository):
+        raise RuntimeError("OPS_ALERT_GITHUB_REPOSITORY must be owner/repository.")
+    return token, repository, assignee
+
+
+def _github_request(
+    method: str,
+    path: str,
+    *,
+    token: str,
+    payload: dict[str, Any] | None = None,
+) -> Any:
+    url = f"https://api.github.com{path}"
+    data = None if payload is None else json.dumps(payload).encode("utf-8")
+    request = urlrequest.Request(
+        url,
+        data=data,
+        method=method,
+        headers={
+            "Accept": "application/vnd.github+json",
+            "Authorization": f"Bearer {token}",
+            "Content-Type": "application/json",
+            "User-Agent": "litoral-trace-ops-alert-receiver",
+            "X-GitHub-Api-Version": "2022-11-28",
+        },
+    )
+    try:
+        with urlrequest.urlopen(request, timeout=10) as response:
+            raw = response.read()
+    except (urlerror.URLError, TimeoutError, OSError) as exc:
+        raise RuntimeError("GitHub incident delivery failed.") from exc
+    if not raw:
+        return None
+    return json.loads(raw.decode("utf-8"))
+
+
+def _marker(alert: AlertmanagerAlert) -> str:
+    fingerprint = _clean_text(alert.fingerprint or "missing", limit=128)
+    return f"{_MARKER_PREFIX}{fingerprint} -->"
+
+
+def _find_open_issue(
+    *,
+    token: str,
+    repository: str,
+    marker: str,
+) -> dict[str, Any] | None:
+    issues = _github_request(
+        "GET",
+        f"/repos/{repository}/issues?state=open&per_page=100",
+        token=token,
+    )
+    for issue in issues or []:
+        if "pull_request" in issue:
+            continue
+        if marker in str(issue.get("body") or ""):
+            return issue
+    return None
+
+
+def _issue_title(alert: AlertmanagerAlert) -> str:
+    alertname = _clean_text(alert.labels.get("alertname", "unknown"), limit=80)
+    severity = _clean_text(alert.labels.get("severity", "warning"), limit=20).upper()
+    return f"[OPS] {severity} {alertname}"[:120]
+
+
+def _issue_body(alert: AlertmanagerAlert) -> str:
+    labels = {
+        key: _clean_text(alert.labels.get(key, ""), limit=120)
+        for key in _ALLOWED_LABEL_KEYS
+        if alert.labels.get(key)
+    }
+    annotations = {
+        key: _clean_text(alert.annotations.get(key, ""), limit=500)
+        for key in _ALLOWED_ANNOTATION_KEYS
+        if alert.annotations.get(key)
+    }
+    lines = [
+        _marker(alert),
+        "Automated Litoral Trace operational alert.",
+        "",
+        f"Status: {_clean_text(alert.status, limit=20)}",
+    ]
+    if alert.startsAt:
+        lines.append(f"Started: {_clean_text(alert.startsAt, limit=80)}")
+    for key, value in labels.items():
+        lines.append(f"{key}: {value}")
+    for key, value in annotations.items():
+        lines.append(f"{key}: {value}")
+    lines.append("")
+    lines.append("No credentials, customer identifiers, URLs, or raw payloads are included.")
+    return "\n".join(lines)
+
+
+def reconcile_alert(alert: AlertmanagerAlert) -> str:
+    token, repository, assignee = _config()
+    marker = _marker(alert)
+    existing = _find_open_issue(token=token, repository=repository, marker=marker)
+    is_firing = alert.status.strip().lower() == "firing"
+
+    if is_firing and existing is None:
+        payload: dict[str, Any] = {
+            "title": _issue_title(alert),
+            "body": _issue_body(alert),
+        }
+        if assignee:
+            payload["assignees"] = [assignee]
+        _github_request(
+            "POST",
+            f"/repos/{repository}/issues",
+            token=token,
+            payload=payload,
+        )
+        return "opened"
+
+    if not is_firing and existing is not None:
+        issue_number = int(existing["number"])
+        _github_request(
+            "PATCH",
+            f"/repos/{repository}/issues/{issue_number}",
+            token=token,
+            payload={"state": "closed", "state_reason": "completed"},
+        )
+        return "closed"
+
+    return "unchanged"
+
+
+app = FastAPI(
+    title="Litoral Trace Ops Alert Receiver",
+    docs_url=None,
+    redoc_url=None,
+    openapi_url=None,
+)
+
+
+@app.get("/health", include_in_schema=False)
+async def health() -> dict[str, str]:
+    try:
+        _config()
+    except RuntimeError:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="unavailable",
+        ) from None
+    return {"status": "ready"}
+
+
+@app.post("/alertmanager", include_in_schema=False)
+async def receive_alertmanager(payload: AlertmanagerPayload) -> dict[str, int]:
+    counters = {"opened": 0, "closed": 0, "unchanged": 0}
+    try:
+        for alert in payload.alerts:
+            result = reconcile_alert(alert)
+            counters[result] += 1
+    except RuntimeError:
+        raise HTTPException(
+            status_code=status.HTTP_502_BAD_GATEWAY,
+            detail="incident delivery failed",
+        ) from None
+    return counters

--- a/tests/test_v1_observability_unittest.py
+++ b/tests/test_v1_observability_unittest.py
@@ -1,0 +1,235 @@
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+from prometheus_client import CollectorRegistry, generate_latest
+
+import main as main_module
+from litoral_trace.observability.api_metrics import (
+    ApiMetrics,
+    classify_http_surface,
+)
+from litoral_trace.observability.ops_alert_receiver import (
+    AlertmanagerAlert,
+    reconcile_alert,
+)
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+class _Session:
+    def __init__(self, *, fail: bool = False):
+        self.fail = fail
+        self.rollbacks = 0
+        self.closes = 0
+
+    def execute(self, _statement):
+        if self.fail:
+            raise RuntimeError("private-postgres-detail")
+        return object()
+
+    def rollback(self):
+        self.rollbacks += 1
+
+    def close(self):
+        self.closes += 1
+
+
+def _sample(registry, name, labels=None):
+    return registry.get_sample_value(name, labels or {})
+
+
+def test_http_metrics_use_bounded_surfaces_and_record_5xx():
+    registry = CollectorRegistry()
+    metrics = ApiMetrics(registry)
+
+    metrics.record_http_response(
+        method="GET",
+        path="/api/v1/lotes/998877?token=never-label-this",
+        status_code=500,
+        duration_seconds=0.25,
+    )
+
+    assert classify_http_surface("/api/v1/lotes/998877") == "api"
+    assert _sample(
+        registry,
+        "litoral_trace_http_requests_total",
+        {"method": "GET", "surface": "api", "status_class": "5xx"},
+    ) == 1
+    rendered = generate_latest(registry)
+    assert b"998877" not in rendered
+    assert b"never-label-this" not in rendered
+
+
+def test_auth_anomaly_metric_is_bounded_by_flow_and_outcome():
+    registry = CollectorRegistry()
+    metrics = ApiMetrics(registry)
+
+    metrics.record_http_response(
+        method="POST",
+        path="/api/v1/auth/login",
+        status_code=401,
+        duration_seconds=0.01,
+    )
+    metrics.record_http_response(
+        method="POST",
+        path="/api/v1/auth/refresh",
+        status_code=403,
+        duration_seconds=0.01,
+    )
+
+    assert _sample(
+        registry,
+        "litoral_trace_auth_anomalies_total",
+        {"flow": "login", "outcome": "unauthorized"},
+    ) == 1
+    assert _sample(
+        registry,
+        "litoral_trace_auth_anomalies_total",
+        {"flow": "refresh", "outcome": "forbidden"},
+    ) == 1
+
+
+def test_dependency_metrics_report_database_and_vault_independently():
+    registry = CollectorRegistry()
+    metrics = ApiMetrics(registry)
+    metrics.set_dependency_readiness(database=True, vault=False)
+
+    assert _sample(
+        registry,
+        "litoral_trace_dependency_ready",
+        {"dependency": "database"},
+    ) == 1
+    assert _sample(
+        registry,
+        "litoral_trace_dependency_ready",
+        {"dependency": "vault"},
+    ) == 0
+
+
+def test_internal_metrics_refreshes_dependency_status(monkeypatch):
+    session = _Session()
+    monkeypatch.setattr(main_module, "get_db_session", lambda: session)
+    monkeypatch.setattr(main_module, "is_vault_storage_ready", lambda: True)
+
+    response = asyncio.run(main_module.internal_metrics())
+
+    assert response.status_code == 200
+    assert b'litoral_trace_dependency_ready{dependency="database"} 1.0' in response.body
+    assert b'litoral_trace_dependency_ready{dependency="vault"} 1.0' in response.body
+    assert session.closes == 1
+
+
+def test_ready_fails_when_vault_is_unavailable_even_if_database_is_ready(monkeypatch):
+    session = _Session()
+    monkeypatch.setattr(main_module, "get_db_session", lambda: session)
+    monkeypatch.setattr(main_module, "is_vault_storage_ready", lambda: False)
+
+    response = asyncio.run(main_module.readiness_check())
+
+    assert response.status_code == 503
+    assert session.closes == 1
+
+
+def test_alert_receiver_opens_sanitized_github_incident(monkeypatch):
+    monkeypatch.setenv("OPS_ALERT_GITHUB_TOKEN", "private-token")
+    monkeypatch.setenv("OPS_ALERT_GITHUB_REPOSITORY", "Jose34345/litoral_trace")
+    monkeypatch.setenv("OPS_ALERT_GITHUB_ASSIGNEE", "Jose34345")
+    monkeypatch.setattr(
+        "litoral_trace.observability.ops_alert_receiver._find_open_issue",
+        lambda **_kwargs: None,
+    )
+    calls = []
+
+    def _request(method, path, *, token, payload=None):
+        calls.append((method, path, token, payload))
+        return {"number": 77}
+
+    monkeypatch.setattr(
+        "litoral_trace.observability.ops_alert_receiver._github_request",
+        _request,
+    )
+
+    result = reconcile_alert(
+        AlertmanagerAlert(
+            status="firing",
+            fingerprint="abc123",
+            labels={
+                "alertname": "LitoralTraceVaultUnavailable",
+                "severity": "critical",
+                "service": "litoral-trace",
+                "component": "vault",
+            },
+            annotations={
+                "summary": "Vault unavailable",
+                "description": "Private storage readiness failed.",
+            },
+        )
+    )
+
+    assert result == "opened"
+    assert calls[0][0] == "POST"
+    assert calls[0][1] == "/repos/Jose34345/litoral_trace/issues"
+    rendered_payload = str(calls[0][3])
+    assert "private-token" not in rendered_payload
+    assert "abc123" in rendered_payload
+
+
+def test_alert_receiver_closes_matching_incident(monkeypatch):
+    monkeypatch.setenv("OPS_ALERT_GITHUB_TOKEN", "private-token")
+    monkeypatch.setenv("OPS_ALERT_GITHUB_REPOSITORY", "Jose34345/litoral_trace")
+    monkeypatch.setattr(
+        "litoral_trace.observability.ops_alert_receiver._find_open_issue",
+        lambda **_kwargs: {"number": 88, "body": "marker"},
+    )
+    calls = []
+
+    def _request(method, path, *, token, payload=None):
+        calls.append((method, path, token, payload))
+        return {}
+
+    monkeypatch.setattr(
+        "litoral_trace.observability.ops_alert_receiver._github_request",
+        _request,
+    )
+
+    result = reconcile_alert(
+        AlertmanagerAlert(
+            status="resolved",
+            fingerprint="abc123",
+            labels={"alertname": "LitoralTraceApi5xxSpike"},
+        )
+    )
+
+    assert result == "closed"
+    assert calls[0][0] == "PATCH"
+    assert calls[0][1].endswith("/issues/88")
+    assert calls[0][3]["state"] == "closed"
+
+
+def test_monitoring_contract_contains_all_v1_alert_families():
+    rules = (ROOT / "monitoring" / "alert_rules.yml").read_text(encoding="utf-8")
+    required_alerts = {
+        "LitoralTraceReadinessUnavailable",
+        "LitoralTraceVaultUnavailable",
+        "LitoralTraceSatelliteQueueBacklog",
+        "LitoralTraceSatelliteStaleJobs",
+        "LitoralTraceSatelliteHeartbeatFailure",
+        "LitoralTraceSatelliteLeaseLost",
+        "LitoralTraceApi5xxSpike",
+        "LitoralTraceAuthAnomalySpike",
+    }
+    for alert_name in required_alerts:
+        assert f"alert: {alert_name}" in rules
+
+
+def test_public_nginx_ingress_blocks_internal_metrics():
+    nginx = (ROOT / "nginx" / "nginx.conf").read_text(encoding="utf-8")
+    assert "location ^~ /internal/" in nginx
+    assert "return 404;" in nginx
+
+    prometheus = (ROOT / "monitoring" / "prometheus.yml").read_text(encoding="utf-8")
+    assert "app:8000" in prometheus
+    assert "metrics_path: /internal/metrics" in prometheus


### PR DESCRIPTION
V1 closure observability tranche for gates 13-20.

Adds:
- low-cardinality FastAPI Prometheus metrics for 5xx/auth anomalies
- separate database/Vault readiness gauges
- private `/internal/metrics` surface blocked at Nginx public ingress
- Prometheus 3.13.1 + Alertmanager 0.33.1 on the private Docker network
- alert rules for readiness, Vault, worker availability, queue backlog/stale jobs, heartbeat/lease failures, API 5xx and auth anomalies
- internal Alertmanager receiver that opens/closes sanitized GitHub incident issues
- CI validation with promtool/amtool
- unit coverage for metrics, readiness, incident reconciliation and public ingress isolation

No production deployment is performed by this PR. Runtime incident delivery requires a fine-grained `OPS_ALERT_GITHUB_TOKEN` stored outside Git with only Metadata read + Issues read/write on the selected repository.