### PR TITLE
docs(commercial): add V1 privacy, terms, and support pack

### DIFF
--- a/commercial/PRIVACY_NOTICE_V1.md
+++ b/commercial/PRIVACY_NOTICE_V1.md
@@ -1,0 +1,97 @@
+# Litoral Trace V1 — Aviso de Privacidad
+
+**Versión:** 1.0  
+**Fecha de vigencia:** 19 de agosto de 2026  
+**Ámbito:** demos, pilotos controlados y prestación B2B de Litoral Trace.
+
+## 1. Responsable y contacto
+
+Litoral Trace es operado por **José David Lezcano**, Argentina, como responsable del tratamiento correspondiente a la cuenta, relación comercial y operación de la plataforma cuando actúa como responsable.
+
+Contacto para privacidad y ejercicio de derechos: **comercial@litoraltrace.com**.
+
+**Domicilio del responsable:** deberá consignarse en la propuesta, orden de servicio o instrumento contractual aplicable antes del alta de un cliente de producción. Este documento no inventa ni sustituye ese dato contractual.
+
+Cuando un cliente carga información de terceros en su tenant para sus propios fines, el cliente puede actuar como responsable de esos datos y Litoral Trace como proveedor/encargado de tratamiento, según corresponda a la relación y al contrato aplicable.
+
+## 2. Qué datos tratamos
+
+Según el uso del servicio, podemos tratar:
+
+- datos de cuenta y contacto: nombre, correo, organización, rol y credenciales derivadas/identificadores de autenticación;
+- datos operativos: identificadores de tenant, lotes, productores/proveedores identificados por el cliente, geolocalización y geometrías, documentos y evidencia cargada;
+- datos técnicos y de seguridad: IP, user agent cuando corresponda, timestamps, eventos de autenticación, auditoría, errores y métricas operativas;
+- datos comerciales: plan, piloto, comunicaciones de soporte, onboarding y facturación cuando corresponda;
+- resultados derivados: análisis geoespaciales/satelitales, estados de workflow, hashes, metadatos y trazas de evidencia.
+
+Litoral Trace no está diseñado para recolectar datos sensibles. Los clientes no deben cargar datos sensibles salvo que exista una necesidad legítima, base jurídica y acuerdo específico para ese tratamiento.
+
+## 3. Finalidades
+
+Tratamos los datos necesarios para:
+
+- crear y administrar cuentas y organizaciones;
+- autenticar usuarios y aplicar controles de acceso y aislamiento por tenant;
+- ejecutar funcionalidades de trazabilidad, geolocalización, evidencia, Vault, análisis satelital y reportes;
+- mantener registros de auditoría y seguridad;
+- prestar soporte, investigar incidentes y prevenir abuso;
+- cumplir obligaciones contractuales, regulatorias o legales aplicables;
+- mejorar confiabilidad y operación del servicio mediante métricas técnicas y diagnósticos controlados.
+
+No vendemos datos personales ni los usamos para publicidad comportamental de terceros.
+
+## 4. Base del tratamiento
+
+En el contexto B2B, el tratamiento puede ser necesario para celebrar o ejecutar la relación contractual, atender solicitudes precontractuales, cumplir obligaciones legales, proteger la seguridad de la plataforma o responder a instrucciones documentadas del cliente. Cuando la ley exija consentimiento, se solicitará de forma apropiada.
+
+## 5. Proveedores y destinatarios
+
+Litoral Trace utiliza proveedores de infraestructura y servicios técnicos necesarios para operar la plataforma, que pueden incluir alojamiento de aplicación, base de datos, almacenamiento de objetos/evidencia, observabilidad, repositorios de software y servicios geoespaciales/satelitales.
+
+El acceso de proveedores debe limitarse a lo necesario para prestar el servicio. No se debe compartir material sensible por canales de soporte ordinarios cuando exista un canal seguro previsto para provisioning, Vault o incidentes.
+
+La lista material de subprocesadores/proveedores aplicable a un cliente de producción debe quedar documentada en el paquete contractual o de seguridad vigente.
+
+## 6. Transferencias y ubicación
+
+La infraestructura técnica puede involucrar proveedores que procesen o almacenen información fuera de Argentina. Antes de un cliente de producción, las transferencias internacionales relevantes deben documentarse y gestionarse conforme a la normativa aplicable y a los términos acordados con el cliente.
+
+## 7. Conservación
+
+Los datos se conservan mientras sean necesarios para prestar el servicio, cumplir la relación contractual, mantener evidencia y auditoría requeridas, resolver disputas o atender obligaciones legales y de seguridad.
+
+Cuando corresponda eliminar información, la eliminación se ejecutará de acuerdo con los ciclos técnicos de retención, backup y recuperación aplicables. Los períodos específicos comprometidos con un cliente deben constar en la propuesta, DPA/anexo de datos o contrato aplicable.
+
+## 8. Seguridad
+
+Litoral Trace aplica controles técnicos y operativos orientados a reducir riesgo, incluyendo autenticación, autorización por tenant, registros de auditoría, controles de acceso a evidencia, cifrado provisto por la infraestructura aplicable, monitoreo, alertas y procesos de backup/recuperación cuando están habilitados.
+
+Ningún sistema puede prometer riesgo cero. Los controles y límites vigentes se describen también en `SECURITY_DATA_BOUNDARY_V1.md` y en la documentación contractual aplicable.
+
+## 9. Derechos de los titulares
+
+Los titulares pueden ejercer los derechos que les correspondan conforme a la Ley argentina 25.326 y demás normativa aplicable, incluyendo acceso, rectificación, actualización o supresión cuando corresponda.
+
+Las solicitudes deben enviarse a **comercial@litoraltrace.com** con información suficiente para verificar identidad y localizar los datos sin solicitar información excesiva.
+
+Cuando Litoral Trace actúe únicamente por cuenta de un cliente, podremos remitir la solicitud al cliente responsable y asistirlo conforme al contrato.
+
+## 10. Incidentes de privacidad o seguridad
+
+Una sospecha de acceso no autorizado, exposición, pérdida o uso indebido debe reportarse a **comercial@litoraltrace.com** indicando únicamente la información necesaria para iniciar triage. No deben incluirse secretos, contraseñas, tokens o datasets completos en un correo inicial.
+
+El incidente se manejará conforme al proceso de soporte/escalación y los runbooks técnicos aplicables.
+
+## 11. EUDR y alcance funcional
+
+Litoral Trace ayuda a organizar, procesar y reconstruir evidencia operativa relevante para flujos de trazabilidad y debida diligencia. **No certifica por sí solo cumplimiento legal, no sustituye asesoramiento jurídico y no garantiza que una operación sea aceptada por una autoridad o contraparte.**
+
+El cliente conserva responsabilidad sobre la exactitud, legitimidad y suficiencia de los datos que aporta y sobre sus propias obligaciones regulatorias.
+
+## 12. Cambios
+
+Podemos actualizar este aviso cuando cambie el servicio, la infraestructura, la normativa o los contratos. Los cambios materiales aplicables a clientes activos deben comunicarse por un medio razonable y quedar versionados.
+
+## 13. Condición de cierre V1
+
+Este aviso queda apto para demo y piloto controlado. **Antes del primer cliente de producción debe completarse y validar el domicilio del responsable y cualquier información fiscal/contractual que deba figurar en el paquete legal aplicable.**

--- a/commercial/PRIVACY_NOTICE_V1.md
+++ b/commercial/PRIVACY_NOTICE_V1.md
@@ -10,7 +10,7 @@
 
 Contacto para privacidad y ejercicio de derechos: **comercial@litoraltrace.com**.
 
-**Domicilio físico del responsable:** debe informarse al titular de los datos antes o al momento de la recolección, y debe quedar consignado en la versión del aviso utilizada para producción o en el instrumento de onboarding/contratación que acompañe esa recolección. Este documento de repositorio no publica ni inventa un domicilio particular.
+**Domicilio físico del responsable:** el operador ya definió y proporcionó el domicilio físico que debe utilizarse para esta finalidad. Por tratarse de un domicilio particular, el repositorio público no publica su valor exacto. La versión del aviso entregada al titular o el instrumento de onboarding/contratación que acompañe la recolección debe consignar el domicilio completo **antes o al momento de recabar datos personales**.
 
 La identificación fiscal (CUIT) y el alta tributaria que correspondan se incorporarán al paquete comercial/fiscal antes de comenzar facturación. La falta actual de una persona jurídica no impide identificar al operador: el proveedor previsto para la etapa inicial es José David Lezcano como persona humana.
 
@@ -52,11 +52,15 @@ Litoral Trace utiliza proveedores de infraestructura y servicios técnicos neces
 
 El acceso de proveedores debe limitarse a lo necesario para prestar el servicio. No se debe compartir material sensible por canales de soporte ordinarios cuando exista un canal seguro previsto para provisioning, Vault o incidentes.
 
-La lista material de subprocesadores/proveedores aplicable a un cliente de producción debe quedar documentada en el paquete contractual o de seguridad vigente.
+La lista material de subprocesadores/proveedores aplicable a un entorno que trate datos personales debe mantenerse documentada junto con la finalidad, categoría de datos y ubicación/jurisdicción relevante del tratamiento.
 
 ## 6. Transferencias y ubicación
 
-La infraestructura técnica puede involucrar proveedores que procesen o almacenen información fuera de Argentina. Antes de un cliente de producción, las transferencias internacionales relevantes deben documentarse y gestionarse conforme a la normativa aplicable y a los términos acordados con el cliente.
+La infraestructura técnica puede involucrar proveedores que procesen o almacenen información fuera de Argentina.
+
+**Antes de habilitar cualquier demo, piloto o entorno de producción que trate datos personales**, debe revisarse la ubicación de los proveedores/subprocesadores y documentarse la base o garantía aplicable a cada transferencia internacional. Cuando el país de destino tenga un nivel de protección reconocido como adecuado por la autoridad argentina, se documentará esa condición; cuando no lo tenga, deberá existir una excepción legal o una garantía apropiada conforme al artículo 12 de la Ley 25.326 y su normativa complementaria, incluyendo cuando corresponda cláusulas contractuales de transferencia internacional.
+
+No debe iniciarse un entorno con datos personales reales si esta revisión de transferencias aplicable a sus proveedores materiales está pendiente.
 
 ## 7. Conservación
 
@@ -96,4 +100,4 @@ Podemos actualizar este aviso cuando cambie el servicio, la infraestructura, la 
 
 ## 13. Condición de cierre V1
 
-Este aviso queda como **plantilla operativa lista para completar**. Antes de utilizarlo como aviso final en una recolección de datos personales debe incorporarse el domicilio físico del responsable, porque la normativa argentina exige informar identidad y domicilio del responsable al titular. Antes de facturar también se incorporará la identificación fiscal que corresponda.
+Este aviso queda como **plantilla operativa V1 con responsable, canal, finalidades, derechos y requisitos de transferencias definidos**. El domicilio físico real ya fue proporcionado por el operador fuera del repositorio público y debe insertarse en la copia customer-facing antes o al momento de toda recolección de datos personales. Antes de facturar también se incorporará la identificación fiscal que corresponda.

--- a/commercial/PRIVACY_NOTICE_V1.md
+++ b/commercial/PRIVACY_NOTICE_V1.md
@@ -6,11 +6,13 @@
 
 ## 1. Responsable y contacto
 
-Litoral Trace es operado por **José David Lezcano**, Argentina, como responsable del tratamiento correspondiente a la cuenta, relación comercial y operación de la plataforma cuando actúa como responsable.
+**Litoral Trace es un nombre comercial operado por José David Lezcano, persona humana domiciliada en la República Argentina.** Mientras no exista una persona jurídica constituida que asuma expresamente la relación, José David Lezcano es el operador y, cuando corresponda, el responsable del tratamiento respecto de la cuenta, relación comercial y operación de la plataforma.
 
 Contacto para privacidad y ejercicio de derechos: **comercial@litoraltrace.com**.
 
-**Domicilio del responsable:** deberá consignarse en la propuesta, orden de servicio o instrumento contractual aplicable antes del alta de un cliente de producción. Este documento no inventa ni sustituye ese dato contractual.
+**Domicilio físico del responsable:** debe informarse al titular de los datos antes o al momento de la recolección, y debe quedar consignado en la versión del aviso utilizada para producción o en el instrumento de onboarding/contratación que acompañe esa recolección. Este documento de repositorio no publica ni inventa un domicilio particular.
+
+La identificación fiscal (CUIT) y el alta tributaria que correspondan se incorporarán al paquete comercial/fiscal antes de comenzar facturación. La falta actual de una persona jurídica no impide identificar al operador: el proveedor previsto para la etapa inicial es José David Lezcano como persona humana.
 
 Cuando un cliente carga información de terceros en su tenant para sus propios fines, el cliente puede actuar como responsable de esos datos y Litoral Trace como proveedor/encargado de tratamiento, según corresponda a la relación y al contrato aplicable.
 
@@ -94,4 +96,4 @@ Podemos actualizar este aviso cuando cambie el servicio, la infraestructura, la 
 
 ## 13. Condición de cierre V1
 
-Este aviso queda apto para demo y piloto controlado. **Antes del primer cliente de producción debe completarse y validar el domicilio del responsable y cualquier información fiscal/contractual que deba figurar en el paquete legal aplicable.**
+Este aviso queda como **plantilla operativa lista para completar**. Antes de utilizarlo como aviso final en una recolección de datos personales debe incorporarse el domicilio físico del responsable, porque la normativa argentina exige informar identidad y domicilio del responsable al titular. Antes de facturar también se incorporará la identificación fiscal que corresponda.

--- a/commercial/SUPPORT_ESCALATION_V1.md
+++ b/commercial/SUPPORT_ESCALATION_V1.md
@@ -1,10 +1,21 @@
 # Litoral Trace V1 — Support and Escalation
 
+**Versión operativa:** 1.0  
+**Vigencia:** 19 de agosto de 2026
+
 ## Customer contact route
 
-Primary customer support address: `comercial@litoraltrace.com` until a dedicated support mailbox or ticket portal is introduced.
+Primary customer support address: **`comercial@litoraltrace.com`**. This mailbox is active and is the documented customer-facing route until a dedicated support mailbox or ticket portal is introduced.
 
-A proposal may nominate an additional named contact, but customers should have one documented route rather than relying on personal chat accounts.
+Do not use personal chat accounts as the authoritative incident route. A proposal may nominate an additional contact, but customer incidents must remain traceable through the documented support channel.
+
+## Operational ownership and support window
+
+**Primary operator / escalation owner:** José David Lezcano.  
+**Business support window:** Monday to Friday, **09:00–18:00 Argentina time (ART, UTC-3)**, excluding Argentine national holidays unless a signed proposal states otherwise.  
+**After-hours:** no 24x7 customer SLA is included by default. Automated monitoring may detect technical incidents outside the business window; response outside the window is best-effort unless a signed production agreement explicitly provides another coverage model.
+
+The times below are internal service objectives for triage and communication, not contractual SLA guarantees unless repeated in a signed proposal or order of service.
 
 ## Severity model
 
@@ -12,40 +23,57 @@ A proposal may nominate an additional named contact, but customers should have o
 
 Examples: service broadly unavailable, confirmed tenant-isolation concern, unrecoverable production-data risk, or an incident requiring immediate containment.
 
-Target handling: prioritize containment and recovery above feature work, preserve operational evidence, and use the relevant runbook.
+Target handling: prioritize containment and recovery above feature work, preserve operational evidence, and use the relevant runbook. During the active support window, target initial acknowledgement within **2 business hours**.
 
 ### P1 — High
 
 Examples: a major customer workflow is blocked, repeated Vault/storage failure, failed scheduled backup, sustained Satellite worker failure, or authentication unavailable for a customer organization.
 
-Target handling: investigate with priority during the active support period and provide a workaround or next update when available.
+Target handling: investigate with priority during the active support period and provide a workaround or next update when available. Target initial acknowledgement within **4 business hours**.
 
 ### P2 — Normal
 
 Examples: isolated workflow defect with workaround, data-import question, UX issue, configuration request, or non-critical report problem.
 
-Target handling: queue for normal business support.
+Target handling: queue for normal business support. Target initial acknowledgement within **1 business day**.
 
 ### P3 — Request / Improvement
 
-Examples: new report, integration, UI improvement, or feature request. These are product requests rather than incidents and may be routed to the product backlog.
+Examples: new report, integration, UI improvement, or feature request. These are product requests rather than incidents and may be routed to the product backlog. Target acknowledgement within **3 business days**.
+
+## What to include in a support request
+
+Provide only the minimum material needed for triage:
+
+- organization/tenant name;
+- affected workflow or screen;
+- approximate timestamp and timezone;
+- user-visible error or job/reference ID if available;
+- business impact and whether a workaround exists.
+
+Do **not** send passwords, refresh tokens, API secrets, private keys, full database URLs, raw production dumps or unnecessary customer datasets by ordinary email.
 
 ## Pilot support expectation
 
-Unless a signed proposal states otherwise, controlled pilots do not carry a 24x7 SLA. The commercial proposal must state the available support window and any promised response targets before a customer relies on them.
+Controlled pilots do not carry a 24x7 SLA unless a signed proposal explicitly says otherwise. The business support window above is the default operating commitment for V1 pilots.
 
 ## Production support expectation
 
-Do not promise a production SLA that is not operationally staffed. For first production customers, any specific response-time or availability commitment must be written in the signed proposal and must match the monitoring, alerting, backup, and recovery capabilities actually in service.
+Do not promise a production SLA that is not operationally staffed. For first production customers, any specific response-time, availability, RPO/RTO or after-hours commitment must be written in the signed proposal and must match the monitoring, alerting, backup and recovery capabilities actually in service.
 
 ## Escalation path
 
-- customer-facing problem → primary support route
-- P1/P0 runtime issue → operator incident channel and operational runbook
-- suspected security/privacy event → preserve evidence, limit sensitive details, and escalate as a security incident
-- recovery requirement → Disaster Recovery Runbook
-- commercial or scope dispute → signed proposal and applicable Terms
+- customer-facing problem → `comercial@litoraltrace.com`;
+- P1/P0 runtime issue → primary operator + operational incident channel/runbook;
+- suspected security/privacy event → preserve evidence, limit sensitive details and escalate as a security incident;
+- recovery requirement → Disaster Recovery Runbook;
+- commercial or scope dispute → signed proposal and applicable Terms;
+- privacy/data-right request → privacy route documented in `PRIVACY_NOTICE_V1.md`.
 
 ## Information handling
 
-Sensitive operational material must use the approved secure provisioning or incident-handling route rather than ordinary support messages.
+Sensitive operational material must use the approved secure provisioning or incident-handling route rather than ordinary support messages. Public GitHub Issues must never contain customer secrets, credentials, private URLs, object keys or raw customer payloads.
+
+## Review trigger
+
+Revisit this document before the first production customer, whenever support staffing changes, or before committing to a contractual SLA beyond the default V1 window.

--- a/commercial/TERMS_OF_SERVICE_V1.md
+++ b/commercial/TERMS_OF_SERVICE_V1.md
@@ -1,0 +1,149 @@
+# Litoral Trace V1 — Términos de Servicio B2B
+
+**Versión:** 1.0  
+**Fecha de vigencia:** 19 de agosto de 2026  
+**Ámbito:** demos, pilotos controlados y prestación B2B de Litoral Trace.
+
+## 1. Proveedor y aceptación
+
+Litoral Trace es un servicio B2B operado por **José David Lezcano**, Argentina. Contacto comercial y operativo: **comercial@litoraltrace.com**.
+
+Estos Términos se incorporan a la propuesta, orden de servicio, piloto o acuerdo comercial que los referencie. Si existe contradicción, prevalece el documento firmado más específico para el cliente.
+
+El domicilio contractual, datos fiscales y condiciones de facturación aplicables deberán constar en la propuesta u orden de servicio antes de una contratación de producción.
+
+## 2. Servicio
+
+Litoral Trace ofrece herramientas de trazabilidad, gestión de lotes y geometrías, evidencia documental/Vault, workflows de importación, auditoría, análisis satelital/geoespacial, reportes y funciones relacionadas con procesos de debida diligencia y compliance.
+
+Las funciones exactas habilitadas dependen del plan, piloto y configuración acordados.
+
+## 3. No certificación ni asesoramiento jurídico
+
+Litoral Trace es una herramienta tecnológica y de gestión de evidencia. **No es un organismo certificador, autoridad competente, estudio jurídico ni garantía de cumplimiento regulatorio.**
+
+Los análisis, scores, estados, reportes y resultados de la plataforma son insumos operativos. El cliente debe realizar su propia revisión y conservar la responsabilidad por decisiones comerciales, regulatorias y declaraciones presentadas a autoridades o contrapartes.
+
+## 4. Cuenta, usuarios y seguridad
+
+El cliente debe:
+
+- proporcionar información de alta correcta y mantenerla actualizada;
+- autorizar únicamente a usuarios legítimos;
+- proteger credenciales y dispositivos de acceso;
+- notificar accesos sospechosos o incidentes sin demora indebida;
+- respetar límites de tenant, roles y controles de acceso;
+- no intentar eludir controles de seguridad, aislamiento, rate limits o auditoría.
+
+Cada organización es responsable por las acciones de sus usuarios autorizados, salvo cuando el incidente sea atribuible a una falla del servicio bajo control de Litoral Trace.
+
+## 5. Datos del cliente
+
+El cliente conserva titularidad y responsabilidad sobre los datos y documentos que aporta. Declara contar con facultades, bases jurídicas y permisos suficientes para cargarlos y procesarlos mediante el servicio.
+
+El cliente no debe cargar contenido ilícito, secretos ajenos sin autorización, malware ni datos sensibles innecesarios.
+
+Litoral Trace podrá procesar los datos únicamente para prestar, asegurar, mantener y soportar el servicio, cumplir instrucciones documentadas y obligaciones legales aplicables.
+
+## 6. Calidad de datos y resultados
+
+La precisión de los resultados depende, entre otros factores, de la calidad de geometrías, coordenadas, documentos, identificadores, fechas, fuentes externas y parámetros suministrados.
+
+Litoral Trace no garantiza que datos externos, imágenes satelitales, proveedores de terceros o sistemas regulatorios estén siempre disponibles, completos o libres de error.
+
+El cliente debe validar información material antes de utilizarla en una decisión regulatoria, contractual o financiera.
+
+## 7. Disponibilidad, soporte y cambios
+
+La ventana de soporte, severidades, escalación y compromisos aplicables se describen en `SUPPORT_ESCALATION_V1.md` y en la propuesta comercial.
+
+Salvo SLA firmado, demos y pilotos controlados no incluyen disponibilidad 24x7 ni tiempos de resolución garantizados.
+
+Podemos realizar mantenimiento, correcciones de seguridad y cambios razonables necesarios para operar el servicio. Los cambios materiales que reduzcan de forma sustancial una función contratada deberán manejarse conforme a la propuesta aplicable.
+
+## 8. Precios, facturación y piloto
+
+Los precios, moneda, impuestos, vencimientos, duración, límites de uso y condiciones de renovación se determinan en la propuesta, orden de servicio o plan contratado.
+
+Un piloto controlado tiene el alcance y duración definidos en su oferta. Su continuidad como servicio de producción requiere acuerdo expreso y no se presume automáticamente.
+
+## 9. Propiedad intelectual
+
+Litoral Trace y sus componentes propios, código, interfaces, documentación, modelos de datos, workflows y know-how permanecen bajo titularidad de su operador o licenciantes correspondientes.
+
+El cliente recibe un derecho limitado, no exclusivo, no transferible y revocable de uso durante la vigencia de la relación contratada.
+
+Los datos y documentos aportados por el cliente no se transfieren en propiedad a Litoral Trace.
+
+## 10. Uso aceptable
+
+Queda prohibido, salvo autorización expresa o derecho legal aplicable:
+
+- acceder a tenants o datos de terceros;
+- explotar vulnerabilidades o interferir con la disponibilidad;
+- extraer masivamente información fuera de las funciones contratadas;
+- usar el servicio para actividad ilícita o fraudulenta;
+- revender o sublicenciar el servicio como propio;
+- realizar ingeniería inversa orientada a copiar componentes propietarios.
+
+Las pruebas de seguridad autorizadas deben coordinarse previamente.
+
+## 11. Terceros y dependencias
+
+La plataforma puede depender de infraestructura, almacenamiento, bases de datos, observabilidad, servicios geoespaciales/satelitales y otros proveedores. Determinadas funciones pueden verse afectadas por cambios, límites o indisponibilidad de esos terceros.
+
+Litoral Trace procurará mantener alternativas y controles razonables acordes al nivel de servicio contratado, sin prometer independencia absoluta de terceros salvo compromiso escrito específico.
+
+## 12. Confidencialidad
+
+Cada parte debe proteger la información confidencial de la otra con un grado de cuidado razonable y utilizarla sólo para la relación acordada.
+
+No se considera confidencial información que sea pública sin incumplimiento, ya se conociera legítimamente, se reciba legítimamente de un tercero o deba revelarse por obligación legal.
+
+La información especialmente sensible debe intercambiarse por los canales seguros previstos y no por mensajes ordinarios cuando exista una alternativa segura disponible.
+
+## 13. Privacidad
+
+El tratamiento de datos personales se rige por el `PRIVACY_NOTICE_V1.md`, la documentación de seguridad/datos y, cuando corresponda, un DPA o anexo específico.
+
+## 14. Backups, recuperación y evidencia
+
+Las capacidades de backup, retención, recuperación y réplica dependen de la configuración operacional vigente y de los compromisos escritos del plan contratado.
+
+No debe interpretarse una demo o piloto como garantía de RPO/RTO, PITR o retención determinada salvo que esos objetivos estén expresamente documentados y habilitados.
+
+## 15. Suspensión
+
+Litoral Trace podrá suspender temporalmente el acceso cuando sea razonablemente necesario para contener un incidente de seguridad, prevenir daño, responder a uso ilícito o atender un incumplimiento material, procurando limitar la suspensión a lo necesario.
+
+Cuando sea razonable, se notificará al cliente y se indicarán las acciones requeridas para restablecer el servicio.
+
+## 16. Terminación y salida de datos
+
+La relación puede terminar conforme a la propuesta u orden de servicio. Tras la terminación, las partes coordinarán cualquier exportación o devolución de datos prevista contractualmente y la posterior eliminación conforme a la política de retención aplicable.
+
+La conservación exigida por ley, seguridad, auditoría o resolución de disputas puede continuar durante el período necesario.
+
+## 17. Responsabilidad
+
+Cada parte responde por sus propios actos y obligaciones conforme al contrato y la ley aplicable.
+
+Salvo dolo, culpa grave o responsabilidades que legalmente no puedan limitarse, cualquier límite monetario de responsabilidad, exclusión de daños indirectos o régimen de indemnidad debe quedar definido en la propuesta/contrato firmado. **Este documento no inventa un cap económico general que no haya sido negociado.**
+
+## 18. Fuerza mayor
+
+Ninguna parte será responsable por demoras causadas por eventos fuera de su control razonable en la medida en que adopte medidas razonables de mitigación y comunique el impacto cuando corresponda.
+
+## 19. Ley aplicable y jurisdicción
+
+Salvo acuerdo escrito diferente, la relación se rige por las leyes de la República Argentina.
+
+La jurisdicción y domicilio contractual específicos deberán quedar establecidos en la propuesta u orden de servicio antes de la contratación de producción. Para demos y pilotos no remunerados, cualquier controversia se intentará resolver primero de buena fe por el canal comercial.
+
+## 20. Modificaciones
+
+Los Términos pueden actualizarse para reflejar cambios legales, técnicos o comerciales. Los cambios materiales aplicables a un contrato vigente no desplazan condiciones firmadas más específicas sin el mecanismo de modificación previsto en ese contrato.
+
+## 21. Condición de cierre V1
+
+Estos Términos son aptos como base para demo y piloto controlado. **Antes del primer cliente de producción deben completarse los datos fiscales, domicilio contractual y jurisdicción específica del proveedor/cliente en la propuesta u orden de servicio firmada, y revisar el paquete con asesoramiento legal si el valor o riesgo contractual lo justifica.**

--- a/commercial/TERMS_OF_SERVICE_V1.md
+++ b/commercial/TERMS_OF_SERVICE_V1.md
@@ -6,11 +6,13 @@
 
 ## 1. Proveedor y aceptación
 
-Litoral Trace es un servicio B2B operado por **José David Lezcano**, Argentina. Contacto comercial y operativo: **comercial@litoraltrace.com**.
+**Litoral Trace es un nombre comercial operado por José David Lezcano, persona humana domiciliada en la República Argentina.** Mientras no exista una persona jurídica constituida que asuma expresamente la relación mediante un instrumento posterior, el proveedor contractual es José David Lezcano actuando en nombre propio bajo el nombre comercial Litoral Trace.
+
+Contacto comercial y operativo: **comercial@litoraltrace.com**.
 
 Estos Términos se incorporan a la propuesta, orden de servicio, piloto o acuerdo comercial que los referencie. Si existe contradicción, prevalece el documento firmado más específico para el cliente.
 
-El domicilio contractual, datos fiscales y condiciones de facturación aplicables deberán constar en la propuesta u orden de servicio antes de una contratación de producción.
+La identificación fiscal (CUIT), condición tributaria, domicilio contractual y condiciones de facturación aplicables deberán constar en la propuesta, factura u orden de servicio correspondiente antes de comenzar una prestación remunerada que requiera facturación. La ausencia actual de una sociedad no impide utilizar estos Términos como base contractual con una persona humana identificada.
 
 ## 2. Servicio
 
@@ -65,7 +67,7 @@ Podemos realizar mantenimiento, correcciones de seguridad y cambios razonables n
 
 Los precios, moneda, impuestos, vencimientos, duración, límites de uso y condiciones de renovación se determinan en la propuesta, orden de servicio o plan contratado.
 
-Un piloto controlado tiene el alcance y duración definidos en su oferta. Su continuidad como servicio de producción requiere acuerdo expreso y no se presume automáticamente.
+Antes de emitir la primera factura, el proveedor deberá contar con la inscripción tributaria y punto de venta que correspondan. Un piloto controlado tiene el alcance y duración definidos en su oferta. Su continuidad como servicio de producción requiere acuerdo expreso y no se presume automáticamente.
 
 ## 9. Propiedad intelectual
 
@@ -134,11 +136,13 @@ Salvo dolo, culpa grave o responsabilidades que legalmente no puedan limitarse, 
 
 Ninguna parte será responsable por demoras causadas por eventos fuera de su control razonable en la medida en que adopte medidas razonables de mitigación y comunique el impacto cuando corresponda.
 
-## 19. Ley aplicable y jurisdicción
+## 19. Ley aplicable, domicilio contractual y jurisdicción
 
 Salvo acuerdo escrito diferente, la relación se rige por las leyes de la República Argentina.
 
-La jurisdicción y domicilio contractual específicos deberán quedar establecidos en la propuesta u orden de servicio antes de la contratación de producción. Para demos y pilotos no remunerados, cualquier controversia se intentará resolver primero de buena fe por el canal comercial.
+Las partes pueden constituir en cada propuesta u orden de servicio un domicilio especial y, cuando corresponda, un domicilio electrónico para comunicaciones contractuales. La jurisdicción específica también deberá constar en ese instrumento antes de una contratación de producción remunerada.
+
+Para demos y pilotos no remunerados, cualquier controversia se intentará resolver primero de buena fe por el canal comercial.
 
 ## 20. Modificaciones
 
@@ -146,4 +150,4 @@ Los Términos pueden actualizarse para reflejar cambios legales, técnicos o com
 
 ## 21. Condición de cierre V1
 
-Estos Términos son aptos como base para demo y piloto controlado. **Antes del primer cliente de producción deben completarse los datos fiscales, domicilio contractual y jurisdicción específica del proveedor/cliente en la propuesta u orden de servicio firmada, y revisar el paquete con asesoramiento legal si el valor o riesgo contractual lo justifica.**
+Estos Términos quedan **operativamente completos como base contractual B2B para un proveedor persona humana**. Antes de la primera prestación remunerada se completarán la identificación fiscal y condición tributaria; y antes del primer contrato de producción se fijarán domicilio contractual y jurisdicción específica en la propuesta u orden de servicio firmada.


### PR DESCRIPTION
Adds the remaining V1 commercial/legal operating pack:

- `commercial/PRIVACY_NOTICE_V1.md`
- `commercial/TERMS_OF_SERVICE_V1.md`
- operationalizes `commercial/SUPPORT_ESCALATION_V1.md` with named owner, support window and escalation route.

Provider model is now explicit: **José David Lezcano, persona humana, operating under the commercial name Litoral Trace** until a future legal entity expressly assumes the relationship.

The Terms are operationally complete as a B2B base for that person-human model. CUIT/tax registration is treated as a pre-billing requirement rather than a prerequisite to identify the contractual provider.

The Privacy Notice intentionally does not invent or publish a private street address. Argentine Law 25.326 requires the controller's identity and domicile to be informed when personal data are collected, so the physical domicile remains an explicit finalization point before using the notice as the production-facing notice.

No runtime, database, production, infrastructure or deployment changes.