### PR TITLE
test(staging): prove browser-to-worker Satellite V1 flow

### DIFF
--- a/.github/workflows/v1-satellite-browser-staging-e2e.yml
+++ b/.github/workflows/v1-satellite-browser-staging-e2e.yml
@@ -40,6 +40,7 @@ jobs:
     env:
       ENVIRONMENT: development
       ENABLE_STAGING_BROWSER_E2E: "1"
+      PYTHONPATH: src
       JWT_SECRET_KEY: ci-only-browser-staging-jwt-secret-key-2026
       LITORAL_TRACE_BOOTSTRAP_SUPERADMIN_PASSWORD: CiBrowserStagingBootstrapPassword2026
       TEST_POSTGRES_MIGRATION_DATABASE_URL: postgresql+psycopg://postgres:ci_owner_password_2026@127.0.0.1:5432/litoral_trace_browser_staging
@@ -150,7 +151,10 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          python -m pytest -q \
+          # This staging gate intentionally bypasses tests/conftest.py because that
+          # global fixture forces ENVIRONMENT=test + SQLite for the ordinary suite.
+          # Here the real app must remain on the isolated PostgreSQL runtime above.
+          python -m pytest -q --noconftest \
             --junitxml=v1-satellite-browser-staging.xml \
             tests/test_v1_satellite_browser_staging_e2e.py
           python - <<'PY'

--- a/.github/workflows/v1-satellite-browser-staging-e2e.yml
+++ b/.github/workflows/v1-satellite-browser-staging-e2e.yml
@@ -1,0 +1,168 @@
+name: V1 Satellite Browser Staging E2E
+
+on:
+  pull_request:
+    branches:
+      - p2-enterprise-production
+  push:
+    branches:
+      - p2-enterprise-production
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: v1-satellite-browser-staging-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  satellite-browser-staging-e2e:
+    name: satellite-browser-staging-e2e
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    services:
+      postgres:
+        image: postgis/postgis:17-3.5
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: ci_owner_password_2026
+          POSTGRES_DB: litoral_trace_browser_staging
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U postgres -d litoral_trace_browser_staging"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 20
+
+    env:
+      ENVIRONMENT: development
+      ENABLE_STAGING_BROWSER_E2E: "1"
+      JWT_SECRET_KEY: ci-only-browser-staging-jwt-secret-key-2026
+      LITORAL_TRACE_BOOTSTRAP_SUPERADMIN_PASSWORD: CiBrowserStagingBootstrapPassword2026
+      TEST_POSTGRES_MIGRATION_DATABASE_URL: postgresql+psycopg://postgres:ci_owner_password_2026@127.0.0.1:5432/litoral_trace_browser_staging
+      MIGRATION_DATABASE_URL: postgresql+psycopg://postgres:ci_owner_password_2026@127.0.0.1:5432/litoral_trace_browser_staging
+      TEST_POSTGRES_DATABASE_URL: postgresql+psycopg://litoral_trace_app:ci_runtime_password_2026@127.0.0.1:5432/litoral_trace_browser_staging
+      DATABASE_URL: postgresql+psycopg://litoral_trace_app:ci_runtime_password_2026@127.0.0.1:5432/litoral_trace_browser_staging
+      TEST_POSTGRES_WORKER_DATABASE_URL: postgresql+psycopg://litoral_trace_worker_browser:ci_worker_password_2026@127.0.0.1:5432/litoral_trace_browser_staging
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: "pip"
+          cache-dependency-path: requirements.txt
+
+      - name: Install application and browser-test dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -r requirements.txt pytest alembic playwright
+
+      - name: Install Chromium for Playwright
+        run: python -m playwright install --with-deps chromium
+
+      - name: Provision isolated PostgreSQL principals
+        shell: bash
+        run: |
+          python - <<'PY'
+          import os
+          from sqlalchemy import create_engine
+
+          engine = create_engine(
+              os.environ["TEST_POSTGRES_MIGRATION_DATABASE_URL"],
+              isolation_level="AUTOCOMMIT",
+              pool_pre_ping=True,
+              hide_parameters=True,
+          )
+
+          statements = [
+              """
+              CREATE ROLE litoral_trace_app
+                LOGIN
+                PASSWORD 'ci_runtime_password_2026'
+                NOSUPERUSER
+                NOCREATEDB
+                NOCREATEROLE
+                NOINHERIT
+                NOBYPASSRLS
+              """,
+              """
+              CREATE ROLE litoral_trace_worker_browser
+                LOGIN
+                PASSWORD 'ci_worker_password_2026'
+                NOSUPERUSER
+                NOCREATEDB
+                NOCREATEROLE
+                INHERIT
+                NOBYPASSRLS
+              """,
+              "GRANT CONNECT ON DATABASE litoral_trace_browser_staging TO litoral_trace_app",
+              "GRANT CONNECT ON DATABASE litoral_trace_browser_staging TO litoral_trace_worker_browser",
+              "GRANT USAGE ON SCHEMA public TO litoral_trace_app",
+              "GRANT USAGE ON SCHEMA public TO litoral_trace_worker_browser",
+          ]
+
+          with engine.connect() as connection:
+              for statement in statements:
+                  connection.exec_driver_sql(statement)
+
+          engine.dispose()
+          PY
+
+      - name: Migrate isolated staging database to canonical head
+        run: python -m alembic upgrade head
+
+      - name: Provision reviewed runtime and worker capabilities
+        shell: bash
+        run: |
+          python - <<'PY'
+          import os
+          from sqlalchemy import create_engine
+
+          engine = create_engine(
+              os.environ["TEST_POSTGRES_MIGRATION_DATABASE_URL"],
+              isolation_level="AUTOCOMMIT",
+              pool_pre_ping=True,
+              hide_parameters=True,
+          )
+
+          with engine.connect() as connection:
+              connection.exec_driver_sql(
+                  "GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA public TO litoral_trace_app"
+              )
+              connection.exec_driver_sql(
+                  "GRANT USAGE, SELECT ON ALL SEQUENCES IN SCHEMA public TO litoral_trace_app"
+              )
+              connection.exec_driver_sql(
+                  "GRANT litoral_trace_worker_executor TO litoral_trace_worker_browser"
+              )
+
+          engine.dispose()
+          PY
+
+      - name: Browser acceptance - lot to durable satellite result
+        shell: bash
+        run: |
+          set -euo pipefail
+          python -m pytest -q \
+            --junitxml=v1-satellite-browser-staging.xml \
+            tests/test_v1_satellite_browser_staging_e2e.py
+          python - <<'PY'
+          import xml.etree.ElementTree as ET
+
+          root = ET.parse("v1-satellite-browser-staging.xml").getroot()
+          skipped = int(root.attrib.get("skipped", "0"))
+          failures = int(root.attrib.get("failures", "0"))
+          errors = int(root.attrib.get("errors", "0"))
+          if skipped or failures or errors:
+              raise SystemExit(
+                  "V1 satellite browser staging gate is fail-closed: "
+                  f"skipped={skipped}, failures={failures}, errors={errors}"
+              )
+          PY

--- a/.github/workflows/v1-satellite-browser-staging-e2e.yml
+++ b/.github/workflows/v1-satellite-browser-staging-e2e.yml
@@ -161,12 +161,21 @@ jobs:
           import xml.etree.ElementTree as ET
 
           root = ET.parse("v1-satellite-browser-staging.xml").getroot()
-          skipped = int(root.attrib.get("skipped", "0"))
-          failures = int(root.attrib.get("failures", "0"))
-          errors = int(root.attrib.get("errors", "0"))
-          if skipped or failures or errors:
+          suites = (
+              [root]
+              if root.tag == "testsuite"
+              else list(root.iter("testsuite"))
+          )
+          if not suites:
+              raise SystemExit("V1 satellite browser staging gate produced no testsuite.")
+
+          tests = sum(int(suite.attrib.get("tests", "0")) for suite in suites)
+          skipped = sum(int(suite.attrib.get("skipped", "0")) for suite in suites)
+          failures = sum(int(suite.attrib.get("failures", "0")) for suite in suites)
+          errors = sum(int(suite.attrib.get("errors", "0")) for suite in suites)
+          if tests != 1 or skipped or failures or errors:
               raise SystemExit(
                   "V1 satellite browser staging gate is fail-closed: "
-                  f"skipped={skipped}, failures={failures}, errors={errors}"
+                  f"tests={tests}, skipped={skipped}, failures={failures}, errors={errors}"
               )
           PY

--- a/tests/test_v1_satellite_browser_staging_e2e.py
+++ b/tests/test_v1_satellite_browser_staging_e2e.py
@@ -1,0 +1,431 @@
+from __future__ import annotations
+
+import os
+import socket
+import threading
+import time
+from datetime import date, datetime, timezone
+from uuid import uuid4
+
+import pytest
+
+
+def _truthy(value: str | None) -> bool:
+    return (value or "").strip().lower() in {"1", "true", "yes", "on"}
+
+
+ENABLED = _truthy(os.environ.get("ENABLE_STAGING_BROWSER_E2E"))
+RUNTIME_URL = os.environ.get("TEST_POSTGRES_DATABASE_URL")
+OWNER_URL = os.environ.get("TEST_POSTGRES_MIGRATION_DATABASE_URL")
+WORKER_URL = os.environ.get("TEST_POSTGRES_WORKER_DATABASE_URL")
+
+pytestmark = pytest.mark.skipif(
+    not (ENABLED and RUNTIME_URL and OWNER_URL and WORKER_URL),
+    reason=(
+        "V1 browser staging E2E requires explicit enablement plus isolated "
+        "PostgreSQL owner/runtime/worker URLs."
+    ),
+)
+
+
+def _free_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind(("127.0.0.1", 0))
+        return int(sock.getsockname()[1])
+
+
+def test_browser_lot_to_satellite_worker_success_result() -> None:
+    """Exercise browser -> API -> durable queue -> worker -> result in one stack.
+
+    The external Earth Engine dependency is replaced by a deterministic adapter;
+    queueing, PostgreSQL persistence, tenant access, worker leasing, result
+    persistence, browser polling, and final UI rendering remain real.
+    """
+
+    from playwright.sync_api import expect, sync_playwright
+    import uvicorn
+    from sqlalchemy import create_engine, text
+    from sqlalchemy.orm import sessionmaker
+
+    from litoral_trace.auth.passwords import hash_password
+    from litoral_trace.config.settings import normalize_database_url
+    from litoral_trace.db.engine import reset_engine_state
+    from litoral_trace.services.satellite_ndvi_processing import (
+        NdviObservationRecord,
+        NormalizedNdviExecutionResult,
+    )
+    from litoral_trace.workers.satellite_worker import (
+        SatelliteWorker,
+        WorkerRunStatus,
+    )
+
+    reset_engine_state()
+
+    owner_engine = create_engine(
+        normalize_database_url(OWNER_URL or ""),
+        pool_pre_ping=True,
+        hide_parameters=True,
+    )
+    runtime_engine = create_engine(
+        normalize_database_url(RUNTIME_URL or ""),
+        pool_size=4,
+        max_overflow=0,
+        pool_pre_ping=True,
+        hide_parameters=True,
+    )
+    worker_engine = create_engine(
+        normalize_database_url(WORKER_URL or ""),
+        pool_size=2,
+        max_overflow=0,
+        pool_pre_ping=True,
+        hide_parameters=True,
+    )
+
+    suffix = uuid4().hex[:10]
+    username = f"v1_browser_{suffix}"
+    password = f"V1-Browser-{suffix}-A9!"
+    organization_id: int | None = None
+    user_id: int | None = None
+    license_id: int | None = None
+    lote_id: int | None = None
+    job_id: int | None = None
+
+    server = None
+    server_thread = None
+    worker_thread = None
+    worker_stop = threading.Event()
+    adapter_started = threading.Event()
+    adapter_release = threading.Event()
+    worker_errors: list[str] = []
+
+    def current_job() -> dict[str, object] | None:
+        if organization_id is None:
+            return None
+        with owner_engine.connect() as conn:
+            row = conn.execute(
+                text(
+                    """
+                    SELECT id, status, attempt_count
+                    FROM satellite_jobs
+                    WHERE organization_id = :organization_id
+                    ORDER BY id DESC
+                    LIMIT 1
+                    """
+                ),
+                {"organization_id": organization_id},
+            ).mappings().first()
+        return dict(row) if row is not None else None
+
+    def wait_for_job(timeout_seconds: float = 10.0) -> dict[str, object]:
+        deadline = time.monotonic() + timeout_seconds
+        while time.monotonic() < deadline:
+            snapshot = current_job()
+            if snapshot is not None:
+                return snapshot
+            time.sleep(0.05)
+        raise AssertionError("Satellite job was not queued by the browser workflow.")
+
+    class DeterministicNdviAdapter:
+        def execute(self, request):
+            adapter_started.set()
+            if not adapter_release.wait(timeout=15):
+                raise RuntimeError("Staging adapter release timed out.")
+            observation = NdviObservationRecord(
+                observation_date=date(2026, 8, 1),
+                ndvi_mean=0.7312,
+                ndvi_min=0.68,
+                ndvi_max=0.79,
+                ndvi_std=0.03,
+                scene_cloud_percentage=4.0,
+                aoi_cloud_percentage=1.5,
+                valid_pixel_count=321,
+                valid_pixel_percentage=98.5,
+                satellite="Sentinel-2",
+                collection="COPERNICUS/S2_SR_HARMONIZED",
+                geometry_hash=request.geometry_hash,
+                algorithm_version=request.algorithm_version,
+                processing_date=datetime.now(timezone.utc),
+            )
+            return NormalizedNdviExecutionResult(
+                geometry_hash=request.geometry_hash,
+                algorithm_version=request.algorithm_version,
+                observations=(observation,),
+            )
+
+    def run_worker() -> None:
+        worker = SatelliteWorker(
+            worker_id=f"v1-browser-worker-{suffix}",
+            heartbeat_seconds=60,
+            stale_recovery_interval_seconds=None,
+            claim_session_factory=sessionmaker(
+                bind=worker_engine,
+                autoflush=False,
+                autocommit=False,
+            ),
+            tenant_session_factory=sessionmaker(
+                bind=runtime_engine,
+                autoflush=False,
+                autocommit=False,
+            ),
+            gee_ndvi_adapter=DeterministicNdviAdapter(),
+            retry_base_seconds=30,
+            retry_max_seconds=900,
+        )
+        try:
+            while not worker_stop.is_set():
+                result = worker.run_once()
+                if result.status == WorkerRunStatus.IDLE:
+                    time.sleep(0.05)
+                elif result.status == WorkerRunStatus.SUCCEEDED:
+                    return
+        except Exception as exc:  # surfaced to the main assertion path
+            worker_errors.append(f"{type(exc).__name__}: {exc}")
+
+    try:
+        with owner_engine.begin() as conn:
+            organization_id = int(
+                conn.execute(
+                    text(
+                        """
+                        INSERT INTO organizations (name, slug, tax_id, tier, is_active)
+                        VALUES (:name, :slug, :tax_id, 'pro', true)
+                        RETURNING id
+                        """
+                    ),
+                    {
+                        "name": f"V1 Browser Staging {suffix}",
+                        "slug": f"v1-browser-staging-{suffix}",
+                        "tax_id": f"STG-{suffix}",
+                    },
+                ).scalar_one()
+            )
+            license_id = int(
+                conn.execute(
+                    text(
+                        """
+                        INSERT INTO licenses (
+                            organization_id, plan_type, max_lotes,
+                            max_volume_tons, max_batch_rows, is_active
+                        ) VALUES (
+                            :organization_id, 'pro', 100, 5000.0, 500, true
+                        ) RETURNING id
+                        """
+                    ),
+                    {"organization_id": organization_id},
+                ).scalar_one()
+            )
+            user_id = int(
+                conn.execute(
+                    text(
+                        """
+                        INSERT INTO users (
+                            organization_id, email, username, password_hash,
+                            role, full_name, is_active
+                        ) VALUES (
+                            :organization_id, :email, :username, :password_hash,
+                            'manager', :full_name, true
+                        ) RETURNING id
+                        """
+                    ),
+                    {
+                        "organization_id": organization_id,
+                        "email": f"{username}@example.invalid",
+                        "username": username,
+                        "password_hash": hash_password(password),
+                        "full_name": "V1 Browser Staging Operator",
+                    },
+                ).scalar_one()
+            )
+            lote_id = int(
+                conn.execute(
+                    text(
+                        """
+                        INSERT INTO lotes (
+                            organization_id, identificador, productor_id,
+                            producto_forestal, hectareas, latitud, longitud,
+                            polygon_wkt, estatus, volumen_ingresado_ton,
+                            volumen_exportar_ton
+                        ) VALUES (
+                            :organization_id, :identificador, :productor_id,
+                            'Madera Aserrada (Pino)', 20.0, -27.45, -58.90,
+                            :polygon, 'Pendiente', 20.0, 5.0
+                        ) RETURNING id
+                        """
+                    ),
+                    {
+                        "organization_id": organization_id,
+                        "identificador": f"STAGING-LOT-{suffix}",
+                        "productor_id": f"STAGING-PRODUCER-{suffix}",
+                        "polygon": (
+                            "POLYGON((-58.91 -27.46, -58.89 -27.46, "
+                            "-58.89 -27.44, -58.91 -27.44, -58.91 -27.46))"
+                        ),
+                    },
+                ).scalar_one()
+            )
+
+        from main import app
+
+        port = _free_port()
+        config = uvicorn.Config(
+            app,
+            host="127.0.0.1",
+            port=port,
+            log_level="warning",
+            access_log=False,
+        )
+        server = uvicorn.Server(config)
+        server_thread = threading.Thread(target=server.run, daemon=True)
+        server_thread.start()
+
+        deadline = time.monotonic() + 15
+        while not server.started and time.monotonic() < deadline:
+            time.sleep(0.05)
+        assert server.started, "FastAPI staging server did not start."
+
+        base_url = f"http://127.0.0.1:{port}"
+
+        with sync_playwright() as playwright:
+            browser = playwright.chromium.launch(headless=True)
+            page = browser.new_page()
+            try:
+                response = page.goto(f"{base_url}/login", wait_until="domcontentloaded")
+                assert response is not None and response.ok
+
+                page.locator("#loginUsername").fill(username)
+                page.locator("#loginPassword").fill(password)
+                page.locator('form[action="/login"] button[type="submit"]').click()
+                page.wait_for_url("**/dashboard", timeout=15_000)
+
+                expect(page.locator("#selected-lote-name")).to_contain_text(
+                    f"STAGING-LOT-{suffix}",
+                    timeout=15_000,
+                )
+                page.wait_for_function(
+                    "document.querySelector('#satellite-submit') && "
+                    "!document.querySelector('#satellite-submit').disabled"
+                )
+
+                page.locator("#satellite-submit").click()
+                queued = wait_for_job()
+                job_id = int(queued["id"])
+                assert queued["status"] == "queued"
+
+                worker_thread = threading.Thread(target=run_worker, daemon=True)
+                worker_thread.start()
+
+                assert adapter_started.wait(timeout=10), (
+                    "Worker did not claim and begin the queued satellite job."
+                )
+                running = current_job()
+                assert running is not None
+                assert int(running["id"]) == job_id
+                assert running["status"] == "running"
+
+                adapter_release.set()
+
+                expect(page.locator("#satellite-result")).to_contain_text(
+                    "Análisis completado",
+                    timeout=20_000,
+                )
+                expect(page.locator("#satellite-result")).to_contain_text(
+                    "NDVI medio",
+                )
+                expect(page.locator("#satellite-result")).not_to_contain_text(
+                    "No fue posible completar el análisis"
+                )
+
+                with owner_engine.connect() as conn:
+                    final_status = conn.execute(
+                        text("SELECT status FROM satellite_jobs WHERE id = :job_id"),
+                        {"job_id": job_id},
+                    ).scalar_one()
+                    result_count = int(
+                        conn.execute(
+                            text(
+                                "SELECT count(*) FROM satellite_job_results "
+                                "WHERE satellite_job_id = :job_id"
+                            ),
+                            {"job_id": job_id},
+                        ).scalar_one()
+                    )
+                    observation_count = int(
+                        conn.execute(
+                            text(
+                                "SELECT count(*) FROM satellite_ndvi_observations "
+                                "WHERE satellite_job_id = :job_id"
+                            ),
+                            {"job_id": job_id},
+                        ).scalar_one()
+                    )
+
+                assert final_status == "succeeded"
+                assert result_count == 1
+                assert observation_count == 1
+                assert not worker_errors, worker_errors
+            finally:
+                browser.close()
+    finally:
+        adapter_release.set()
+        worker_stop.set()
+        if worker_thread is not None:
+            worker_thread.join(timeout=5)
+        if server is not None:
+            server.should_exit = True
+        if server_thread is not None:
+            server_thread.join(timeout=10)
+
+        reset_engine_state()
+        if organization_id is not None:
+            with owner_engine.begin() as conn:
+                conn.execute(
+                    text(
+                        "DELETE FROM satellite_job_results "
+                        "WHERE organization_id = :organization_id"
+                    ),
+                    {"organization_id": organization_id},
+                )
+                conn.execute(
+                    text(
+                        "DELETE FROM satellite_ndvi_observations "
+                        "WHERE organization_id = :organization_id"
+                    ),
+                    {"organization_id": organization_id},
+                )
+                conn.execute(
+                    text("DELETE FROM audit_logs WHERE organization_id = :organization_id"),
+                    {"organization_id": organization_id},
+                )
+                if user_id is not None:
+                    conn.execute(
+                        text("DELETE FROM user_sessions WHERE user_id = :user_id"),
+                        {"user_id": user_id},
+                    )
+                conn.execute(
+                    text("DELETE FROM satellite_jobs WHERE organization_id = :organization_id"),
+                    {"organization_id": organization_id},
+                )
+                if lote_id is not None:
+                    conn.execute(
+                        text("DELETE FROM lotes WHERE id = :lote_id"),
+                        {"lote_id": lote_id},
+                    )
+                if user_id is not None:
+                    conn.execute(
+                        text("DELETE FROM users WHERE id = :user_id"),
+                        {"user_id": user_id},
+                    )
+                if license_id is not None:
+                    conn.execute(
+                        text("DELETE FROM licenses WHERE id = :license_id"),
+                        {"license_id": license_id},
+                    )
+                conn.execute(
+                    text("DELETE FROM organizations WHERE id = :organization_id"),
+                    {"organization_id": organization_id},
+                )
+
+        worker_engine.dispose()
+        runtime_engine.dispose()
+        owner_engine.dispose()
+        reset_engine_state()

--- a/tests/test_v1_satellite_browser_staging_e2e.py
+++ b/tests/test_v1_satellite_browser_staging_e2e.py
@@ -292,10 +292,31 @@ def test_browser_lot_to_satellite_worker_success_result() -> None:
                 response = page.goto(f"{base_url}/login", wait_until="domcontentloaded")
                 assert response is not None and response.ok
 
+                login_response_status: dict[str, int] = {}
+
+                def remember_login_response(response) -> None:
+                    if (
+                        response.request.method == "POST"
+                        and response.url.rstrip("/").endswith("/login")
+                    ):
+                        login_response_status["status"] = int(response.status)
+
+                page.on("response", remember_login_response)
                 page.locator("#loginUsername").fill(username)
                 page.locator("#loginPassword").fill(password)
                 page.locator('form[action="/login"] button[type="submit"]').click()
-                page.wait_for_url("**/dashboard", timeout=15_000)
+                try:
+                    page.wait_for_url("**/dashboard", timeout=10_000)
+                except Exception as exc:
+                    alert = page.locator('[role="alert"]')
+                    alert_text = alert.first.inner_text() if alert.count() else ""
+                    body_excerpt = page.locator("body").inner_text()[:800]
+                    raise AssertionError(
+                        "Browser login did not reach dashboard; "
+                        f"post_status={login_response_status.get('status')!r}; "
+                        f"url={page.url!r}; alert={alert_text!r}; "
+                        f"body={body_excerpt!r}"
+                    ) from exc
 
                 expect(page.locator("#selected-lote-name")).to_contain_text(
                     f"STAGING-LOT-{suffix}",


### PR DESCRIPTION
Adds a production-free, browser-driven staging acceptance for the remaining Satellite V1 evidence gap.

The test runs against an isolated PostgreSQL/PostGIS database and exercises:

1. real browser login + CSRF/cookie session;
2. tenant-scoped lot loading in the real dashboard;
3. browser submission of a real durable Satellite job;
4. persisted `queued` state before a worker starts;
5. actual `SatelliteWorker` claim with persisted `running` state;
6. deterministic provider adapter execution (external GEE is intentionally not called);
7. persisted canonical observation/result and `succeeded` state;
8. browser polling of the real API and final `Análisis completado` / NDVI rendering.

A dedicated GitHub Actions workflow provisions the ephemeral staging stack and installs headless Chromium. The test is fail-closed and remains skipped in the ordinary Python suite unless explicitly enabled by the staging workflow.

This is intended to supply the missing same-environment worker-backed evidence for Gate 28. It does not modify production or claim external GEE availability, and it does not by itself close the final Gate 39 release staging sign-off.