### PR TITLE
security(render): protect internal metrics on public ingress

### DIFF
--- a/render_entrypoint.py
+++ b/render_entrypoint.py
@@ -1,0 +1,46 @@
+"""Render-specific public ASGI entrypoint.
+
+The canonical production topology exposes ``/internal/metrics`` only on the
+private service network and blocks ``/internal/*`` at Nginx. Render's direct
+Web Service ingress does not have that Nginx boundary, so this wrapper applies
+the same public-ingress invariant before delegating to the FastAPI app.
+"""
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
+from typing import Any
+
+from starlette.responses import Response
+
+from main import app as fastapi_app
+
+
+ASGIReceive = Callable[[], Awaitable[dict[str, Any]]]
+ASGISend = Callable[[dict[str, Any]], Awaitable[None]]
+ASGIApp = Callable[[dict[str, Any], ASGIReceive, ASGISend], Awaitable[None]]
+
+
+class RenderPublicIngressGuard:
+    """Return 404 for private infrastructure paths on Render public ingress."""
+
+    def __init__(self, downstream: ASGIApp):
+        self._downstream = downstream
+
+    async def __call__(
+        self,
+        scope: dict[str, Any],
+        receive: ASGIReceive,
+        send: ASGISend,
+    ) -> None:
+        if (
+            scope.get("type") == "http"
+            and str(scope.get("path", "")).startswith("/internal/")
+        ):
+            response = Response(status_code=404)
+            await response(scope, receive, send)
+            return
+
+        await self._downstream(scope, receive, send)
+
+
+app = RenderPublicIngressGuard(fastapi_app)

--- a/tests/test_render_ingress_hardening_unittest.py
+++ b/tests/test_render_ingress_hardening_unittest.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+import asyncio
+
+from render_entrypoint import RenderPublicIngressGuard
+
+
+async def _receive():
+    return {"type": "http.request", "body": b"", "more_body": False}
+
+
+def _run_request(path: str):
+    downstream_calls = []
+    sent = []
+
+    async def downstream(scope, receive, send):
+        del receive
+        downstream_calls.append(scope["path"])
+        await send(
+            {
+                "type": "http.response.start",
+                "status": 204,
+                "headers": [],
+            }
+        )
+        await send(
+            {
+                "type": "http.response.body",
+                "body": b"",
+            }
+        )
+
+    async def send(message):
+        sent.append(message)
+
+    guard = RenderPublicIngressGuard(downstream)
+    scope = {
+        "type": "http",
+        "asgi": {"version": "3.0"},
+        "http_version": "1.1",
+        "method": "GET",
+        "scheme": "https",
+        "path": path,
+        "raw_path": path.encode("utf-8"),
+        "query_string": b"",
+        "headers": [],
+        "client": ("203.0.113.10", 54321),
+        "server": ("litoraltrace.com", 443),
+    }
+
+    asyncio.run(guard(scope, _receive, send))
+    return downstream_calls, sent
+
+
+def test_render_public_ingress_returns_404_for_internal_metrics():
+    downstream_calls, sent = _run_request("/internal/metrics")
+
+    assert downstream_calls == []
+    assert sent[0]["type"] == "http.response.start"
+    assert sent[0]["status"] == 404
+
+
+def test_render_public_ingress_blocks_entire_internal_namespace():
+    downstream_calls, sent = _run_request("/internal/future-private-endpoint")
+
+    assert downstream_calls == []
+    assert sent[0]["status"] == 404
+
+
+def test_render_public_ingress_delegates_public_routes_unchanged():
+    downstream_calls, sent = _run_request("/ready")
+
+    assert downstream_calls == ["/ready"]
+    assert sent[0]["status"] == 204


### PR DESCRIPTION
Final V1 hardening for the Render Web Service.

- adds a Render-specific ASGI entrypoint that returns 404 for `/internal/*`
- preserves the canonical `main:app` topology used behind Nginx/Prometheus
- keeps `/ready`, `/health`, public web routes and authenticated product routes unchanged
- adds regression tests for private-path blocking and normal route delegation

Operational cutover after merge: change Render Start Command from `uvicorn main:app ...` to `uvicorn render_entrypoint:app ...`.