### PR TITLE
fix(frontend): keep pending satellite jobs non-failure

### DIFF
--- a/src/litoral_trace/templates/dashboard.html
+++ b/src/litoral_trace/templates/dashboard.html
@@ -401,7 +401,7 @@
             }
             await new Promise((resolve) => window.setTimeout(resolve, 2000));
         }
-        throw new Error('El trabajo sigue en proceso. Podés volver a consultar su estado más tarde.');
+        return { pending: true, job_id: jobId };
     }
 
     async function submitSatellite(event) {
@@ -438,6 +438,10 @@
             });
             satelliteResult.textContent = `Job #${job.job_id} aceptado. Esperando procesamiento…`;
             const result = await pollSatelliteJob(job.job_id);
+            if (result?.pending) {
+                satelliteResult.textContent = `Job #${job.job_id} sigue en proceso. Podés continuar usando la plataforma y consultar su estado más tarde.`;
+                return;
+            }
             const observations = Array.isArray(result.observations) ? result.observations : [];
             const latest = observations.length ? observations[observations.length - 1] : null;
             satelliteResult.replaceChildren();

--- a/tests/test_v1_demo_workflows_unittest.py
+++ b/tests/test_v1_demo_workflows_unittest.py
@@ -20,6 +20,14 @@ def test_dashboard_uses_real_tenant_lotes_and_satellite_api() -> None:
     assert "No emite un certificado oficial EUDR" in content
 
 
+def test_dashboard_treats_poll_timeout_as_pending_not_failure() -> None:
+    content = _read(DASHBOARD)
+
+    assert "return { pending: true, job_id: jobId };" in content
+    assert "sigue en proceso. Podés continuar usando la plataforma" in content
+    assert "throw new Error('El trabajo sigue en proceso." not in content
+
+
 def test_dashboard_does_not_present_fabricated_compliance_success() -> None:
     content = _read(DASHBOARD).lower()
 


### PR DESCRIPTION
Closes the remaining V1 Satellite dashboard UX ambiguity without changing backend semantics:

- polling-window exhaustion now returns a neutral pending state instead of throwing an error;
- the dashboard tells the operator that the job is still processing and can be checked later;
- genuine API errors and `failed` satellite jobs still use failure messaging;
- adds a regression contract so pending cannot silently regress into failure copy.

This is a UX/contract fix only. It does **not** claim Gate 28 complete: worker-backed same-environment `queued → running → succeeded → result` evidence is still required before that gate can turn green.

No production deployment, database mutation, worker configuration, or external GEE call is performed by this PR.