### PR TITLE
ops(render): keep free service warm with scheduled health probe

### DIFF
--- a/.github/workflows/render-keep-warm.yml
+++ b/.github/workflows/render-keep-warm.yml
@@ -1,0 +1,36 @@
+name: Render Keep Warm
+
+on:
+  schedule:
+    # Offset from the top of the hour to reduce GitHub schedule congestion.
+    - cron: "2-57/5 * * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: render-keep-warm
+  cancel-in-progress: true
+
+jobs:
+  ping:
+    name: ping-litoraltrace-health
+    runs-on: ubuntu-latest
+    timeout-minutes: 3
+    steps:
+      - name: Wake and verify public health endpoint
+        shell: bash
+        run: |
+          set -euo pipefail
+          curl \
+            --fail \
+            --silent \
+            --show-error \
+            --location \
+            --max-time 90 \
+            --retry 2 \
+            --retry-delay 5 \
+            --retry-all-errors \
+            https://litoraltrace.com/health \
+            >/dev/null


### PR DESCRIPTION
Keeps the current Render Free web service responsive during the pre-revenue/demo phase by requesting https://litoraltrace.com/health every five minutes from the repository default branch.

Safety/operational notes:
- GET-only health probe; no database or production mutation.
- 90s timeout allows a cold Render service to wake.
- workflow_dispatch included for manual verification.
- this is a temporary pre-revenue workaround; paid always-on hosting remains the right target once real customers depend on uptime.