### PR TITLE
test(release): final V1 acceptance for gates 37-39

### DIFF
--- a/.github/workflows/v1-final-release-acceptance.yml
+++ b/.github/workflows/v1-final-release-acceptance.yml
@@ -1,0 +1,188 @@
+name: V1 Final Release Acceptance
+
+on:
+  pull_request:
+    branches:
+      - p2-enterprise-production
+  push:
+    branches:
+      - p2-enterprise-production
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: v1-final-release-acceptance-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  v1-final-staging-e2e:
+    name: v1-final-staging-e2e
+    runs-on: ubuntu-latest
+    timeout-minutes: 35
+
+    services:
+      postgres:
+        image: postgis/postgis:17-3.5
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: ci_owner_password_2026
+          POSTGRES_DB: litoral_trace_final_staging
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U postgres -d litoral_trace_final_staging"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 20
+
+    env:
+      ENVIRONMENT: development
+      ENABLE_STAGING_BROWSER_E2E: "1"
+      ENABLE_V1_FINAL_STAGING_E2E: "1"
+      PYTHONPATH: src
+      JWT_SECRET_KEY: ci-only-final-staging-jwt-secret-key-2026
+      LITORAL_TRACE_BOOTSTRAP_SUPERADMIN_PASSWORD: CiFinalStagingBootstrapPassword2026
+      TEST_POSTGRES_MIGRATION_DATABASE_URL: postgresql+psycopg://postgres:ci_owner_password_2026@127.0.0.1:5432/litoral_trace_final_staging
+      MIGRATION_DATABASE_URL: postgresql+psycopg://postgres:ci_owner_password_2026@127.0.0.1:5432/litoral_trace_final_staging
+      TEST_POSTGRES_DATABASE_URL: postgresql+psycopg://litoral_trace_app:ci_runtime_password_2026@127.0.0.1:5432/litoral_trace_final_staging
+      DATABASE_URL: postgresql+psycopg://litoral_trace_app:ci_runtime_password_2026@127.0.0.1:5432/litoral_trace_final_staging
+      TEST_POSTGRES_WORKER_DATABASE_URL: postgresql+psycopg://litoral_trace_worker_final:ci_worker_password_2026@127.0.0.1:5432/litoral_trace_final_staging
+
+    steps:
+      - name: Checkout candidate
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: "pip"
+          cache-dependency-path: requirements.txt
+
+      - name: Install application and browser dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -r requirements.txt pytest alembic playwright
+
+      - name: Install Chromium
+        run: python -m playwright install --with-deps chromium
+
+      - name: Provision isolated PostgreSQL principals
+        shell: bash
+        run: |
+          python - <<'PY'
+          import os
+          from sqlalchemy import create_engine
+
+          engine = create_engine(
+              os.environ["TEST_POSTGRES_MIGRATION_DATABASE_URL"],
+              isolation_level="AUTOCOMMIT",
+              pool_pre_ping=True,
+              hide_parameters=True,
+          )
+
+          statements = [
+              """
+              CREATE ROLE litoral_trace_app
+                LOGIN
+                PASSWORD 'ci_runtime_password_2026'
+                NOSUPERUSER
+                NOCREATEDB
+                NOCREATEROLE
+                NOINHERIT
+                NOBYPASSRLS
+              """,
+              """
+              CREATE ROLE litoral_trace_worker_final
+                LOGIN
+                PASSWORD 'ci_worker_password_2026'
+                NOSUPERUSER
+                NOCREATEDB
+                NOCREATEROLE
+                INHERIT
+                NOBYPASSRLS
+              """,
+              "GRANT CONNECT ON DATABASE litoral_trace_final_staging TO litoral_trace_app",
+              "GRANT CONNECT ON DATABASE litoral_trace_final_staging TO litoral_trace_worker_final",
+              "GRANT USAGE ON SCHEMA public TO litoral_trace_app",
+              "GRANT USAGE ON SCHEMA public TO litoral_trace_worker_final",
+          ]
+
+          with engine.connect() as connection:
+              for statement in statements:
+                  connection.exec_driver_sql(statement)
+
+          engine.dispose()
+          PY
+
+      - name: Migrate final staging database to canonical head
+        run: python -m alembic upgrade head
+
+      - name: Provision reviewed runtime and worker capabilities
+        shell: bash
+        run: |
+          python - <<'PY'
+          import os
+          from sqlalchemy import create_engine
+
+          engine = create_engine(
+              os.environ["TEST_POSTGRES_MIGRATION_DATABASE_URL"],
+              isolation_level="AUTOCOMMIT",
+              pool_pre_ping=True,
+              hide_parameters=True,
+          )
+
+          with engine.connect() as connection:
+              connection.exec_driver_sql(
+                  "GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA public TO litoral_trace_app"
+              )
+              connection.exec_driver_sql(
+                  "GRANT USAGE, SELECT ON ALL SEQUENCES IN SCHEMA public TO litoral_trace_app"
+              )
+              connection.exec_driver_sql(
+                  "GRANT litoral_trace_worker_executor TO litoral_trace_worker_final"
+              )
+
+          engine.dispose()
+          PY
+
+      - name: Verify canonical staging revision
+        shell: bash
+        run: |
+          set -euo pipefail
+          python -m alembic current | tee v1-final-alembic-current.txt
+          grep -F "018_add_batch_evidence_links" v1-final-alembic-current.txt
+
+      - name: Gate 39 - final browser staging sign-off
+        shell: bash
+        run: |
+          set -euo pipefail
+          python -m pytest -q --noconftest \
+            --junitxml=v1-final-staging.xml \
+            tests/test_v1_release_browser_staging_e2e.py \
+            tests/test_v1_satellite_browser_staging_e2e.py
+
+          python - <<'PY'
+          import xml.etree.ElementTree as ET
+
+          root = ET.parse("v1-final-staging.xml").getroot()
+          suites = [root] if root.tag == "testsuite" else list(root.iter("testsuite"))
+          if not suites:
+              raise SystemExit("V1 final staging acceptance produced no testsuite.")
+
+          tests = sum(int(suite.attrib.get("tests", "0")) for suite in suites)
+          skipped = sum(int(suite.attrib.get("skipped", "0")) for suite in suites)
+          failures = sum(int(suite.attrib.get("failures", "0")) for suite in suites)
+          errors = sum(int(suite.attrib.get("errors", "0")) for suite in suites)
+
+          if tests != 2 or skipped or failures or errors:
+              raise SystemExit(
+                  "Gate 39 is fail-closed: "
+                  f"tests={tests}, skipped={skipped}, failures={failures}, errors={errors}"
+              )
+          PY
+
+      - name: Confirm acceptance left repository clean
+        run: git diff --exit-code

--- a/tests/test_v1_release_browser_staging_e2e.py
+++ b/tests/test_v1_release_browser_staging_e2e.py
@@ -1,0 +1,274 @@
+from __future__ import annotations
+
+import os
+import socket
+import threading
+import time
+from uuid import uuid4
+
+import pytest
+
+
+def _truthy(value: str | None) -> bool:
+    return (value or "").strip().lower() in {"1", "true", "yes", "on"}
+
+
+ENABLED = _truthy(os.environ.get("ENABLE_V1_FINAL_STAGING_E2E"))
+RUNTIME_URL = os.environ.get("TEST_POSTGRES_DATABASE_URL")
+OWNER_URL = os.environ.get("TEST_POSTGRES_MIGRATION_DATABASE_URL")
+
+pytestmark = pytest.mark.skipif(
+    not (ENABLED and RUNTIME_URL and OWNER_URL),
+    reason=(
+        "V1 final browser staging E2E requires explicit enablement plus "
+        "isolated PostgreSQL owner/runtime URLs."
+    ),
+)
+
+
+def _free_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind(("127.0.0.1", 0))
+        return int(sock.getsockname()[1])
+
+
+def test_release_browser_public_auth_and_operator_surfaces() -> None:
+    """Prove the final V1 browser shell across public and operator surfaces.
+
+    This is intentionally broader than the dedicated Satellite browser test:
+    public pages, auth redirect/login, tenant lot rendering, Batch workspace and
+    Vault workspace are all exercised against one real isolated PostgreSQL
+    runtime. Data-heavy Satellite execution remains covered by the companion
+    staging E2E in the same final-acceptance workflow.
+    """
+
+    from playwright.sync_api import expect, sync_playwright
+    import uvicorn
+    from sqlalchemy import create_engine, text
+
+    from litoral_trace.auth.passwords import hash_password
+    from litoral_trace.config.settings import normalize_database_url
+    from litoral_trace.db.engine import reset_engine_state
+
+    reset_engine_state()
+
+    owner_engine = create_engine(
+        normalize_database_url(OWNER_URL or ""),
+        pool_pre_ping=True,
+        hide_parameters=True,
+    )
+    runtime_engine = create_engine(
+        normalize_database_url(RUNTIME_URL or ""),
+        pool_size=4,
+        max_overflow=0,
+        pool_pre_ping=True,
+        hide_parameters=True,
+    )
+
+    suffix = uuid4().hex[:10]
+    username = f"v1_release_{suffix}"
+    password = f"V1-Release-{suffix}-A9!"
+    organization_id: int | None = None
+    user_id: int | None = None
+    license_id: int | None = None
+    lote_id: int | None = None
+
+    server = None
+    server_thread = None
+
+    try:
+        with owner_engine.begin() as conn:
+            organization_id = int(
+                conn.execute(
+                    text(
+                        """
+                        INSERT INTO organizations (name, slug, tax_id, tier, is_active)
+                        VALUES (:name, :slug, :tax_id, 'pro', true)
+                        RETURNING id
+                        """
+                    ),
+                    {
+                        "name": f"V1 Final Staging {suffix}",
+                        "slug": f"v1-final-staging-{suffix}",
+                        "tax_id": f"FINAL-{suffix}",
+                    },
+                ).scalar_one()
+            )
+            license_id = int(
+                conn.execute(
+                    text(
+                        """
+                        INSERT INTO licenses (
+                            organization_id, plan_type, max_lotes,
+                            max_volume_tons, max_batch_rows, is_active
+                        ) VALUES (
+                            :organization_id, 'pro', 100, 5000.0, 500, true
+                        ) RETURNING id
+                        """
+                    ),
+                    {"organization_id": organization_id},
+                ).scalar_one()
+            )
+            user_id = int(
+                conn.execute(
+                    text(
+                        """
+                        INSERT INTO users (
+                            organization_id, email, username, password_hash,
+                            role, full_name, is_active
+                        ) VALUES (
+                            :organization_id, :email, :username, :password_hash,
+                            'manager', :full_name, true
+                        ) RETURNING id
+                        """
+                    ),
+                    {
+                        "organization_id": organization_id,
+                        "email": f"{username}@example.invalid",
+                        "username": username,
+                        "password_hash": hash_password(password),
+                        "full_name": "V1 Final Staging Operator",
+                    },
+                ).scalar_one()
+            )
+            lote_id = int(
+                conn.execute(
+                    text(
+                        """
+                        INSERT INTO lotes (
+                            organization_id, identificador, productor_id,
+                            producto_forestal, hectareas, latitud, longitud,
+                            polygon_wkt, estatus, volumen_ingresado_ton,
+                            volumen_exportar_ton
+                        ) VALUES (
+                            :organization_id, :identificador, :productor_id,
+                            'Madera Aserrada (Pino)', 12.0, -27.45, -58.90,
+                            :polygon, 'Pendiente', 12.0, 3.0
+                        ) RETURNING id
+                        """
+                    ),
+                    {
+                        "organization_id": organization_id,
+                        "identificador": f"FINAL-LOT-{suffix}",
+                        "productor_id": f"FINAL-PRODUCER-{suffix}",
+                        "polygon": (
+                            "POLYGON((-58.91 -27.46, -58.89 -27.46, "
+                            "-58.89 -27.44, -58.91 -27.44, -58.91 -27.46))"
+                        ),
+                    },
+                ).scalar_one()
+            )
+
+        from main import app
+
+        port = _free_port()
+        config = uvicorn.Config(
+            app,
+            host="127.0.0.1",
+            port=port,
+            log_level="warning",
+            access_log=False,
+        )
+        server = uvicorn.Server(config)
+        server_thread = threading.Thread(target=server.run, daemon=True)
+        server_thread.start()
+
+        deadline = time.monotonic() + 15
+        while not server.started and time.monotonic() < deadline:
+            time.sleep(0.05)
+        assert server.started, "FastAPI final staging server did not start."
+
+        base_url = f"http://127.0.0.1:{port}"
+
+        with sync_playwright() as playwright:
+            browser = playwright.chromium.launch(headless=True)
+            page = browser.new_page()
+            try:
+                response = page.goto(base_url, wait_until="domcontentloaded")
+                assert response is not None and response.ok
+                expect(page.locator("body")).to_contain_text("Litoral Trace")
+
+                response = page.goto(
+                    f"{base_url}/regional-intelligence",
+                    wait_until="domcontentloaded",
+                )
+                assert response is not None and response.ok
+                assert page.url.rstrip("/").endswith("/regional-intelligence")
+
+                page.goto(f"{base_url}/dashboard", wait_until="domcontentloaded")
+                assert page.url.rstrip("/").endswith("/login")
+
+                page.locator("#loginUsername").fill(username)
+                page.locator("#loginPassword").fill(password)
+                page.locator('form[action="/login"] button[type="submit"]').click()
+                page.wait_for_url("**/dashboard", timeout=10_000)
+
+                expect(page.locator("#selected-lote-name")).to_contain_text(
+                    f"FINAL-LOT-{suffix}",
+                    timeout=15_000,
+                )
+
+                response = page.goto(
+                    f"{base_url}/imports",
+                    wait_until="domcontentloaded",
+                )
+                assert response is not None and response.ok
+                assert page.url.rstrip("/").endswith("/imports")
+                assert "/login" not in page.url
+
+                response = page.goto(
+                    f"{base_url}/vault",
+                    wait_until="domcontentloaded",
+                )
+                assert response is not None and response.ok
+                assert page.url.rstrip("/").endswith("/vault")
+                assert "/login" not in page.url
+
+                page.goto(f"{base_url}/dashboard", wait_until="domcontentloaded")
+                expect(page.locator("#selected-lote-name")).to_contain_text(
+                    f"FINAL-LOT-{suffix}",
+                    timeout=10_000,
+                )
+            finally:
+                browser.close()
+    finally:
+        if server is not None:
+            server.should_exit = True
+        if server_thread is not None:
+            server_thread.join(timeout=10)
+
+        reset_engine_state()
+        if organization_id is not None:
+            with owner_engine.begin() as conn:
+                conn.execute(
+                    text("DELETE FROM audit_logs WHERE organization_id = :organization_id"),
+                    {"organization_id": organization_id},
+                )
+                if user_id is not None:
+                    conn.execute(
+                        text("DELETE FROM user_sessions WHERE user_id = :user_id"),
+                        {"user_id": user_id},
+                    )
+                if lote_id is not None:
+                    conn.execute(
+                        text("DELETE FROM lotes WHERE id = :lote_id"),
+                        {"lote_id": lote_id},
+                    )
+                if user_id is not None:
+                    conn.execute(
+                        text("DELETE FROM users WHERE id = :user_id"),
+                        {"user_id": user_id},
+                    )
+                if license_id is not None:
+                    conn.execute(
+                        text("DELETE FROM licenses WHERE id = :license_id"),
+                        {"license_id": license_id},
+                    )
+                conn.execute(
+                    text("DELETE FROM organizations WHERE id = :organization_id"),
+                    {"organization_id": organization_id},
+                )
+
+        runtime_engine.dispose()
+        owner_engine.dispose()
+        reset_engine_state()


### PR DESCRIPTION
Final V1 release-candidate acceptance without touching production.

Scope:
- adds broad browser staging smoke for public/authenticated operator surfaces;
- runs it alongside the existing browser-to-worker Satellite E2E on isolated PostGIS;
- preserves existing required CI and release-integration gates on the same PR candidate;
- no production deploy, no production database mutation, no external GEE call.

Closure intent after all checks pass on the same candidate:
- Gate 37: complete offline CI PASS
- Gate 38: complete integration acceptance PASS
- Gate 39: final staging E2E PASS

Gate 23 / Gate 24 remain intentionally blocked by the >=7-day PITR requirement and are not part of this PR.