### PR TITLE
P1 Traceability Genealogy (P1A–P1D)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,7 @@ jobs:
             echo "Expected exactly one Alembic head."
             exit 1
           fi
-          grep -Fx "018_add_batch_evidence_links (head)" alembic-heads.txt
+          grep -Fx "019_add_traceability_genealogy (head)" alembic-heads.txt
 
       - name: Run pytest suite
         run: python -m pytest -q -rs

--- a/.github/workflows/release-integration-gates.yml
+++ b/.github/workflows/release-integration-gates.yml
@@ -284,6 +284,22 @@ jobs:
               raise SystemExit(f"Gate 12 is fail-closed: {skipped} test(s) skipped")
           PY
 
+      - name: Gate 13 - P1A traceability PostgreSQL acceptance
+        shell: bash
+        run: |
+          set -euo pipefail
+          python -m pytest -q \
+            --junitxml=gate13-traceability.xml \
+            tests/test_traceability_p1a_postgres_integration.py
+          python - <<'PY'
+          import xml.etree.ElementTree as ET
+
+          root = ET.parse("gate13-traceability.xml").getroot()
+          skipped = int(root.attrib.get("skipped", "0"))
+          if skipped:
+              raise SystemExit(f"Gate 13 is fail-closed: {skipped} test(s) skipped")
+          PY
+
       - name: Verify canonical database head
         shell: bash
         run: |

--- a/.github/workflows/release-integration-gates.yml
+++ b/.github/workflows/release-integration-gates.yml
@@ -345,6 +345,27 @@ jobs:
               )
           PY
 
+      - name: Gate 16 - P1D traceability UI acceptance
+        shell: bash
+        run: |
+          set -euo pipefail
+          python -m pytest -q \
+            --junitxml=gate16-traceability-ui.xml \
+            tests/test_traceability_p1d_ui_unittest.py
+          python - <<'PY'
+          import xml.etree.ElementTree as ET
+
+          root = ET.parse("gate16-traceability-ui.xml").getroot()
+          skipped = int(root.attrib.get("skipped", "0"))
+          failures = int(root.attrib.get("failures", "0"))
+          errors = int(root.attrib.get("errors", "0"))
+          if skipped or failures or errors:
+              raise SystemExit(
+                  "Gate 16 is fail-closed: "
+                  f"skipped={skipped}, failures={failures}, errors={errors}"
+              )
+          PY
+
       - name: Verify canonical database head
         shell: bash
         run: |

--- a/.github/workflows/release-integration-gates.yml
+++ b/.github/workflows/release-integration-gates.yml
@@ -265,8 +265,8 @@ jobs:
               raise SystemExit(f"Gate 11 is fail-closed: {skipped} test(s) skipped")
           PY
 
-      - name: Migrate isolated database to canonical head
-        run: python -m alembic upgrade head
+      - name: Migrate isolated database through Batch acceptance revision
+        run: python -m alembic upgrade 018_add_batch_evidence_links
 
       - name: Gate 12 - Batch PostgreSQL acceptance
         shell: bash
@@ -283,6 +283,9 @@ jobs:
           if skipped:
               raise SystemExit(f"Gate 12 is fail-closed: {skipped} test(s) skipped")
           PY
+
+      - name: Migrate isolated database to canonical head
+        run: python -m alembic upgrade head
 
       - name: Gate 13 - P1A traceability PostgreSQL acceptance
         shell: bash

--- a/.github/workflows/release-integration-gates.yml
+++ b/.github/workflows/release-integration-gates.yml
@@ -289,7 +289,7 @@ jobs:
         run: |
           set -euo pipefail
           python -m alembic current | tee alembic-current.txt
-          grep -F "018_add_batch_evidence_links" alembic-current.txt
+          grep -F "019_add_traceability_genealogy" alembic-current.txt
 
       - name: Cleanup ephemeral integration files and MinIO
         if: always()

--- a/.github/workflows/release-integration-gates.yml
+++ b/.github/workflows/release-integration-gates.yml
@@ -303,6 +303,27 @@ jobs:
               raise SystemExit(f"Gate 13 is fail-closed: {skipped} test(s) skipped")
           PY
 
+      - name: Gate 14 - P1B ledger concurrency acceptance
+        shell: bash
+        run: |
+          set -euo pipefail
+          python -m pytest -q \
+            --junitxml=gate14-ledger.xml \
+            tests/test_traceability_p1b_postgres_integration.py
+          python - <<'PY'
+          import xml.etree.ElementTree as ET
+
+          root = ET.parse("gate14-ledger.xml").getroot()
+          skipped = int(root.attrib.get("skipped", "0"))
+          failures = int(root.attrib.get("failures", "0"))
+          errors = int(root.attrib.get("errors", "0"))
+          if skipped or failures or errors:
+              raise SystemExit(
+                  "Gate 14 is fail-closed: "
+                  f"skipped={skipped}, failures={failures}, errors={errors}"
+              )
+          PY
+
       - name: Verify canonical database head
         shell: bash
         run: |

--- a/.github/workflows/release-integration-gates.yml
+++ b/.github/workflows/release-integration-gates.yml
@@ -324,6 +324,27 @@ jobs:
               )
           PY
 
+      - name: Gate 15 - P1C reverse lineage acceptance
+        shell: bash
+        run: |
+          set -euo pipefail
+          python -m pytest -q \
+            --junitxml=gate15-lineage.xml \
+            tests/test_traceability_p1c_postgres_integration.py
+          python - <<'PY'
+          import xml.etree.ElementTree as ET
+
+          root = ET.parse("gate15-lineage.xml").getroot()
+          skipped = int(root.attrib.get("skipped", "0"))
+          failures = int(root.attrib.get("failures", "0"))
+          errors = int(root.attrib.get("errors", "0"))
+          if skipped or failures or errors:
+              raise SystemExit(
+                  "Gate 15 is fail-closed: "
+                  f"skipped={skipped}, failures={failures}, errors={errors}"
+              )
+          PY
+
       - name: Verify canonical database head
         shell: bash
         run: |

--- a/.github/workflows/v1-final-release-acceptance.yml
+++ b/.github/workflows/v1-final-release-acceptance.yml
@@ -153,7 +153,7 @@ jobs:
         run: |
           set -euo pipefail
           python -m alembic current | tee v1-final-alembic-current.txt
-          grep -F "018_add_batch_evidence_links" v1-final-alembic-current.txt
+          grep -F "019_add_traceability_genealogy" v1-final-alembic-current.txt
 
       - name: Gate 39 - final browser staging sign-off
         shell: bash

--- a/alembic/versions/019_add_traceability_genealogy.py
+++ b/alembic/versions/019_add_traceability_genealogy.py
@@ -1,0 +1,324 @@
+"""Add tenant-safe industrial genealogy graph for chain of custody.
+
+Revision ID: 019_add_traceability_genealogy
+Revises: 018_add_batch_evidence_links
+Create Date: 2026-08-20 20:30:00.000000
+"""
+from __future__ import annotations
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+revision: str = "019_add_traceability_genealogy"
+down_revision: Union[str, Sequence[str], None] = "018_add_batch_evidence_links"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+RUNTIME_ROLE = "litoral_trace_app"
+WORKER_EXECUTOR_ROLE = "litoral_trace_worker_executor"
+TENANT_CONTEXT_SQL = (
+    "NULLIF(current_setting('app.current_organization_id', true), '')::integer"
+)
+TENANT_TABLES = (
+    "traceability_batches",
+    "traceability_events",
+    "traceability_event_inputs",
+    "traceability_event_outputs",
+    "shipments",
+    "shipment_items",
+)
+
+
+def _create_rls(table_name: str) -> None:
+    tenant_match_sql = f"organization_id = {TENANT_CONTEXT_SQL}"
+    op.execute(f"ALTER TABLE public.{table_name} ENABLE ROW LEVEL SECURITY")
+    op.execute(f"ALTER TABLE public.{table_name} FORCE ROW LEVEL SECURITY")
+    op.execute(
+        f"CREATE POLICY {table_name}_tenant_select ON public.{table_name} "
+        f"FOR SELECT USING ({tenant_match_sql})"
+    )
+    op.execute(
+        f"CREATE POLICY {table_name}_tenant_insert ON public.{table_name} "
+        f"FOR INSERT WITH CHECK ({tenant_match_sql})"
+    )
+    op.execute(
+        f"CREATE POLICY {table_name}_tenant_update ON public.{table_name} "
+        f"FOR UPDATE USING ({tenant_match_sql}) WITH CHECK ({tenant_match_sql})"
+    )
+
+
+def _drop_rls(table_name: str) -> None:
+    for action in ("update", "insert", "select"):
+        op.execute(
+            f"DROP POLICY IF EXISTS {table_name}_tenant_{action} ON public.{table_name}"
+        )
+    op.execute(f"ALTER TABLE public.{table_name} NO FORCE ROW LEVEL SECURITY")
+    op.execute(f"ALTER TABLE public.{table_name} DISABLE ROW LEVEL SECURITY")
+
+
+def _grant_runtime_access(table_name: str) -> None:
+    sequence_name = f"{table_name}_id_seq"
+    op.execute(f"REVOKE ALL PRIVILEGES ON TABLE public.{table_name} FROM PUBLIC")
+    op.execute(f"REVOKE ALL PRIVILEGES ON SEQUENCE public.{sequence_name} FROM PUBLIC")
+    op.execute(
+        f"GRANT SELECT, INSERT, UPDATE ON TABLE public.{table_name} TO {RUNTIME_ROLE}"
+    )
+    op.execute(
+        f"GRANT USAGE, SELECT ON SEQUENCE public.{sequence_name} TO {RUNTIME_ROLE}"
+    )
+    op.execute(
+        f"REVOKE ALL PRIVILEGES ON TABLE public.{table_name} FROM {WORKER_EXECUTOR_ROLE}"
+    )
+    op.execute(
+        f"REVOKE ALL PRIVILEGES ON SEQUENCE public.{sequence_name} FROM {WORKER_EXECUTOR_ROLE}"
+    )
+
+
+def _revoke_runtime_access(table_name: str) -> None:
+    sequence_name = f"{table_name}_id_seq"
+    op.execute(
+        f"REVOKE USAGE, SELECT ON SEQUENCE public.{sequence_name} FROM {RUNTIME_ROLE}"
+    )
+    op.execute(
+        f"REVOKE SELECT, INSERT, UPDATE ON TABLE public.{table_name} FROM {RUNTIME_ROLE}"
+    )
+
+
+def upgrade() -> None:
+    # Required by the source-lot composite FK and reconciles ORM/schema drift.
+    op.create_unique_constraint(
+        "uq_lotes_id_organization_id", "lotes", ["id", "organization_id"]
+    )
+
+    op.create_table(
+        "traceability_batches",
+        sa.Column("id", sa.Integer(), autoincrement=True, nullable=False),
+        sa.Column("public_id", sa.Uuid(), nullable=False, server_default=sa.text("gen_random_uuid()")),
+        sa.Column("organization_id", sa.Integer(), nullable=False),
+        sa.Column("code", sa.String(length=120), nullable=False),
+        sa.Column("product_name", sa.String(length=160), nullable=False),
+        sa.Column("stage", sa.String(length=32), nullable=False),
+        sa.Column("unit", sa.String(length=16), nullable=False),
+        sa.Column("status", sa.String(length=16), nullable=False, server_default="ACTIVE"),
+        sa.Column("source_lote_id", sa.Integer(), nullable=True),
+        sa.Column("created_by_user_id", sa.Integer(), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.text("CURRENT_TIMESTAMP")),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.text("CURRENT_TIMESTAMP")),
+        sa.CheckConstraint(
+            "stage IN ('RECEIPT','RAW_MATERIAL','INTERMEDIATE','FINISHED_GOOD')",
+            name="ck_traceability_batches_stage",
+        ),
+        sa.CheckConstraint("unit IN ('TON','KG','M3')", name="ck_traceability_batches_unit"),
+        sa.CheckConstraint("status IN ('ACTIVE','CLOSED','VOID')", name="ck_traceability_batches_status"),
+        sa.ForeignKeyConstraint(
+            ["organization_id"], ["organizations.id"],
+            name="fk_traceability_batches_organization_id", ondelete="RESTRICT"
+        ),
+        sa.ForeignKeyConstraint(
+            ["source_lote_id", "organization_id"],
+            ["lotes.id", "lotes.organization_id"],
+            name="fk_traceability_batches_source_lote_tenant", ondelete="RESTRICT"
+        ),
+        sa.ForeignKeyConstraint(
+            ["created_by_user_id"], ["users.id"],
+            name="fk_traceability_batches_created_by_user_id", ondelete="SET NULL"
+        ),
+        sa.PrimaryKeyConstraint("id", name="pk_traceability_batches"),
+        sa.UniqueConstraint("id", "organization_id", name="uq_traceability_batches_id_org"),
+        sa.UniqueConstraint("public_id", name="uq_traceability_batches_public_id"),
+    )
+    op.create_index(
+        "uq_traceability_batches_tenant_code_ci", "traceability_batches",
+        ["organization_id", sa.text("lower(code)")], unique=True
+    )
+    op.create_index(
+        "ix_traceability_batches_tenant_stage_status", "traceability_batches",
+        ["organization_id", "stage", "status"]
+    )
+    op.create_index(
+        "ix_traceability_batches_tenant_source_lote", "traceability_batches",
+        ["organization_id", "source_lote_id"]
+    )
+
+    op.create_table(
+        "traceability_events",
+        sa.Column("id", sa.Integer(), autoincrement=True, nullable=False),
+        sa.Column("public_id", sa.Uuid(), nullable=False, server_default=sa.text("gen_random_uuid()")),
+        sa.Column("organization_id", sa.Integer(), nullable=False),
+        sa.Column("event_code", sa.String(length=120), nullable=False),
+        sa.Column("event_type", sa.String(length=32), nullable=False),
+        sa.Column("status", sa.String(length=16), nullable=False, server_default="DRAFT"),
+        sa.Column("occurred_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("facility_reference", sa.String(length=160), nullable=True),
+        sa.Column("notes", sa.Text(), nullable=True),
+        sa.Column("created_by_user_id", sa.Integer(), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.text("CURRENT_TIMESTAMP")),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.text("CURRENT_TIMESTAMP")),
+        sa.CheckConstraint(
+            "event_type IN ('RECEIPT','TRANSFORMATION','MIX','SPLIT','REPACK','ADJUSTMENT')",
+            name="ck_traceability_events_type",
+        ),
+        sa.CheckConstraint("status IN ('DRAFT','POSTED','VOID')", name="ck_traceability_events_status"),
+        sa.ForeignKeyConstraint(
+            ["organization_id"], ["organizations.id"],
+            name="fk_traceability_events_organization_id", ondelete="RESTRICT"
+        ),
+        sa.ForeignKeyConstraint(
+            ["created_by_user_id"], ["users.id"],
+            name="fk_traceability_events_created_by_user_id", ondelete="SET NULL"
+        ),
+        sa.PrimaryKeyConstraint("id", name="pk_traceability_events"),
+        sa.UniqueConstraint("id", "organization_id", name="uq_traceability_events_id_org"),
+        sa.UniqueConstraint("public_id", name="uq_traceability_events_public_id"),
+    )
+    op.create_index(
+        "uq_traceability_events_tenant_code_ci", "traceability_events",
+        ["organization_id", sa.text("lower(event_code)")], unique=True
+    )
+    op.create_index(
+        "ix_traceability_events_tenant_occurred_at", "traceability_events",
+        ["organization_id", "occurred_at"]
+    )
+    op.create_index(
+        "ix_traceability_events_tenant_type_status", "traceability_events",
+        ["organization_id", "event_type", "status"]
+    )
+
+    for table_name, direction in (
+        ("traceability_event_inputs", "inputs"),
+        ("traceability_event_outputs", "outputs"),
+    ):
+        op.create_table(
+            table_name,
+            sa.Column("id", sa.Integer(), autoincrement=True, nullable=False),
+            sa.Column("organization_id", sa.Integer(), nullable=False),
+            sa.Column("event_id", sa.Integer(), nullable=False),
+            sa.Column("batch_id", sa.Integer(), nullable=False),
+            sa.Column("quantity", sa.Numeric(precision=18, scale=6), nullable=False),
+            sa.Column("unit", sa.String(length=16), nullable=False),
+            sa.Column("created_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.text("CURRENT_TIMESTAMP")),
+            sa.CheckConstraint("quantity > 0", name=f"ck_traceability_event_{direction}_quantity"),
+            sa.CheckConstraint("unit IN ('TON','KG','M3')", name=f"ck_traceability_event_{direction}_unit"),
+            sa.ForeignKeyConstraint(
+                ["event_id", "organization_id"],
+                ["traceability_events.id", "traceability_events.organization_id"],
+                name=f"fk_traceability_event_{direction}_event_tenant", ondelete="RESTRICT"
+            ),
+            sa.ForeignKeyConstraint(
+                ["batch_id", "organization_id"],
+                ["traceability_batches.id", "traceability_batches.organization_id"],
+                name=f"fk_traceability_event_{direction}_batch_tenant", ondelete="RESTRICT"
+            ),
+            sa.PrimaryKeyConstraint("id", name=f"pk_traceability_event_{direction}"),
+            sa.UniqueConstraint("event_id", "batch_id", name=f"uq_traceability_event_{direction}_event_batch"),
+        )
+        op.create_index(
+            f"ix_traceability_event_{direction}_tenant_batch", table_name,
+            ["organization_id", "batch_id"]
+        )
+
+    op.create_table(
+        "shipments",
+        sa.Column("id", sa.Integer(), autoincrement=True, nullable=False),
+        sa.Column("public_id", sa.Uuid(), nullable=False, server_default=sa.text("gen_random_uuid()")),
+        sa.Column("organization_id", sa.Integer(), nullable=False),
+        sa.Column("shipment_code", sa.String(length=120), nullable=False),
+        sa.Column("sale_reference", sa.String(length=160), nullable=True),
+        sa.Column("buyer_reference", sa.String(length=160), nullable=True),
+        sa.Column("destination_country", sa.String(length=2), nullable=True),
+        sa.Column("shipped_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("status", sa.String(length=16), nullable=False, server_default="DRAFT"),
+        sa.Column("created_by_user_id", sa.Integer(), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.text("CURRENT_TIMESTAMP")),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.text("CURRENT_TIMESTAMP")),
+        sa.CheckConstraint(
+            "status IN ('DRAFT','CONFIRMED','DISPATCHED','CANCELLED')",
+            name="ck_shipments_status"
+        ),
+        sa.CheckConstraint(
+            "destination_country IS NULL OR length(destination_country) = 2",
+            name="ck_shipments_destination_country"
+        ),
+        sa.ForeignKeyConstraint(
+            ["organization_id"], ["organizations.id"],
+            name="fk_shipments_organization_id", ondelete="RESTRICT"
+        ),
+        sa.ForeignKeyConstraint(
+            ["created_by_user_id"], ["users.id"],
+            name="fk_shipments_created_by_user_id", ondelete="SET NULL"
+        ),
+        sa.PrimaryKeyConstraint("id", name="pk_shipments"),
+        sa.UniqueConstraint("id", "organization_id", name="uq_shipments_id_org"),
+        sa.UniqueConstraint("public_id", name="uq_shipments_public_id"),
+    )
+    op.create_index(
+        "uq_shipments_tenant_code_ci", "shipments",
+        ["organization_id", sa.text("lower(shipment_code)")], unique=True
+    )
+    op.create_index(
+        "ix_shipments_tenant_shipped_at", "shipments",
+        ["organization_id", "shipped_at"]
+    )
+    op.create_index(
+        "ix_shipments_tenant_status", "shipments", ["organization_id", "status"]
+    )
+
+    op.create_table(
+        "shipment_items",
+        sa.Column("id", sa.Integer(), autoincrement=True, nullable=False),
+        sa.Column("organization_id", sa.Integer(), nullable=False),
+        sa.Column("shipment_id", sa.Integer(), nullable=False),
+        sa.Column("batch_id", sa.Integer(), nullable=False),
+        sa.Column("quantity", sa.Numeric(precision=18, scale=6), nullable=False),
+        sa.Column("unit", sa.String(length=16), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.text("CURRENT_TIMESTAMP")),
+        sa.CheckConstraint("quantity > 0", name="ck_shipment_items_quantity"),
+        sa.CheckConstraint("unit IN ('TON','KG','M3')", name="ck_shipment_items_unit"),
+        sa.ForeignKeyConstraint(
+            ["shipment_id", "organization_id"],
+            ["shipments.id", "shipments.organization_id"],
+            name="fk_shipment_items_shipment_tenant", ondelete="RESTRICT"
+        ),
+        sa.ForeignKeyConstraint(
+            ["batch_id", "organization_id"],
+            ["traceability_batches.id", "traceability_batches.organization_id"],
+            name="fk_shipment_items_batch_tenant", ondelete="RESTRICT"
+        ),
+        sa.PrimaryKeyConstraint("id", name="pk_shipment_items"),
+        sa.UniqueConstraint("shipment_id", "batch_id", name="uq_shipment_items_shipment_batch"),
+    )
+    op.create_index(
+        "ix_shipment_items_tenant_batch", "shipment_items", ["organization_id", "batch_id"]
+    )
+
+    for table_name in TENANT_TABLES:
+        _create_rls(table_name)
+        _grant_runtime_access(table_name)
+
+
+def downgrade() -> None:
+    for table_name in reversed(TENANT_TABLES):
+        _revoke_runtime_access(table_name)
+        _drop_rls(table_name)
+
+    op.drop_index("ix_shipment_items_tenant_batch", table_name="shipment_items")
+    op.drop_table("shipment_items")
+    op.drop_index("ix_shipments_tenant_status", table_name="shipments")
+    op.drop_index("ix_shipments_tenant_shipped_at", table_name="shipments")
+    op.drop_index("uq_shipments_tenant_code_ci", table_name="shipments")
+    op.drop_table("shipments")
+    op.drop_index("ix_traceability_event_outputs_tenant_batch", table_name="traceability_event_outputs")
+    op.drop_table("traceability_event_outputs")
+    op.drop_index("ix_traceability_event_inputs_tenant_batch", table_name="traceability_event_inputs")
+    op.drop_table("traceability_event_inputs")
+    op.drop_index("ix_traceability_events_tenant_type_status", table_name="traceability_events")
+    op.drop_index("ix_traceability_events_tenant_occurred_at", table_name="traceability_events")
+    op.drop_index("uq_traceability_events_tenant_code_ci", table_name="traceability_events")
+    op.drop_table("traceability_events")
+    op.drop_index("ix_traceability_batches_tenant_source_lote", table_name="traceability_batches")
+    op.drop_index("ix_traceability_batches_tenant_stage_status", table_name="traceability_batches")
+    op.drop_index("uq_traceability_batches_tenant_code_ci", table_name="traceability_batches")
+    op.drop_table("traceability_batches")
+    op.drop_constraint("uq_lotes_id_organization_id", "lotes", type_="unique")

--- a/alembic/versions/019_add_traceability_genealogy.py
+++ b/alembic/versions/019_add_traceability_genealogy.py
@@ -87,15 +87,18 @@ def _revoke_runtime_access(table_name: str) -> None:
 
 
 def upgrade() -> None:
-    # Required by the source-lot composite FK and reconciles ORM/schema drift.
-    op.create_unique_constraint(
-        "uq_lotes_id_organization_id", "lotes", ["id", "organization_id"]
-    )
-
+    # Revision 018 already owns uq_lotes_id_organization_id. P1A reuses that
+    # tenant-safe composite key for source-lot references instead of creating
+    # a duplicate constraint.
     op.create_table(
         "traceability_batches",
         sa.Column("id", sa.Integer(), autoincrement=True, nullable=False),
-        sa.Column("public_id", sa.Uuid(), nullable=False, server_default=sa.text("gen_random_uuid()")),
+        sa.Column(
+            "public_id",
+            sa.Uuid(),
+            nullable=False,
+            server_default=sa.text("gen_random_uuid()"),
+        ),
         sa.Column("organization_id", sa.Integer(), nullable=False),
         sa.Column("code", sa.String(length=120), nullable=False),
         sa.Column("product_name", sa.String(length=160), nullable=False),
@@ -104,48 +107,85 @@ def upgrade() -> None:
         sa.Column("status", sa.String(length=16), nullable=False, server_default="ACTIVE"),
         sa.Column("source_lote_id", sa.Integer(), nullable=True),
         sa.Column("created_by_user_id", sa.Integer(), nullable=True),
-        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.text("CURRENT_TIMESTAMP")),
-        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.text("CURRENT_TIMESTAMP")),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("CURRENT_TIMESTAMP"),
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("CURRENT_TIMESTAMP"),
+        ),
         sa.CheckConstraint(
             "stage IN ('RECEIPT','RAW_MATERIAL','INTERMEDIATE','FINISHED_GOOD')",
             name="ck_traceability_batches_stage",
         ),
-        sa.CheckConstraint("unit IN ('TON','KG','M3')", name="ck_traceability_batches_unit"),
-        sa.CheckConstraint("status IN ('ACTIVE','CLOSED','VOID')", name="ck_traceability_batches_status"),
+        sa.CheckConstraint(
+            "unit IN ('TON','KG','M3')",
+            name="ck_traceability_batches_unit",
+        ),
+        sa.CheckConstraint(
+            "status IN ('ACTIVE','CLOSED','VOID')",
+            name="ck_traceability_batches_status",
+        ),
         sa.ForeignKeyConstraint(
-            ["organization_id"], ["organizations.id"],
-            name="fk_traceability_batches_organization_id", ondelete="RESTRICT"
+            ["organization_id"],
+            ["organizations.id"],
+            name="fk_traceability_batches_organization_id",
+            ondelete="RESTRICT",
         ),
         sa.ForeignKeyConstraint(
             ["source_lote_id", "organization_id"],
             ["lotes.id", "lotes.organization_id"],
-            name="fk_traceability_batches_source_lote_tenant", ondelete="RESTRICT"
+            name="fk_traceability_batches_source_lote_tenant",
+            ondelete="RESTRICT",
         ),
         sa.ForeignKeyConstraint(
-            ["created_by_user_id"], ["users.id"],
-            name="fk_traceability_batches_created_by_user_id", ondelete="SET NULL"
+            ["created_by_user_id"],
+            ["users.id"],
+            name="fk_traceability_batches_created_by_user_id",
+            ondelete="SET NULL",
         ),
         sa.PrimaryKeyConstraint("id", name="pk_traceability_batches"),
-        sa.UniqueConstraint("id", "organization_id", name="uq_traceability_batches_id_org"),
-        sa.UniqueConstraint("public_id", name="uq_traceability_batches_public_id"),
+        sa.UniqueConstraint(
+            "id",
+            "organization_id",
+            name="uq_traceability_batches_id_org",
+        ),
+        sa.UniqueConstraint(
+            "public_id",
+            name="uq_traceability_batches_public_id",
+        ),
     )
     op.create_index(
-        "uq_traceability_batches_tenant_code_ci", "traceability_batches",
-        ["organization_id", sa.text("lower(code)")], unique=True
+        "uq_traceability_batches_tenant_code_ci",
+        "traceability_batches",
+        ["organization_id", sa.text("lower(code)")],
+        unique=True,
     )
     op.create_index(
-        "ix_traceability_batches_tenant_stage_status", "traceability_batches",
-        ["organization_id", "stage", "status"]
+        "ix_traceability_batches_tenant_stage_status",
+        "traceability_batches",
+        ["organization_id", "stage", "status"],
     )
     op.create_index(
-        "ix_traceability_batches_tenant_source_lote", "traceability_batches",
-        ["organization_id", "source_lote_id"]
+        "ix_traceability_batches_tenant_source_lote",
+        "traceability_batches",
+        ["organization_id", "source_lote_id"],
     )
 
     op.create_table(
         "traceability_events",
         sa.Column("id", sa.Integer(), autoincrement=True, nullable=False),
-        sa.Column("public_id", sa.Uuid(), nullable=False, server_default=sa.text("gen_random_uuid()")),
+        sa.Column(
+            "public_id",
+            sa.Uuid(),
+            nullable=False,
+            server_default=sa.text("gen_random_uuid()"),
+        ),
         sa.Column("organization_id", sa.Integer(), nullable=False),
         sa.Column("event_code", sa.String(length=120), nullable=False),
         sa.Column("event_type", sa.String(length=32), nullable=False),
@@ -154,36 +194,64 @@ def upgrade() -> None:
         sa.Column("facility_reference", sa.String(length=160), nullable=True),
         sa.Column("notes", sa.Text(), nullable=True),
         sa.Column("created_by_user_id", sa.Integer(), nullable=True),
-        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.text("CURRENT_TIMESTAMP")),
-        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.text("CURRENT_TIMESTAMP")),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("CURRENT_TIMESTAMP"),
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("CURRENT_TIMESTAMP"),
+        ),
         sa.CheckConstraint(
             "event_type IN ('RECEIPT','TRANSFORMATION','MIX','SPLIT','REPACK','ADJUSTMENT')",
             name="ck_traceability_events_type",
         ),
-        sa.CheckConstraint("status IN ('DRAFT','POSTED','VOID')", name="ck_traceability_events_status"),
-        sa.ForeignKeyConstraint(
-            ["organization_id"], ["organizations.id"],
-            name="fk_traceability_events_organization_id", ondelete="RESTRICT"
+        sa.CheckConstraint(
+            "status IN ('DRAFT','POSTED','VOID')",
+            name="ck_traceability_events_status",
         ),
         sa.ForeignKeyConstraint(
-            ["created_by_user_id"], ["users.id"],
-            name="fk_traceability_events_created_by_user_id", ondelete="SET NULL"
+            ["organization_id"],
+            ["organizations.id"],
+            name="fk_traceability_events_organization_id",
+            ondelete="RESTRICT",
+        ),
+        sa.ForeignKeyConstraint(
+            ["created_by_user_id"],
+            ["users.id"],
+            name="fk_traceability_events_created_by_user_id",
+            ondelete="SET NULL",
         ),
         sa.PrimaryKeyConstraint("id", name="pk_traceability_events"),
-        sa.UniqueConstraint("id", "organization_id", name="uq_traceability_events_id_org"),
-        sa.UniqueConstraint("public_id", name="uq_traceability_events_public_id"),
+        sa.UniqueConstraint(
+            "id",
+            "organization_id",
+            name="uq_traceability_events_id_org",
+        ),
+        sa.UniqueConstraint(
+            "public_id",
+            name="uq_traceability_events_public_id",
+        ),
     )
     op.create_index(
-        "uq_traceability_events_tenant_code_ci", "traceability_events",
-        ["organization_id", sa.text("lower(event_code)")], unique=True
+        "uq_traceability_events_tenant_code_ci",
+        "traceability_events",
+        ["organization_id", sa.text("lower(event_code)")],
+        unique=True,
     )
     op.create_index(
-        "ix_traceability_events_tenant_occurred_at", "traceability_events",
-        ["organization_id", "occurred_at"]
+        "ix_traceability_events_tenant_occurred_at",
+        "traceability_events",
+        ["organization_id", "occurred_at"],
     )
     op.create_index(
-        "ix_traceability_events_tenant_type_status", "traceability_events",
-        ["organization_id", "event_type", "status"]
+        "ix_traceability_events_tenant_type_status",
+        "traceability_events",
+        ["organization_id", "event_type", "status"],
     )
 
     for table_name, direction in (
@@ -196,73 +264,131 @@ def upgrade() -> None:
             sa.Column("organization_id", sa.Integer(), nullable=False),
             sa.Column("event_id", sa.Integer(), nullable=False),
             sa.Column("batch_id", sa.Integer(), nullable=False),
-            sa.Column("quantity", sa.Numeric(precision=18, scale=6), nullable=False),
+            sa.Column(
+                "quantity",
+                sa.Numeric(precision=18, scale=6),
+                nullable=False,
+            ),
             sa.Column("unit", sa.String(length=16), nullable=False),
-            sa.Column("created_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.text("CURRENT_TIMESTAMP")),
-            sa.CheckConstraint("quantity > 0", name=f"ck_traceability_event_{direction}_quantity"),
-            sa.CheckConstraint("unit IN ('TON','KG','M3')", name=f"ck_traceability_event_{direction}_unit"),
+            sa.Column(
+                "created_at",
+                sa.DateTime(timezone=True),
+                nullable=False,
+                server_default=sa.text("CURRENT_TIMESTAMP"),
+            ),
+            sa.CheckConstraint(
+                "quantity > 0",
+                name=f"ck_traceability_event_{direction}_quantity",
+            ),
+            sa.CheckConstraint(
+                "unit IN ('TON','KG','M3')",
+                name=f"ck_traceability_event_{direction}_unit",
+            ),
             sa.ForeignKeyConstraint(
                 ["event_id", "organization_id"],
                 ["traceability_events.id", "traceability_events.organization_id"],
-                name=f"fk_traceability_event_{direction}_event_tenant", ondelete="RESTRICT"
+                name=f"fk_traceability_event_{direction}_event_tenant",
+                ondelete="RESTRICT",
             ),
             sa.ForeignKeyConstraint(
                 ["batch_id", "organization_id"],
                 ["traceability_batches.id", "traceability_batches.organization_id"],
-                name=f"fk_traceability_event_{direction}_batch_tenant", ondelete="RESTRICT"
+                name=f"fk_traceability_event_{direction}_batch_tenant",
+                ondelete="RESTRICT",
             ),
-            sa.PrimaryKeyConstraint("id", name=f"pk_traceability_event_{direction}"),
-            sa.UniqueConstraint("event_id", "batch_id", name=f"uq_traceability_event_{direction}_event_batch"),
+            sa.PrimaryKeyConstraint(
+                "id",
+                name=f"pk_traceability_event_{direction}",
+            ),
+            sa.UniqueConstraint(
+                "event_id",
+                "batch_id",
+                name=f"uq_traceability_event_{direction}_event_batch",
+            ),
         )
         op.create_index(
-            f"ix_traceability_event_{direction}_tenant_batch", table_name,
-            ["organization_id", "batch_id"]
+            f"ix_traceability_event_{direction}_tenant_batch",
+            table_name,
+            ["organization_id", "batch_id"],
         )
 
     op.create_table(
         "shipments",
         sa.Column("id", sa.Integer(), autoincrement=True, nullable=False),
-        sa.Column("public_id", sa.Uuid(), nullable=False, server_default=sa.text("gen_random_uuid()")),
+        sa.Column(
+            "public_id",
+            sa.Uuid(),
+            nullable=False,
+            server_default=sa.text("gen_random_uuid()"),
+        ),
         sa.Column("organization_id", sa.Integer(), nullable=False),
         sa.Column("shipment_code", sa.String(length=120), nullable=False),
         sa.Column("sale_reference", sa.String(length=160), nullable=True),
         sa.Column("buyer_reference", sa.String(length=160), nullable=True),
         sa.Column("destination_country", sa.String(length=2), nullable=True),
         sa.Column("shipped_at", sa.DateTime(timezone=True), nullable=True),
-        sa.Column("status", sa.String(length=16), nullable=False, server_default="DRAFT"),
+        sa.Column(
+            "status",
+            sa.String(length=16),
+            nullable=False,
+            server_default="DRAFT",
+        ),
         sa.Column("created_by_user_id", sa.Integer(), nullable=True),
-        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.text("CURRENT_TIMESTAMP")),
-        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.text("CURRENT_TIMESTAMP")),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("CURRENT_TIMESTAMP"),
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("CURRENT_TIMESTAMP"),
+        ),
         sa.CheckConstraint(
             "status IN ('DRAFT','CONFIRMED','DISPATCHED','CANCELLED')",
-            name="ck_shipments_status"
+            name="ck_shipments_status",
         ),
         sa.CheckConstraint(
             "destination_country IS NULL OR length(destination_country) = 2",
-            name="ck_shipments_destination_country"
+            name="ck_shipments_destination_country",
         ),
         sa.ForeignKeyConstraint(
-            ["organization_id"], ["organizations.id"],
-            name="fk_shipments_organization_id", ondelete="RESTRICT"
+            ["organization_id"],
+            ["organizations.id"],
+            name="fk_shipments_organization_id",
+            ondelete="RESTRICT",
         ),
         sa.ForeignKeyConstraint(
-            ["created_by_user_id"], ["users.id"],
-            name="fk_shipments_created_by_user_id", ondelete="SET NULL"
+            ["created_by_user_id"],
+            ["users.id"],
+            name="fk_shipments_created_by_user_id",
+            ondelete="SET NULL",
         ),
         sa.PrimaryKeyConstraint("id", name="pk_shipments"),
-        sa.UniqueConstraint("id", "organization_id", name="uq_shipments_id_org"),
+        sa.UniqueConstraint(
+            "id",
+            "organization_id",
+            name="uq_shipments_id_org",
+        ),
         sa.UniqueConstraint("public_id", name="uq_shipments_public_id"),
     )
     op.create_index(
-        "uq_shipments_tenant_code_ci", "shipments",
-        ["organization_id", sa.text("lower(shipment_code)")], unique=True
+        "uq_shipments_tenant_code_ci",
+        "shipments",
+        ["organization_id", sa.text("lower(shipment_code)")],
+        unique=True,
     )
     op.create_index(
-        "ix_shipments_tenant_shipped_at", "shipments",
-        ["organization_id", "shipped_at"]
+        "ix_shipments_tenant_shipped_at",
+        "shipments",
+        ["organization_id", "shipped_at"],
     )
     op.create_index(
-        "ix_shipments_tenant_status", "shipments", ["organization_id", "status"]
+        "ix_shipments_tenant_status",
+        "shipments",
+        ["organization_id", "status"],
     )
 
     op.create_table(
@@ -271,26 +397,49 @@ def upgrade() -> None:
         sa.Column("organization_id", sa.Integer(), nullable=False),
         sa.Column("shipment_id", sa.Integer(), nullable=False),
         sa.Column("batch_id", sa.Integer(), nullable=False),
-        sa.Column("quantity", sa.Numeric(precision=18, scale=6), nullable=False),
+        sa.Column(
+            "quantity",
+            sa.Numeric(precision=18, scale=6),
+            nullable=False,
+        ),
         sa.Column("unit", sa.String(length=16), nullable=False),
-        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.text("CURRENT_TIMESTAMP")),
-        sa.CheckConstraint("quantity > 0", name="ck_shipment_items_quantity"),
-        sa.CheckConstraint("unit IN ('TON','KG','M3')", name="ck_shipment_items_unit"),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("CURRENT_TIMESTAMP"),
+        ),
+        sa.CheckConstraint(
+            "quantity > 0",
+            name="ck_shipment_items_quantity",
+        ),
+        sa.CheckConstraint(
+            "unit IN ('TON','KG','M3')",
+            name="ck_shipment_items_unit",
+        ),
         sa.ForeignKeyConstraint(
             ["shipment_id", "organization_id"],
             ["shipments.id", "shipments.organization_id"],
-            name="fk_shipment_items_shipment_tenant", ondelete="RESTRICT"
+            name="fk_shipment_items_shipment_tenant",
+            ondelete="RESTRICT",
         ),
         sa.ForeignKeyConstraint(
             ["batch_id", "organization_id"],
             ["traceability_batches.id", "traceability_batches.organization_id"],
-            name="fk_shipment_items_batch_tenant", ondelete="RESTRICT"
+            name="fk_shipment_items_batch_tenant",
+            ondelete="RESTRICT",
         ),
         sa.PrimaryKeyConstraint("id", name="pk_shipment_items"),
-        sa.UniqueConstraint("shipment_id", "batch_id", name="uq_shipment_items_shipment_batch"),
+        sa.UniqueConstraint(
+            "shipment_id",
+            "batch_id",
+            name="uq_shipment_items_shipment_batch",
+        ),
     )
     op.create_index(
-        "ix_shipment_items_tenant_batch", "shipment_items", ["organization_id", "batch_id"]
+        "ix_shipment_items_tenant_batch",
+        "shipment_items",
+        ["organization_id", "batch_id"],
     )
 
     for table_name in TENANT_TABLES:
@@ -303,22 +452,48 @@ def downgrade() -> None:
         _revoke_runtime_access(table_name)
         _drop_rls(table_name)
 
-    op.drop_index("ix_shipment_items_tenant_batch", table_name="shipment_items")
+    op.drop_index(
+        "ix_shipment_items_tenant_batch",
+        table_name="shipment_items",
+    )
     op.drop_table("shipment_items")
     op.drop_index("ix_shipments_tenant_status", table_name="shipments")
     op.drop_index("ix_shipments_tenant_shipped_at", table_name="shipments")
     op.drop_index("uq_shipments_tenant_code_ci", table_name="shipments")
     op.drop_table("shipments")
-    op.drop_index("ix_traceability_event_outputs_tenant_batch", table_name="traceability_event_outputs")
+    op.drop_index(
+        "ix_traceability_event_outputs_tenant_batch",
+        table_name="traceability_event_outputs",
+    )
     op.drop_table("traceability_event_outputs")
-    op.drop_index("ix_traceability_event_inputs_tenant_batch", table_name="traceability_event_inputs")
+    op.drop_index(
+        "ix_traceability_event_inputs_tenant_batch",
+        table_name="traceability_event_inputs",
+    )
     op.drop_table("traceability_event_inputs")
-    op.drop_index("ix_traceability_events_tenant_type_status", table_name="traceability_events")
-    op.drop_index("ix_traceability_events_tenant_occurred_at", table_name="traceability_events")
-    op.drop_index("uq_traceability_events_tenant_code_ci", table_name="traceability_events")
+    op.drop_index(
+        "ix_traceability_events_tenant_type_status",
+        table_name="traceability_events",
+    )
+    op.drop_index(
+        "ix_traceability_events_tenant_occurred_at",
+        table_name="traceability_events",
+    )
+    op.drop_index(
+        "uq_traceability_events_tenant_code_ci",
+        table_name="traceability_events",
+    )
     op.drop_table("traceability_events")
-    op.drop_index("ix_traceability_batches_tenant_source_lote", table_name="traceability_batches")
-    op.drop_index("ix_traceability_batches_tenant_stage_status", table_name="traceability_batches")
-    op.drop_index("uq_traceability_batches_tenant_code_ci", table_name="traceability_batches")
+    op.drop_index(
+        "ix_traceability_batches_tenant_source_lote",
+        table_name="traceability_batches",
+    )
+    op.drop_index(
+        "ix_traceability_batches_tenant_stage_status",
+        table_name="traceability_batches",
+    )
+    op.drop_index(
+        "uq_traceability_batches_tenant_code_ci",
+        table_name="traceability_batches",
+    )
     op.drop_table("traceability_batches")
-    op.drop_constraint("uq_lotes_id_organization_id", "lotes", type_="unique")

--- a/main.py
+++ b/main.py
@@ -60,6 +60,9 @@ from litoral_trace.api.satellite import (
 from litoral_trace.api.settings import (
     router as settings_router,
 )
+from litoral_trace.api.traceability import (
+    router as traceability_router,
+)
 from litoral_trace.api.vault import (
     router as vault_router,
 )
@@ -152,6 +155,10 @@ app.include_router(
 
 app.include_router(
     batch_evidence_router
+)
+
+app.include_router(
+    traceability_router
 )
 
 app.include_router(

--- a/src/litoral_trace/api/batch_evidence.py
+++ b/src/litoral_trace/api/batch_evidence.py
@@ -426,14 +426,3 @@ async def desvincular_evidencia_batch_endpoint(
             "Cache-Control": "no-store",
         },
     )
-
-
-# API composition: main.py already imports this exported router. Keep the
-# established Batch Evidence routes intact while registering the independent
-# P1C traceability router without coupling its URL prefix to /api/v1/batch.
-from litoral_trace.api.traceability import router as traceability_router
-
-_batch_evidence_router = router
-router = APIRouter()
-router.include_router(_batch_evidence_router)
-router.include_router(traceability_router)

--- a/src/litoral_trace/api/batch_evidence.py
+++ b/src/litoral_trace/api/batch_evidence.py
@@ -426,3 +426,14 @@ async def desvincular_evidencia_batch_endpoint(
             "Cache-Control": "no-store",
         },
     )
+
+
+# API composition: main.py already imports this exported router. Keep the
+# established Batch Evidence routes intact while registering the independent
+# P1C traceability router without coupling its URL prefix to /api/v1/batch.
+from litoral_trace.api.traceability import router as traceability_router
+
+_batch_evidence_router = router
+router = APIRouter()
+router.include_router(_batch_evidence_router)
+router.include_router(traceability_router)

--- a/src/litoral_trace/api/traceability.py
+++ b/src/litoral_trace/api/traceability.py
@@ -1,0 +1,80 @@
+"""Read-only industrial traceability API for P1C reverse genealogy."""
+from __future__ import annotations
+
+from typing import Any
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi.responses import JSONResponse
+
+from litoral_trace.api.auth import UserTenantContext
+from litoral_trace.auth.rbac import Permission, require_permission
+from litoral_trace.db.tenant import get_tenant_scoped_db_session
+from litoral_trace.services.traceability_lineage import (
+    TraceabilityLineageNotFoundError,
+    TraceabilityLineageService,
+    TraceabilityLineageValidationError,
+)
+
+
+router = APIRouter(
+    prefix="/api/v1/traceability",
+    tags=["Trazabilidad Industrial"],
+)
+
+
+def _detail(*, code: str, message: str) -> dict[str, str]:
+    return {
+        "code": code,
+        "message": message,
+    }
+
+
+@router.get(
+    "/shipments/{shipment_code}/origin",
+    response_model=dict[str, Any],
+)
+async def obtener_origen_despacho_endpoint(
+    shipment_code: str,
+    user: UserTenantContext = Depends(
+        require_permission(Permission.LOTE_READ)
+    ),
+) -> JSONResponse:
+    """Reconstruct one tenant shipment back to source parcels and producers.
+
+    Quantities attributed to source parcels use the explicit
+    ``PROPORTIONAL_INPUT_ALLOCATION`` convention when industrial events mix
+    multiple homogeneous inputs. ``complete=false`` means the chain contains
+    a gap and must not be presented as closed provenance evidence.
+    """
+    session = get_tenant_scoped_db_session(user.organization_id)
+    if session is None:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail=_detail(
+                code="TRACEABILITY_SERVICE_UNAVAILABLE",
+                message="El servicio de trazabilidad no está disponible temporalmente.",
+            ),
+        )
+
+    try:
+        service = TraceabilityLineageService(
+            session=session,
+            organization_id=user.organization_id,
+        )
+        payload = service.trace_shipment(shipment_code)
+        return JSONResponse(
+            status_code=status.HTTP_200_OK,
+            content=payload,
+        )
+    except TraceabilityLineageValidationError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
+            detail=_detail(code=exc.code, message=str(exc)),
+        ) from None
+    except TraceabilityLineageNotFoundError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=_detail(code=exc.code, message=str(exc)),
+        ) from None
+    finally:
+        session.close()

--- a/src/litoral_trace/api/traceability.py
+++ b/src/litoral_trace/api/traceability.py
@@ -1,4 +1,4 @@
-"""Read-only industrial traceability API for P1C reverse genealogy."""
+"""Industrial traceability API and domain router composition."""
 from __future__ import annotations
 
 from typing import Any
@@ -14,9 +14,10 @@ from litoral_trace.services.traceability_lineage import (
     TraceabilityLineageService,
     TraceabilityLineageValidationError,
 )
+from litoral_trace.web.traceability import router as traceability_web_router
 
 
-router = APIRouter(
+api_router = APIRouter(
     prefix="/api/v1/traceability",
     tags=["Trazabilidad Industrial"],
 )
@@ -29,7 +30,7 @@ def _detail(*, code: str, message: str) -> dict[str, str]:
     }
 
 
-@router.get(
+@api_router.get(
     "/shipments/{shipment_code}/origin",
     response_model=dict[str, Any],
 )
@@ -78,3 +79,12 @@ async def obtener_origen_despacho_endpoint(
         ) from None
     finally:
         session.close()
+
+
+# ``main.py`` includes one traceability-domain router. Keeping both the API
+# contract and the P1D browser workspace beneath this composition avoids a
+# second registration path while leaving the P1C service as the single source
+# of lineage truth.
+router = APIRouter()
+router.include_router(api_router)
+router.include_router(traceability_web_router)

--- a/src/litoral_trace/db/models/__init__.py
+++ b/src/litoral_trace/db/models/__init__.py
@@ -12,6 +12,14 @@ from litoral_trace.db.models.user_session import UserSession
 from litoral_trace.db.models.vault_document import VaultDocument
 from litoral_trace.db.models.batch_import import BatchImport
 from litoral_trace.db.models.batch_evidence_link import BatchEvidenceLink
+from litoral_trace.db.models.traceability import (
+    Shipment,
+    ShipmentItem,
+    TraceabilityBatch,
+    TraceabilityEvent,
+    TraceabilityEventInput,
+    TraceabilityEventOutput,
+)
 
 __all__ = [
     "Organization",
@@ -27,4 +35,10 @@ __all__ = [
     "VaultDocument",
     "BatchImport",
     "BatchEvidenceLink",
+    "TraceabilityBatch",
+    "TraceabilityEvent",
+    "TraceabilityEventInput",
+    "TraceabilityEventOutput",
+    "Shipment",
+    "ShipmentItem",
 ]

--- a/src/litoral_trace/db/models/traceability.py
+++ b/src/litoral_trace/db/models/traceability.py
@@ -1,0 +1,294 @@
+"""Industrial traceability graph models for end-to-end chain of custody."""
+from __future__ import annotations
+
+from datetime import datetime
+from decimal import Decimal
+from typing import TYPE_CHECKING, Final
+from uuid import UUID, uuid4
+
+from sqlalchemy import (
+    CheckConstraint,
+    DateTime,
+    ForeignKey,
+    ForeignKeyConstraint,
+    Index,
+    Integer,
+    Numeric,
+    String,
+    Text,
+    UniqueConstraint,
+    Uuid,
+    func,
+)
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from litoral_trace.db.base import Base, TimestampMixin
+
+if TYPE_CHECKING:
+    from litoral_trace.db.models.lote import Lote
+    from litoral_trace.db.models.user import User
+
+TRACEABILITY_BATCH_STAGES: Final[frozenset[str]] = frozenset(
+    {"RECEIPT", "RAW_MATERIAL", "INTERMEDIATE", "FINISHED_GOOD"}
+)
+TRACEABILITY_BATCH_STATUSES: Final[frozenset[str]] = frozenset(
+    {"ACTIVE", "CLOSED", "VOID"}
+)
+TRACEABILITY_EVENT_TYPES: Final[frozenset[str]] = frozenset(
+    {"RECEIPT", "TRANSFORMATION", "MIX", "SPLIT", "REPACK", "ADJUSTMENT"}
+)
+TRACEABILITY_EVENT_STATUSES: Final[frozenset[str]] = frozenset(
+    {"DRAFT", "POSTED", "VOID"}
+)
+TRACEABILITY_UNITS: Final[frozenset[str]] = frozenset({"TON", "KG", "M3"})
+
+
+class TraceabilityBatch(Base, TimestampMixin):
+    """Material lot node in the industrial genealogy graph."""
+
+    __tablename__ = "traceability_batches"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    public_id: Mapped[UUID] = mapped_column(Uuid(as_uuid=True), default=uuid4, nullable=False)
+    organization_id: Mapped[int] = mapped_column(Integer, nullable=False)
+    code: Mapped[str] = mapped_column(String(120), nullable=False)
+    product_name: Mapped[str] = mapped_column(String(160), nullable=False)
+    stage: Mapped[str] = mapped_column(String(32), nullable=False)
+    unit: Mapped[str] = mapped_column(String(16), nullable=False)
+    status: Mapped[str] = mapped_column(String(16), nullable=False, default="ACTIVE", server_default="ACTIVE")
+    source_lote_id: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    created_by_user_id: Mapped[int | None] = mapped_column(
+        Integer,
+        ForeignKey("users.id", ondelete="SET NULL", name="fk_traceability_batches_created_by_user_id"),
+        nullable=True,
+    )
+
+    source_lote: Mapped[Lote | None] = relationship("Lote")
+    created_by_user: Mapped[User | None] = relationship("User")
+    event_inputs: Mapped[list[TraceabilityEventInput]] = relationship(
+        "TraceabilityEventInput", back_populates="batch", cascade="save-update, merge"
+    )
+    event_outputs: Mapped[list[TraceabilityEventOutput]] = relationship(
+        "TraceabilityEventOutput", back_populates="batch", cascade="save-update, merge"
+    )
+    shipment_items: Mapped[list[ShipmentItem]] = relationship(
+        "ShipmentItem", back_populates="batch", cascade="save-update, merge"
+    )
+
+    __table_args__ = (
+        UniqueConstraint("id", "organization_id", name="uq_traceability_batches_id_org"),
+        UniqueConstraint("public_id", name="uq_traceability_batches_public_id"),
+        ForeignKeyConstraint(
+            ["organization_id"], ["organizations.id"],
+            name="fk_traceability_batches_organization_id", ondelete="RESTRICT"
+        ),
+        ForeignKeyConstraint(
+            ["source_lote_id", "organization_id"],
+            ["lotes.id", "lotes.organization_id"],
+            name="fk_traceability_batches_source_lote_tenant",
+            ondelete="RESTRICT",
+        ),
+        CheckConstraint(
+            "stage IN ('RECEIPT','RAW_MATERIAL','INTERMEDIATE','FINISHED_GOOD')",
+            name="ck_traceability_batches_stage",
+        ),
+        CheckConstraint("unit IN ('TON','KG','M3')", name="ck_traceability_batches_unit"),
+        CheckConstraint("status IN ('ACTIVE','CLOSED','VOID')", name="ck_traceability_batches_status"),
+        Index("uq_traceability_batches_tenant_code_ci", "organization_id", func.lower(code), unique=True),
+        Index("ix_traceability_batches_tenant_stage_status", "organization_id", "stage", "status"),
+        Index("ix_traceability_batches_tenant_source_lote", "organization_id", "source_lote_id"),
+    )
+
+
+class TraceabilityEvent(Base, TimestampMixin):
+    """Industrial event connecting one or more input batches to output batches."""
+
+    __tablename__ = "traceability_events"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    public_id: Mapped[UUID] = mapped_column(Uuid(as_uuid=True), default=uuid4, nullable=False)
+    organization_id: Mapped[int] = mapped_column(
+        Integer,
+        ForeignKey("organizations.id", ondelete="RESTRICT", name="fk_traceability_events_organization_id"),
+        nullable=False,
+    )
+    event_code: Mapped[str] = mapped_column(String(120), nullable=False)
+    event_type: Mapped[str] = mapped_column(String(32), nullable=False)
+    status: Mapped[str] = mapped_column(String(16), nullable=False, default="DRAFT", server_default="DRAFT")
+    occurred_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
+    facility_reference: Mapped[str | None] = mapped_column(String(160), nullable=True)
+    notes: Mapped[str | None] = mapped_column(Text, nullable=True)
+    created_by_user_id: Mapped[int | None] = mapped_column(
+        Integer,
+        ForeignKey("users.id", ondelete="SET NULL", name="fk_traceability_events_created_by_user_id"),
+        nullable=True,
+    )
+
+    inputs: Mapped[list[TraceabilityEventInput]] = relationship(
+        "TraceabilityEventInput", back_populates="event", cascade="save-update, merge"
+    )
+    outputs: Mapped[list[TraceabilityEventOutput]] = relationship(
+        "TraceabilityEventOutput", back_populates="event", cascade="save-update, merge"
+    )
+    created_by_user: Mapped[User | None] = relationship("User")
+
+    __table_args__ = (
+        UniqueConstraint("id", "organization_id", name="uq_traceability_events_id_org"),
+        UniqueConstraint("public_id", name="uq_traceability_events_public_id"),
+        CheckConstraint(
+            "event_type IN ('RECEIPT','TRANSFORMATION','MIX','SPLIT','REPACK','ADJUSTMENT')",
+            name="ck_traceability_events_type",
+        ),
+        CheckConstraint("status IN ('DRAFT','POSTED','VOID')", name="ck_traceability_events_status"),
+        Index("uq_traceability_events_tenant_code_ci", "organization_id", func.lower(event_code), unique=True),
+        Index("ix_traceability_events_tenant_occurred_at", "organization_id", "occurred_at"),
+        Index("ix_traceability_events_tenant_type_status", "organization_id", "event_type", "status"),
+    )
+
+
+class TraceabilityEventInput(Base):
+    """Quantity of one batch consumed by an industrial event."""
+
+    __tablename__ = "traceability_event_inputs"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    organization_id: Mapped[int] = mapped_column(Integer, nullable=False)
+    event_id: Mapped[int] = mapped_column(Integer, nullable=False)
+    batch_id: Mapped[int] = mapped_column(Integer, nullable=False)
+    quantity: Mapped[Decimal] = mapped_column(Numeric(18, 6), nullable=False)
+    unit: Mapped[str] = mapped_column(String(16), nullable=False)
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False, server_default=func.now())
+
+    event: Mapped[TraceabilityEvent] = relationship("TraceabilityEvent", back_populates="inputs")
+    batch: Mapped[TraceabilityBatch] = relationship("TraceabilityBatch", back_populates="event_inputs")
+
+    __table_args__ = (
+        ForeignKeyConstraint(
+            ["event_id", "organization_id"],
+            ["traceability_events.id", "traceability_events.organization_id"],
+            name="fk_traceability_event_inputs_event_tenant", ondelete="RESTRICT",
+        ),
+        ForeignKeyConstraint(
+            ["batch_id", "organization_id"],
+            ["traceability_batches.id", "traceability_batches.organization_id"],
+            name="fk_traceability_event_inputs_batch_tenant", ondelete="RESTRICT",
+        ),
+        UniqueConstraint("event_id", "batch_id", name="uq_traceability_event_inputs_event_batch"),
+        CheckConstraint("quantity > 0", name="ck_traceability_event_inputs_quantity"),
+        CheckConstraint("unit IN ('TON','KG','M3')", name="ck_traceability_event_inputs_unit"),
+        Index("ix_traceability_event_inputs_tenant_batch", "organization_id", "batch_id"),
+    )
+
+
+class TraceabilityEventOutput(Base):
+    """Quantity of one batch produced by an industrial event."""
+
+    __tablename__ = "traceability_event_outputs"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    organization_id: Mapped[int] = mapped_column(Integer, nullable=False)
+    event_id: Mapped[int] = mapped_column(Integer, nullable=False)
+    batch_id: Mapped[int] = mapped_column(Integer, nullable=False)
+    quantity: Mapped[Decimal] = mapped_column(Numeric(18, 6), nullable=False)
+    unit: Mapped[str] = mapped_column(String(16), nullable=False)
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False, server_default=func.now())
+
+    event: Mapped[TraceabilityEvent] = relationship("TraceabilityEvent", back_populates="outputs")
+    batch: Mapped[TraceabilityBatch] = relationship("TraceabilityBatch", back_populates="event_outputs")
+
+    __table_args__ = (
+        ForeignKeyConstraint(
+            ["event_id", "organization_id"],
+            ["traceability_events.id", "traceability_events.organization_id"],
+            name="fk_traceability_event_outputs_event_tenant", ondelete="RESTRICT",
+        ),
+        ForeignKeyConstraint(
+            ["batch_id", "organization_id"],
+            ["traceability_batches.id", "traceability_batches.organization_id"],
+            name="fk_traceability_event_outputs_batch_tenant", ondelete="RESTRICT",
+        ),
+        UniqueConstraint("event_id", "batch_id", name="uq_traceability_event_outputs_event_batch"),
+        CheckConstraint("quantity > 0", name="ck_traceability_event_outputs_quantity"),
+        CheckConstraint("unit IN ('TON','KG','M3')", name="ck_traceability_event_outputs_unit"),
+        Index("ix_traceability_event_outputs_tenant_batch", "organization_id", "batch_id"),
+    )
+
+
+class Shipment(Base, TimestampMixin):
+    """Commercial dispatch/sale that consumes one or more traceability batches."""
+
+    __tablename__ = "shipments"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    public_id: Mapped[UUID] = mapped_column(Uuid(as_uuid=True), default=uuid4, nullable=False)
+    organization_id: Mapped[int] = mapped_column(
+        Integer,
+        ForeignKey("organizations.id", ondelete="RESTRICT", name="fk_shipments_organization_id"),
+        nullable=False,
+    )
+    shipment_code: Mapped[str] = mapped_column(String(120), nullable=False)
+    sale_reference: Mapped[str | None] = mapped_column(String(160), nullable=True)
+    buyer_reference: Mapped[str | None] = mapped_column(String(160), nullable=True)
+    destination_country: Mapped[str | None] = mapped_column(String(2), nullable=True)
+    shipped_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    status: Mapped[str] = mapped_column(String(16), nullable=False, default="DRAFT", server_default="DRAFT")
+    created_by_user_id: Mapped[int | None] = mapped_column(
+        Integer,
+        ForeignKey("users.id", ondelete="SET NULL", name="fk_shipments_created_by_user_id"),
+        nullable=True,
+    )
+
+    items: Mapped[list[ShipmentItem]] = relationship(
+        "ShipmentItem", back_populates="shipment", cascade="save-update, merge"
+    )
+    created_by_user: Mapped[User | None] = relationship("User")
+
+    __table_args__ = (
+        UniqueConstraint("id", "organization_id", name="uq_shipments_id_org"),
+        UniqueConstraint("public_id", name="uq_shipments_public_id"),
+        CheckConstraint(
+            "status IN ('DRAFT','CONFIRMED','DISPATCHED','CANCELLED')",
+            name="ck_shipments_status",
+        ),
+        CheckConstraint(
+            "destination_country IS NULL OR length(destination_country) = 2",
+            name="ck_shipments_destination_country",
+        ),
+        Index("uq_shipments_tenant_code_ci", "organization_id", func.lower(shipment_code), unique=True),
+        Index("ix_shipments_tenant_shipped_at", "organization_id", "shipped_at"),
+        Index("ix_shipments_tenant_status", "organization_id", "status"),
+    )
+
+
+class ShipmentItem(Base):
+    """Quantity of a traceability batch allocated to one shipment."""
+
+    __tablename__ = "shipment_items"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    organization_id: Mapped[int] = mapped_column(Integer, nullable=False)
+    shipment_id: Mapped[int] = mapped_column(Integer, nullable=False)
+    batch_id: Mapped[int] = mapped_column(Integer, nullable=False)
+    quantity: Mapped[Decimal] = mapped_column(Numeric(18, 6), nullable=False)
+    unit: Mapped[str] = mapped_column(String(16), nullable=False)
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False, server_default=func.now())
+
+    shipment: Mapped[Shipment] = relationship("Shipment", back_populates="items")
+    batch: Mapped[TraceabilityBatch] = relationship("TraceabilityBatch", back_populates="shipment_items")
+
+    __table_args__ = (
+        ForeignKeyConstraint(
+            ["shipment_id", "organization_id"],
+            ["shipments.id", "shipments.organization_id"],
+            name="fk_shipment_items_shipment_tenant", ondelete="RESTRICT",
+        ),
+        ForeignKeyConstraint(
+            ["batch_id", "organization_id"],
+            ["traceability_batches.id", "traceability_batches.organization_id"],
+            name="fk_shipment_items_batch_tenant", ondelete="RESTRICT",
+        ),
+        UniqueConstraint("shipment_id", "batch_id", name="uq_shipment_items_shipment_batch"),
+        CheckConstraint("quantity > 0", name="ck_shipment_items_quantity"),
+        CheckConstraint("unit IN ('TON','KG','M3')", name="ck_shipment_items_unit"),
+        Index("ix_shipment_items_tenant_batch", "organization_id", "batch_id"),
+    )

--- a/src/litoral_trace/db/tenant.py
+++ b/src/litoral_trace/db/tenant.py
@@ -22,6 +22,9 @@ from litoral_trace.db.models import (
     Lote,
     SatelliteJob,
     SatelliteNdviObservation,
+    Shipment,
+    TraceabilityBatch,
+    TraceabilityEvent,
     User,
 )
 
@@ -37,6 +40,9 @@ TenantModel = type[
     | SatelliteJob
     | SatelliteNdviObservation
     | BatchImport
+    | TraceabilityBatch
+    | TraceabilityEvent
+    | Shipment
 ]
 TenantEntity = (
     Lote
@@ -47,6 +53,9 @@ TenantEntity = (
     | SatelliteJob
     | SatelliteNdviObservation
     | BatchImport
+    | TraceabilityBatch
+    | TraceabilityEvent
+    | Shipment
 )
 
 

--- a/src/litoral_trace/services/audit.py
+++ b/src/litoral_trace/services/audit.py
@@ -34,6 +34,8 @@ class AuditAction(StrEnum):
     LOTE_BATCH_UPLOAD = "lote.batch_upload"
     LOTE_BATCH_EVIDENCE_LINK = "lote.batch_evidence.link"
     LOTE_BATCH_EVIDENCE_UNLINK = "lote.batch_evidence.unlink"
+    TRACEABILITY_EVENT_POST = "traceability.event.post"
+    TRACEABILITY_SHIPMENT_DISPATCH = "traceability.shipment.dispatch"
     SATELLITE_NDVI_RUN = "satellite.ndvi.run"
     SATELLITE_JOB_SUBMIT = "satellite.job.submit"
     SATELLITE_JOB_SUCCEEDED = "satellite.job.succeeded"

--- a/src/litoral_trace/services/traceability_ledger.py
+++ b/src/litoral_trace/services/traceability_ledger.py
@@ -53,9 +53,6 @@ ZERO = Decimal("0.000000")
 LEDGER_EVENT_TYPES = frozenset(
     {"RECEIPT", "TRANSFORMATION", "MIX", "SPLIT", "REPACK", "ADJUSTMENT"}
 )
-TRANSFORMING_EVENT_TYPES = frozenset(
-    {"TRANSFORMATION", "MIX", "SPLIT", "REPACK"}
-)
 
 
 class TraceabilityLedgerError(RuntimeError):
@@ -157,6 +154,13 @@ def _normalize_organization_id(value: int | str) -> int:
             "El tenant de trazabilidad no es válido."
         )
     return organization_id
+
+
+def _as_utc(value: datetime) -> datetime:
+    """Normalize SQLite-naive and PostgreSQL-aware timestamps for comparison."""
+    if value.tzinfo is None:
+        return value.replace(tzinfo=timezone.utc)
+    return value.astimezone(timezone.utc)
 
 
 def _sum_scalar(session: Session, statement) -> Decimal:
@@ -584,7 +588,10 @@ class TraceabilityLedgerService:
                     organization_id=org_id,
                     batch_id=batch.id,
                 )
-                if produced_at is not None and event.occurred_at < produced_at:
+                if (
+                    produced_at is not None
+                    and _as_utc(event.occurred_at) < _as_utc(produced_at)
+                ):
                     raise TraceabilityValidationError(
                         "EVENT_BEFORE_INPUT_PRODUCTION",
                         "El evento no puede ocurrir antes de la producción de una de sus entradas.",
@@ -638,9 +645,8 @@ class TraceabilityLedgerService:
                 before_data={"status": "DRAFT"},
                 after_data={"status": "POSTED"},
             )
-            session.commit()
 
-            return EventPostingResult(
+            result = EventPostingResult(
                 organization_id=org_id,
                 event_id=int(event.id),
                 event_public_id=event.public_id,
@@ -649,6 +655,8 @@ class TraceabilityLedgerService:
                 status="POSTED",
                 unit_balances=summaries,
             )
+            session.commit()
+            return result
         except TraceabilityLedgerError:
             session.rollback()
             raise
@@ -721,7 +729,9 @@ class TraceabilityLedgerService:
                 organization_id=org_id,
                 batch_ids=[item.batch_id for item in items],
             )
-            dispatch_time = shipment.shipped_at or datetime.now(timezone.utc)
+            dispatch_time = _as_utc(
+                shipment.shipped_at or datetime.now(timezone.utc)
+            )
             quantities_by_unit = _line_totals(items)
 
             for item in items:
@@ -768,7 +778,7 @@ class TraceabilityLedgerService:
                         "SHIPMENT_WITHOUT_POSTED_ORIGIN",
                         "No se puede despachar material sin un evento productor contabilizado.",
                     )
-                if dispatch_time < produced_at:
+                if dispatch_time < _as_utc(produced_at):
                     raise TraceabilityValidationError(
                         "SHIPMENT_BEFORE_PRODUCTION",
                         "El despacho no puede ocurrir antes de la producción del material.",
@@ -803,9 +813,8 @@ class TraceabilityLedgerService:
                     "shipped_at": dispatch_time.isoformat(),
                 },
             )
-            session.commit()
 
-            return ShipmentDispatchResult(
+            result = ShipmentDispatchResult(
                 organization_id=org_id,
                 shipment_id=int(shipment.id),
                 shipment_public_id=shipment.public_id,
@@ -814,6 +823,8 @@ class TraceabilityLedgerService:
                 shipped_at=dispatch_time,
                 quantities_by_unit=tuple(sorted(quantities_by_unit.items())),
             )
+            session.commit()
+            return result
         except TraceabilityLedgerError:
             session.rollback()
             raise

--- a/src/litoral_trace/services/traceability_ledger.py
+++ b/src/litoral_trace/services/traceability_ledger.py
@@ -1,0 +1,831 @@
+"""Transactional industrial ledger for P1B chain-of-custody enforcement.
+
+The ledger is intentionally derived from immutable business movements instead
+of persisting a mutable ``current_stock`` field. A batch balance is:
+
+    posted outputs - posted inputs - dispatched shipment items
+
+Posting and dispatch operations lock all affected material batches in stable
+ID order before validating availability. On PostgreSQL this serializes
+competing consumers of the same stock and prevents double-spend.
+
+P1B uses a homogeneous physical accounting basis per event. For the initial
+Corrientes forestry workflow this is normally M3 (solid wood volume) through
+roundwood -> sawn/intermediate -> finished product. Cross-unit transformation
+requires a later explicit, evidence-backed conversion profile and therefore
+fails closed here instead of applying hidden density/yield assumptions.
+"""
+from __future__ import annotations
+
+from collections import defaultdict
+from collections.abc import Callable, Iterable
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from decimal import Decimal, InvalidOperation, ROUND_HALF_UP
+from typing import Any
+from uuid import UUID
+
+from sqlalchemy import func, select
+from sqlalchemy.exc import SQLAlchemyError
+from sqlalchemy.orm import Session
+
+from litoral_trace.db.engine import get_db_session
+from litoral_trace.db.models import (
+    Shipment,
+    ShipmentItem,
+    TraceabilityBatch,
+    TraceabilityEvent,
+    TraceabilityEventInput,
+    TraceabilityEventOutput,
+)
+from litoral_trace.db.tenant import set_tenant_db_context
+from litoral_trace.services.audit import (
+    AuditAction,
+    AuditActor,
+    AuditOutcome,
+    AuditRequestContext,
+    record_audit_event,
+)
+
+
+QTY_QUANTUM = Decimal("0.000001")
+ZERO = Decimal("0.000000")
+LEDGER_EVENT_TYPES = frozenset(
+    {"RECEIPT", "TRANSFORMATION", "MIX", "SPLIT", "REPACK", "ADJUSTMENT"}
+)
+TRANSFORMING_EVENT_TYPES = frozenset(
+    {"TRANSFORMATION", "MIX", "SPLIT", "REPACK"}
+)
+
+
+class TraceabilityLedgerError(RuntimeError):
+    """Base class for safe P1B ledger failures."""
+
+
+class TraceabilityAuthorizationError(TraceabilityLedgerError):
+    """Authenticated actor does not belong to the requested tenant."""
+
+
+class TraceabilityNotFoundError(TraceabilityLedgerError):
+    """Requested tenant-scoped traceability entity does not exist."""
+
+
+class TraceabilityStateError(TraceabilityLedgerError):
+    """Requested transition is invalid for the current entity state."""
+
+
+class TraceabilityValidationError(TraceabilityLedgerError):
+    """Stable domain validation failure suitable for API translation."""
+
+    def __init__(self, code: str, detail: str) -> None:
+        self.code = code
+        self.detail = detail
+        super().__init__(detail)
+
+
+class TraceabilityPersistenceError(TraceabilityLedgerError):
+    """Sanitized persistence failure that never exposes raw DB details."""
+
+
+@dataclass(frozen=True)
+class BatchInventoryBalance:
+    organization_id: int
+    batch_id: int
+    batch_public_id: UUID
+    batch_code: str
+    unit: str
+    produced: Decimal
+    consumed: Decimal
+    dispatched: Decimal
+    available: Decimal
+
+
+@dataclass(frozen=True)
+class UnitBalanceSummary:
+    unit: str
+    input_quantity: Decimal
+    output_quantity: Decimal
+    loss_quantity: Decimal
+    yield_ratio: Decimal | None
+
+
+@dataclass(frozen=True)
+class EventPostingResult:
+    organization_id: int
+    event_id: int
+    event_public_id: UUID
+    event_code: str
+    event_type: str
+    status: str
+    unit_balances: tuple[UnitBalanceSummary, ...]
+
+
+@dataclass(frozen=True)
+class ShipmentDispatchResult:
+    organization_id: int
+    shipment_id: int
+    shipment_public_id: UUID
+    shipment_code: str
+    status: str
+    shipped_at: datetime
+    quantities_by_unit: tuple[tuple[str, Decimal], ...]
+
+
+SessionFactory = Callable[[], Session | None]
+
+
+def _qty(value: Any) -> Decimal:
+    try:
+        decimal_value = Decimal(str(value))
+    except (InvalidOperation, TypeError, ValueError) as exc:
+        raise TraceabilityValidationError(
+            "INVALID_QUANTITY",
+            "La cantidad de trazabilidad no es válida.",
+        ) from exc
+    return decimal_value.quantize(QTY_QUANTUM, rounding=ROUND_HALF_UP)
+
+
+def _normalize_organization_id(value: int | str) -> int:
+    try:
+        organization_id = int(value)
+    except (TypeError, ValueError) as exc:
+        raise TraceabilityAuthorizationError(
+            "El tenant de trazabilidad no es válido."
+        ) from exc
+    if organization_id <= 0:
+        raise TraceabilityAuthorizationError(
+            "El tenant de trazabilidad no es válido."
+        )
+    return organization_id
+
+
+def _sum_scalar(session: Session, statement) -> Decimal:
+    value = session.execute(statement).scalar_one()
+    return _qty(value or ZERO)
+
+
+def _line_totals(lines: Iterable[Any]) -> dict[str, Decimal]:
+    totals: dict[str, Decimal] = defaultdict(lambda: ZERO)
+    for line in lines:
+        totals[str(line.unit)] = _qty(totals[str(line.unit)] + _qty(line.quantity))
+    return dict(totals)
+
+
+def _unit_summaries(
+    inputs: Iterable[TraceabilityEventInput],
+    outputs: Iterable[TraceabilityEventOutput],
+) -> tuple[UnitBalanceSummary, ...]:
+    input_totals = _line_totals(inputs)
+    output_totals = _line_totals(outputs)
+    units = sorted(set(input_totals) | set(output_totals))
+    summaries: list[UnitBalanceSummary] = []
+    for unit in units:
+        input_quantity = input_totals.get(unit, ZERO)
+        output_quantity = output_totals.get(unit, ZERO)
+        loss_quantity = _qty(max(input_quantity - output_quantity, ZERO))
+        yield_ratio = None
+        if input_quantity > ZERO:
+            yield_ratio = (
+                output_quantity / input_quantity
+            ).quantize(QTY_QUANTUM, rounding=ROUND_HALF_UP)
+        summaries.append(
+            UnitBalanceSummary(
+                unit=unit,
+                input_quantity=input_quantity,
+                output_quantity=output_quantity,
+                loss_quantity=loss_quantity,
+                yield_ratio=yield_ratio,
+            )
+        )
+    return tuple(summaries)
+
+
+class TraceabilityLedgerService:
+    """Post industrial movements atomically while enforcing provenance stock."""
+
+    def __init__(self, *, session_factory: SessionFactory | None = None) -> None:
+        self._session_factory = session_factory or get_db_session
+
+    @staticmethod
+    def _validate_actor_scope(actor: AuditActor, organization_id: int) -> None:
+        if int(actor.organization_id) != organization_id:
+            raise TraceabilityAuthorizationError(
+                "El actor autenticado no pertenece al tenant de trazabilidad."
+            )
+
+    @staticmethod
+    def _lock_batches(
+        session: Session,
+        *,
+        organization_id: int,
+        batch_ids: Iterable[int],
+    ) -> dict[int, TraceabilityBatch]:
+        normalized_ids = sorted({int(batch_id) for batch_id in batch_ids})
+        if not normalized_ids:
+            return {}
+
+        statement = (
+            select(TraceabilityBatch)
+            .where(
+                TraceabilityBatch.organization_id == organization_id,
+                TraceabilityBatch.id.in_(normalized_ids),
+            )
+            .order_by(TraceabilityBatch.id)
+            .with_for_update()
+        )
+        batches = session.execute(statement).scalars().all()
+        by_id = {int(batch.id): batch for batch in batches}
+        if len(by_id) != len(normalized_ids):
+            raise TraceabilityNotFoundError(
+                "Uno o más lotes industriales no existen en el tenant activo."
+            )
+        return by_id
+
+    @staticmethod
+    def _latest_producer_time(
+        session: Session,
+        *,
+        organization_id: int,
+        batch_id: int,
+    ) -> datetime | None:
+        return session.execute(
+            select(func.max(TraceabilityEvent.occurred_at))
+            .join(
+                TraceabilityEventOutput,
+                TraceabilityEventOutput.event_id == TraceabilityEvent.id,
+            )
+            .where(
+                TraceabilityEvent.organization_id == organization_id,
+                TraceabilityEvent.status == "POSTED",
+                TraceabilityEventOutput.organization_id == organization_id,
+                TraceabilityEventOutput.batch_id == batch_id,
+            )
+        ).scalar_one()
+
+    @staticmethod
+    def _posted_producer_count(
+        session: Session,
+        *,
+        organization_id: int,
+        batch_id: int,
+    ) -> int:
+        return int(
+            session.execute(
+                select(func.count(TraceabilityEventOutput.id))
+                .join(
+                    TraceabilityEvent,
+                    TraceabilityEvent.id == TraceabilityEventOutput.event_id,
+                )
+                .where(
+                    TraceabilityEvent.organization_id == organization_id,
+                    TraceabilityEvent.status == "POSTED",
+                    TraceabilityEventOutput.organization_id == organization_id,
+                    TraceabilityEventOutput.batch_id == batch_id,
+                )
+            ).scalar_one()
+        )
+
+    @staticmethod
+    def _balance_for_batch(
+        session: Session,
+        *,
+        organization_id: int,
+        batch: TraceabilityBatch,
+    ) -> BatchInventoryBalance:
+        produced = _sum_scalar(
+            session,
+            select(func.coalesce(func.sum(TraceabilityEventOutput.quantity), 0))
+            .join(
+                TraceabilityEvent,
+                TraceabilityEvent.id == TraceabilityEventOutput.event_id,
+            )
+            .where(
+                TraceabilityEventOutput.organization_id == organization_id,
+                TraceabilityEventOutput.batch_id == batch.id,
+                TraceabilityEvent.status == "POSTED",
+                TraceabilityEvent.organization_id == organization_id,
+            ),
+        )
+        consumed = _sum_scalar(
+            session,
+            select(func.coalesce(func.sum(TraceabilityEventInput.quantity), 0))
+            .join(
+                TraceabilityEvent,
+                TraceabilityEvent.id == TraceabilityEventInput.event_id,
+            )
+            .where(
+                TraceabilityEventInput.organization_id == organization_id,
+                TraceabilityEventInput.batch_id == batch.id,
+                TraceabilityEvent.status == "POSTED",
+                TraceabilityEvent.organization_id == organization_id,
+            ),
+        )
+        dispatched = _sum_scalar(
+            session,
+            select(func.coalesce(func.sum(ShipmentItem.quantity), 0))
+            .join(Shipment, Shipment.id == ShipmentItem.shipment_id)
+            .where(
+                ShipmentItem.organization_id == organization_id,
+                ShipmentItem.batch_id == batch.id,
+                Shipment.organization_id == organization_id,
+                Shipment.status == "DISPATCHED",
+            ),
+        )
+        available = _qty(produced - consumed - dispatched)
+        return BatchInventoryBalance(
+            organization_id=organization_id,
+            batch_id=int(batch.id),
+            batch_public_id=batch.public_id,
+            batch_code=batch.code,
+            unit=batch.unit,
+            produced=produced,
+            consumed=consumed,
+            dispatched=dispatched,
+            available=available,
+        )
+
+    def get_batch_balance(
+        self,
+        *,
+        organization_id: int | str,
+        batch_id: int,
+    ) -> BatchInventoryBalance:
+        org_id = _normalize_organization_id(organization_id)
+        session = self._session_factory()
+        if session is None:
+            raise TraceabilityPersistenceError(
+                "Servicio de base de datos no disponible."
+            )
+        try:
+            set_tenant_db_context(session, org_id)
+            batch = session.execute(
+                select(TraceabilityBatch).where(
+                    TraceabilityBatch.organization_id == org_id,
+                    TraceabilityBatch.id == int(batch_id),
+                )
+            ).scalar_one_or_none()
+            if batch is None:
+                raise TraceabilityNotFoundError(
+                    "El lote industrial no existe en el tenant activo."
+                )
+            return self._balance_for_batch(
+                session,
+                organization_id=org_id,
+                batch=batch,
+            )
+        except TraceabilityLedgerError:
+            session.rollback()
+            raise
+        except SQLAlchemyError as exc:
+            session.rollback()
+            raise TraceabilityPersistenceError(
+                "No fue posible consultar el saldo del lote industrial."
+            ) from exc
+        finally:
+            session.close()
+
+    @staticmethod
+    def _validate_lines_against_batches(
+        *,
+        batches: dict[int, TraceabilityBatch],
+        inputs: list[TraceabilityEventInput],
+        outputs: list[TraceabilityEventOutput],
+    ) -> None:
+        for line in [*inputs, *outputs]:
+            batch = batches[int(line.batch_id)]
+            if batch.status != "ACTIVE":
+                raise TraceabilityValidationError(
+                    "BATCH_NOT_ACTIVE",
+                    f"El lote industrial {batch.code} no está activo.",
+                )
+            if str(line.unit) != str(batch.unit):
+                raise TraceabilityValidationError(
+                    "BATCH_UNIT_MISMATCH",
+                    (
+                        f"La línea del lote {batch.code} usa {line.unit}, "
+                        f"pero el lote está contabilizado en {batch.unit}."
+                    ),
+                )
+            if _qty(line.quantity) <= ZERO:
+                raise TraceabilityValidationError(
+                    "NON_POSITIVE_QUANTITY",
+                    "Todas las cantidades del evento deben ser mayores que cero.",
+                )
+
+    @staticmethod
+    def _validate_event_shape(
+        event: TraceabilityEvent,
+        inputs: list[TraceabilityEventInput],
+        outputs: list[TraceabilityEventOutput],
+        batches: dict[int, TraceabilityBatch],
+    ) -> None:
+        event_type = str(event.event_type)
+        if event_type not in LEDGER_EVENT_TYPES:
+            raise TraceabilityValidationError(
+                "UNSUPPORTED_EVENT_TYPE",
+                "El tipo de evento industrial no está soportado por el ledger.",
+            )
+
+        input_ids = {int(line.batch_id) for line in inputs}
+        output_ids = {int(line.batch_id) for line in outputs}
+        if input_ids & output_ids:
+            raise TraceabilityValidationError(
+                "SELF_REFERENTIAL_EVENT",
+                "Un mismo lote no puede ser entrada y salida del mismo evento.",
+            )
+
+        if event_type == "RECEIPT":
+            if inputs or not outputs:
+                raise TraceabilityValidationError(
+                    "INVALID_RECEIPT_SHAPE",
+                    "Una recepción debe crear al menos una salida y no consumir lotes.",
+                )
+            for line in outputs:
+                batch = batches[int(line.batch_id)]
+                if batch.stage not in {"RECEIPT", "RAW_MATERIAL"}:
+                    raise TraceabilityValidationError(
+                        "INVALID_RECEIPT_STAGE",
+                        "Una recepción sólo puede originar lotes de recepción o materia prima.",
+                    )
+                if batch.source_lote_id is None:
+                    raise TraceabilityValidationError(
+                        "RECEIPT_WITHOUT_SOURCE_PLOT",
+                        (
+                            "La materia prima recibida debe estar vinculada a un "
+                            "lote/parcela de origen antes de contabilizar stock."
+                        ),
+                    )
+            return
+
+        if event_type == "ADJUSTMENT":
+            if not inputs or outputs:
+                raise TraceabilityValidationError(
+                    "INVALID_ADJUSTMENT_SHAPE",
+                    (
+                        "P1B sólo admite ajustes negativos documentados: deben "
+                        "consumir stock y no crear material nuevo."
+                    ),
+                )
+            return
+
+        if not inputs or not outputs:
+            raise TraceabilityValidationError(
+                "INVALID_TRANSFORMATION_SHAPE",
+                "La operación industrial debe tener entradas y salidas.",
+            )
+
+        input_totals = _line_totals(inputs)
+        output_totals = _line_totals(outputs)
+        if set(output_totals) - set(input_totals):
+            raise TraceabilityValidationError(
+                "UNIT_CONVERSION_REQUIRED",
+                (
+                    "La transformación intenta producir una unidad física que no "
+                    "existe en las entradas. Debe definirse una conversión "
+                    "documentada antes de automatizar ese proceso."
+                ),
+            )
+        for unit, output_quantity in output_totals.items():
+            if output_quantity > input_totals.get(unit, ZERO):
+                raise TraceabilityValidationError(
+                    "OUTPUT_EXCEEDS_INPUT",
+                    (
+                        f"La salida {output_quantity} {unit} supera la entrada "
+                        f"{input_totals.get(unit, ZERO)} {unit}."
+                    ),
+                )
+
+    def post_event(
+        self,
+        *,
+        organization_id: int | str,
+        event_id: int,
+        actor: AuditActor,
+        request_context: AuditRequestContext | None = None,
+    ) -> EventPostingResult:
+        org_id = _normalize_organization_id(organization_id)
+        self._validate_actor_scope(actor, org_id)
+        session = self._session_factory()
+        if session is None:
+            raise TraceabilityPersistenceError(
+                "Servicio de base de datos no disponible."
+            )
+
+        try:
+            set_tenant_db_context(session, org_id)
+            event = session.execute(
+                select(TraceabilityEvent)
+                .where(
+                    TraceabilityEvent.organization_id == org_id,
+                    TraceabilityEvent.id == int(event_id),
+                )
+                .with_for_update()
+            ).scalar_one_or_none()
+            if event is None:
+                raise TraceabilityNotFoundError(
+                    "El evento industrial no existe en el tenant activo."
+                )
+            if event.status != "DRAFT":
+                raise TraceabilityStateError(
+                    "Sólo los eventos DRAFT pueden contabilizarse."
+                )
+
+            inputs = list(
+                session.execute(
+                    select(TraceabilityEventInput)
+                    .where(
+                        TraceabilityEventInput.organization_id == org_id,
+                        TraceabilityEventInput.event_id == event.id,
+                    )
+                    .order_by(TraceabilityEventInput.id)
+                ).scalars().all()
+            )
+            outputs = list(
+                session.execute(
+                    select(TraceabilityEventOutput)
+                    .where(
+                        TraceabilityEventOutput.organization_id == org_id,
+                        TraceabilityEventOutput.event_id == event.id,
+                    )
+                    .order_by(TraceabilityEventOutput.id)
+                ).scalars().all()
+            )
+
+            batches = self._lock_batches(
+                session,
+                organization_id=org_id,
+                batch_ids=[line.batch_id for line in [*inputs, *outputs]],
+            )
+            self._validate_lines_against_batches(
+                batches=batches,
+                inputs=inputs,
+                outputs=outputs,
+            )
+            self._validate_event_shape(event, inputs, outputs, batches)
+
+            for line in inputs:
+                batch = batches[int(line.batch_id)]
+                balance = self._balance_for_batch(
+                    session,
+                    organization_id=org_id,
+                    batch=batch,
+                )
+                requested = _qty(line.quantity)
+                if requested > balance.available:
+                    raise TraceabilityValidationError(
+                        "INSUFFICIENT_BATCH_STOCK",
+                        (
+                            f"El lote {batch.code} dispone de {balance.available} "
+                            f"{batch.unit} y se intentan consumir {requested} {batch.unit}."
+                        ),
+                    )
+                produced_at = self._latest_producer_time(
+                    session,
+                    organization_id=org_id,
+                    batch_id=batch.id,
+                )
+                if produced_at is not None and event.occurred_at < produced_at:
+                    raise TraceabilityValidationError(
+                        "EVENT_BEFORE_INPUT_PRODUCTION",
+                        "El evento no puede ocurrir antes de la producción de una de sus entradas.",
+                    )
+
+            for line in outputs:
+                if self._posted_producer_count(
+                    session,
+                    organization_id=org_id,
+                    batch_id=int(line.batch_id),
+                ):
+                    raise TraceabilityValidationError(
+                        "BATCH_ALREADY_HAS_PRODUCER",
+                        (
+                            f"El lote {batches[int(line.batch_id)].code} ya tiene "
+                            "un evento productor contabilizado."
+                        ),
+                    )
+
+            summaries = _unit_summaries(inputs, outputs)
+            event.status = "POSTED"
+            session.flush()
+
+            record_audit_event(
+                session,
+                actor=actor,
+                action=AuditAction.TRACEABILITY_EVENT_POST,
+                entity_type="traceability_event",
+                entity_id=event.id,
+                outcome=AuditOutcome.SUCCESS,
+                request_context=request_context,
+                metadata={
+                    "event_code": event.event_code,
+                    "event_type": event.event_type,
+                    "facility_reference": event.facility_reference,
+                    "unit_balances": [
+                        {
+                            "unit": item.unit,
+                            "input_quantity": str(item.input_quantity),
+                            "output_quantity": str(item.output_quantity),
+                            "loss_quantity": str(item.loss_quantity),
+                            "yield_ratio": (
+                                str(item.yield_ratio)
+                                if item.yield_ratio is not None
+                                else None
+                            ),
+                        }
+                        for item in summaries
+                    ],
+                },
+                before_data={"status": "DRAFT"},
+                after_data={"status": "POSTED"},
+            )
+            session.commit()
+
+            return EventPostingResult(
+                organization_id=org_id,
+                event_id=int(event.id),
+                event_public_id=event.public_id,
+                event_code=event.event_code,
+                event_type=event.event_type,
+                status="POSTED",
+                unit_balances=summaries,
+            )
+        except TraceabilityLedgerError:
+            session.rollback()
+            raise
+        except SQLAlchemyError as exc:
+            session.rollback()
+            raise TraceabilityPersistenceError(
+                "No fue posible contabilizar el evento industrial."
+            ) from exc
+        except Exception as exc:
+            session.rollback()
+            raise TraceabilityPersistenceError(
+                "No fue posible completar la contabilización industrial."
+            ) from exc
+        finally:
+            session.close()
+
+    def dispatch_shipment(
+        self,
+        *,
+        organization_id: int | str,
+        shipment_id: int,
+        actor: AuditActor,
+        request_context: AuditRequestContext | None = None,
+    ) -> ShipmentDispatchResult:
+        org_id = _normalize_organization_id(organization_id)
+        self._validate_actor_scope(actor, org_id)
+        session = self._session_factory()
+        if session is None:
+            raise TraceabilityPersistenceError(
+                "Servicio de base de datos no disponible."
+            )
+
+        try:
+            set_tenant_db_context(session, org_id)
+            shipment = session.execute(
+                select(Shipment)
+                .where(
+                    Shipment.organization_id == org_id,
+                    Shipment.id == int(shipment_id),
+                )
+                .with_for_update()
+            ).scalar_one_or_none()
+            if shipment is None:
+                raise TraceabilityNotFoundError(
+                    "El despacho no existe en el tenant activo."
+                )
+            if shipment.status not in {"DRAFT", "CONFIRMED"}:
+                raise TraceabilityStateError(
+                    "Sólo los despachos DRAFT o CONFIRMED pueden despacharse."
+                )
+
+            items = list(
+                session.execute(
+                    select(ShipmentItem)
+                    .where(
+                        ShipmentItem.organization_id == org_id,
+                        ShipmentItem.shipment_id == shipment.id,
+                    )
+                    .order_by(ShipmentItem.id)
+                ).scalars().all()
+            )
+            if not items:
+                raise TraceabilityValidationError(
+                    "EMPTY_SHIPMENT",
+                    "El despacho debe contener al menos un lote industrial.",
+                )
+
+            batches = self._lock_batches(
+                session,
+                organization_id=org_id,
+                batch_ids=[item.batch_id for item in items],
+            )
+            dispatch_time = shipment.shipped_at or datetime.now(timezone.utc)
+            quantities_by_unit = _line_totals(items)
+
+            for item in items:
+                batch = batches[int(item.batch_id)]
+                if batch.status != "ACTIVE":
+                    raise TraceabilityValidationError(
+                        "BATCH_NOT_ACTIVE",
+                        f"El lote industrial {batch.code} no está activo.",
+                    )
+                if str(item.unit) != str(batch.unit):
+                    raise TraceabilityValidationError(
+                        "BATCH_UNIT_MISMATCH",
+                        (
+                            f"El despacho usa {item.unit} para {batch.code}, "
+                            f"pero el lote está contabilizado en {batch.unit}."
+                        ),
+                    )
+                requested = _qty(item.quantity)
+                if requested <= ZERO:
+                    raise TraceabilityValidationError(
+                        "NON_POSITIVE_QUANTITY",
+                        "Las cantidades despachadas deben ser mayores que cero.",
+                    )
+                balance = self._balance_for_batch(
+                    session,
+                    organization_id=org_id,
+                    batch=batch,
+                )
+                if requested > balance.available:
+                    raise TraceabilityValidationError(
+                        "INSUFFICIENT_BATCH_STOCK",
+                        (
+                            f"El lote {batch.code} dispone de {balance.available} "
+                            f"{batch.unit} y se intentan despachar {requested} {batch.unit}."
+                        ),
+                    )
+                produced_at = self._latest_producer_time(
+                    session,
+                    organization_id=org_id,
+                    batch_id=batch.id,
+                )
+                if produced_at is None:
+                    raise TraceabilityValidationError(
+                        "SHIPMENT_WITHOUT_POSTED_ORIGIN",
+                        "No se puede despachar material sin un evento productor contabilizado.",
+                    )
+                if dispatch_time < produced_at:
+                    raise TraceabilityValidationError(
+                        "SHIPMENT_BEFORE_PRODUCTION",
+                        "El despacho no puede ocurrir antes de la producción del material.",
+                    )
+
+            previous_status = shipment.status
+            shipment.status = "DISPATCHED"
+            shipment.shipped_at = dispatch_time
+            session.flush()
+
+            record_audit_event(
+                session,
+                actor=actor,
+                action=AuditAction.TRACEABILITY_SHIPMENT_DISPATCH,
+                entity_type="shipment",
+                entity_id=shipment.id,
+                outcome=AuditOutcome.SUCCESS,
+                request_context=request_context,
+                metadata={
+                    "shipment_code": shipment.shipment_code,
+                    "sale_reference": shipment.sale_reference,
+                    "buyer_reference": shipment.buyer_reference,
+                    "destination_country": shipment.destination_country,
+                    "quantities_by_unit": {
+                        unit: str(quantity)
+                        for unit, quantity in quantities_by_unit.items()
+                    },
+                },
+                before_data={"status": previous_status},
+                after_data={
+                    "status": "DISPATCHED",
+                    "shipped_at": dispatch_time.isoformat(),
+                },
+            )
+            session.commit()
+
+            return ShipmentDispatchResult(
+                organization_id=org_id,
+                shipment_id=int(shipment.id),
+                shipment_public_id=shipment.public_id,
+                shipment_code=shipment.shipment_code,
+                status="DISPATCHED",
+                shipped_at=dispatch_time,
+                quantities_by_unit=tuple(sorted(quantities_by_unit.items())),
+            )
+        except TraceabilityLedgerError:
+            session.rollback()
+            raise
+        except SQLAlchemyError as exc:
+            session.rollback()
+            raise TraceabilityPersistenceError(
+                "No fue posible contabilizar el despacho."
+            ) from exc
+        except Exception as exc:
+            session.rollback()
+            raise TraceabilityPersistenceError(
+                "No fue posible completar el despacho."
+            ) from exc
+        finally:
+            session.close()

--- a/src/litoral_trace/services/traceability_lineage.py
+++ b/src/litoral_trace/services/traceability_lineage.py
@@ -1,0 +1,731 @@
+"""Reverse genealogy queries for buyer-ready chain-of-custody evidence.
+
+P1C deliberately reads the immutable P1A/P1B graph instead of persisting a
+second provenance projection. The main commercial query starts at a shipment
+and walks backwards through posted producer events until source ``Lote``
+records are reached.
+
+Where a transformation mixes more than one homogeneous input, P1C attributes
+output provenance according to each input's share of total event input. This
+is an explicit accounting convention (``PROPORTIONAL_INPUT_ALLOCATION``), not
+an assertion that individual fibres can be physically distinguished after
+mixing. Missing producers, cycles, unit inconsistencies, or broken source
+links make the lineage incomplete instead of being silently accepted.
+"""
+from __future__ import annotations
+
+from collections import defaultdict
+from dataclasses import dataclass
+from decimal import Decimal, ROUND_HALF_UP
+from typing import Any
+
+from sqlalchemy import func, select
+from sqlalchemy.orm import Session
+
+from litoral_trace.db.models import (
+    Lote,
+    Shipment,
+    ShipmentItem,
+    TraceabilityBatch,
+    TraceabilityEvent,
+    TraceabilityEventInput,
+    TraceabilityEventOutput,
+)
+from litoral_trace.db.tenant import set_tenant_db_context
+
+
+QTY_QUANTUM = Decimal("0.000001")
+ZERO = Decimal("0.000000")
+ONE = Decimal("1.000000")
+MAX_LINEAGE_DEPTH = 64
+ALLOCATION_METHOD = "PROPORTIONAL_INPUT_ALLOCATION"
+
+
+class TraceabilityLineageError(RuntimeError):
+    """Base P1C lineage failure."""
+
+
+class TraceabilityLineageValidationError(TraceabilityLineageError):
+    """Invalid lineage query input."""
+
+    def __init__(self, code: str, detail: str) -> None:
+        super().__init__(detail)
+        self.code = code
+
+
+class TraceabilityLineageNotFoundError(TraceabilityLineageError):
+    """Requested tenant-scoped shipment does not exist."""
+
+    def __init__(self, code: str, detail: str) -> None:
+        super().__init__(detail)
+        self.code = code
+
+
+@dataclass(frozen=True)
+class _Profile:
+    shares: dict[int, Decimal]
+    event_ids: frozenset[int]
+    issues: tuple[dict[str, Any], ...]
+
+
+class TraceabilityLineageService:
+    """Read-only reverse genealogy service scoped to one tenant."""
+
+    def __init__(
+        self,
+        *,
+        session: Session,
+        organization_id: int,
+        max_depth: int = MAX_LINEAGE_DEPTH,
+    ) -> None:
+        if session is None:
+            raise TraceabilityLineageValidationError(
+                "LINEAGE_SESSION_REQUIRED",
+                "Se requiere una sesión de base de datos válida.",
+            )
+        try:
+            normalized_org = int(organization_id)
+        except (TypeError, ValueError) as exc:
+            raise TraceabilityLineageValidationError(
+                "LINEAGE_TENANT_INVALID",
+                "organization_id debe ser un entero válido.",
+            ) from exc
+        if normalized_org <= 0:
+            raise TraceabilityLineageValidationError(
+                "LINEAGE_TENANT_INVALID",
+                "organization_id debe ser mayor que cero.",
+            )
+        if max_depth <= 0:
+            raise TraceabilityLineageValidationError(
+                "LINEAGE_DEPTH_INVALID",
+                "max_depth debe ser mayor que cero.",
+            )
+
+        self.session = session
+        self.organization_id = normalized_org
+        self.max_depth = max_depth
+        set_tenant_db_context(self.session, self.organization_id)
+
+        self._batch_cache: dict[int, TraceabilityBatch | None] = {}
+        self._lote_cache: dict[int, Lote | None] = {}
+        self._producer_cache: dict[int, list[tuple[TraceabilityEventOutput, TraceabilityEvent]]] = {}
+        self._event_inputs_cache: dict[int, list[TraceabilityEventInput]] = {}
+        self._event_outputs_cache: dict[int, list[TraceabilityEventOutput]] = {}
+        self._event_cache: dict[int, TraceabilityEvent | None] = {}
+        self._profile_cache: dict[int, _Profile] = {}
+
+    @staticmethod
+    def _q(value: Decimal | int | str) -> Decimal:
+        return Decimal(value).quantize(QTY_QUANTUM, rounding=ROUND_HALF_UP)
+
+    @classmethod
+    def _decimal_str(cls, value: Decimal | int | str) -> str:
+        return f"{cls._q(value):.6f}"
+
+    @staticmethod
+    def _issue(
+        code: str,
+        message: str,
+        *,
+        batch_id: int | None = None,
+        event_id: int | None = None,
+    ) -> dict[str, Any]:
+        issue: dict[str, Any] = {
+            "code": code,
+            "message": message,
+        }
+        if batch_id is not None:
+            issue["batch_id"] = batch_id
+        if event_id is not None:
+            issue["event_id"] = event_id
+        return issue
+
+    def _get_batch(self, batch_id: int) -> TraceabilityBatch | None:
+        if batch_id not in self._batch_cache:
+            self._batch_cache[batch_id] = self.session.execute(
+                select(TraceabilityBatch).where(
+                    TraceabilityBatch.id == batch_id,
+                    TraceabilityBatch.organization_id == self.organization_id,
+                )
+            ).scalar_one_or_none()
+        return self._batch_cache[batch_id]
+
+    def _get_lote(self, lote_id: int) -> Lote | None:
+        if lote_id not in self._lote_cache:
+            self._lote_cache[lote_id] = self.session.execute(
+                select(Lote).where(
+                    Lote.id == lote_id,
+                    Lote.organization_id == self.organization_id,
+                )
+            ).scalar_one_or_none()
+        return self._lote_cache[lote_id]
+
+    def _get_event(self, event_id: int) -> TraceabilityEvent | None:
+        if event_id not in self._event_cache:
+            self._event_cache[event_id] = self.session.execute(
+                select(TraceabilityEvent).where(
+                    TraceabilityEvent.id == event_id,
+                    TraceabilityEvent.organization_id == self.organization_id,
+                )
+            ).scalar_one_or_none()
+        return self._event_cache[event_id]
+
+    def _get_producers(
+        self,
+        batch_id: int,
+    ) -> list[tuple[TraceabilityEventOutput, TraceabilityEvent]]:
+        if batch_id not in self._producer_cache:
+            rows = self.session.execute(
+                select(TraceabilityEventOutput, TraceabilityEvent)
+                .join(
+                    TraceabilityEvent,
+                    (TraceabilityEvent.id == TraceabilityEventOutput.event_id)
+                    & (
+                        TraceabilityEvent.organization_id
+                        == TraceabilityEventOutput.organization_id
+                    ),
+                )
+                .where(
+                    TraceabilityEventOutput.organization_id == self.organization_id,
+                    TraceabilityEventOutput.batch_id == batch_id,
+                    TraceabilityEvent.status == "POSTED",
+                )
+                .order_by(TraceabilityEvent.id)
+            ).all()
+            self._producer_cache[batch_id] = [
+                (output, event) for output, event in rows
+            ]
+        return self._producer_cache[batch_id]
+
+    def _get_event_inputs(self, event_id: int) -> list[TraceabilityEventInput]:
+        if event_id not in self._event_inputs_cache:
+            self._event_inputs_cache[event_id] = list(
+                self.session.execute(
+                    select(TraceabilityEventInput)
+                    .where(
+                        TraceabilityEventInput.organization_id == self.organization_id,
+                        TraceabilityEventInput.event_id == event_id,
+                    )
+                    .order_by(TraceabilityEventInput.id)
+                ).scalars().all()
+            )
+        return self._event_inputs_cache[event_id]
+
+    def _get_event_outputs(self, event_id: int) -> list[TraceabilityEventOutput]:
+        if event_id not in self._event_outputs_cache:
+            self._event_outputs_cache[event_id] = list(
+                self.session.execute(
+                    select(TraceabilityEventOutput)
+                    .where(
+                        TraceabilityEventOutput.organization_id == self.organization_id,
+                        TraceabilityEventOutput.event_id == event_id,
+                    )
+                    .order_by(TraceabilityEventOutput.id)
+                ).scalars().all()
+            )
+        return self._event_outputs_cache[event_id]
+
+    def _profile_batch(
+        self,
+        batch_id: int,
+        *,
+        path: tuple[int, ...] = (),
+        depth: int = 0,
+    ) -> _Profile:
+        if batch_id in self._profile_cache:
+            return self._profile_cache[batch_id]
+
+        if depth > self.max_depth:
+            return _Profile(
+                shares={},
+                event_ids=frozenset(),
+                issues=(
+                    self._issue(
+                        "LINEAGE_DEPTH_EXCEEDED",
+                        "La genealogía excede la profundidad máxima permitida.",
+                        batch_id=batch_id,
+                    ),
+                ),
+            )
+
+        if batch_id in path:
+            return _Profile(
+                shares={},
+                event_ids=frozenset(),
+                issues=(
+                    self._issue(
+                        "LINEAGE_CYCLE_DETECTED",
+                        "Se detectó un ciclo en la genealogía industrial.",
+                        batch_id=batch_id,
+                    ),
+                ),
+            )
+
+        batch = self._get_batch(batch_id)
+        if batch is None:
+            return _Profile(
+                shares={},
+                event_ids=frozenset(),
+                issues=(
+                    self._issue(
+                        "LINEAGE_BATCH_NOT_FOUND",
+                        "Un lote industrial referenciado no está disponible para el tenant.",
+                        batch_id=batch_id,
+                    ),
+                ),
+            )
+
+        producers = self._get_producers(batch.id)
+        producer_event_ids = frozenset(event.id for _, event in producers)
+
+        if batch.source_lote_id is not None:
+            lote = self._get_lote(batch.source_lote_id)
+            if lote is None:
+                profile = _Profile(
+                    shares={},
+                    event_ids=producer_event_ids,
+                    issues=(
+                        self._issue(
+                            "SOURCE_LOTE_NOT_FOUND",
+                            "El lote industrial declara un origen que no puede resolverse.",
+                            batch_id=batch.id,
+                        ),
+                    ),
+                )
+                self._profile_cache[batch.id] = profile
+                return profile
+
+            issues: list[dict[str, Any]] = []
+            if len(producers) > 1:
+                issues.append(
+                    self._issue(
+                        "MULTIPLE_POSTED_PRODUCERS",
+                        "El lote fuente tiene más de un evento productor contabilizado.",
+                        batch_id=batch.id,
+                    )
+                )
+            for _, event in producers:
+                if event.event_type != "RECEIPT":
+                    issues.append(
+                        self._issue(
+                            "SOURCE_BATCH_NON_RECEIPT_PRODUCER",
+                            "Un lote vinculado a parcela fue producido por un evento distinto de RECEIPT.",
+                            batch_id=batch.id,
+                            event_id=event.id,
+                        )
+                    )
+
+            profile = _Profile(
+                shares={lote.id: ONE},
+                event_ids=producer_event_ids,
+                issues=tuple(issues),
+            )
+            self._profile_cache[batch.id] = profile
+            return profile
+
+        if not producers:
+            profile = _Profile(
+                shares={},
+                event_ids=frozenset(),
+                issues=(
+                    self._issue(
+                        "MISSING_PROVENANCE",
+                        "El lote industrial no tiene parcela de origen ni evento productor POSTED.",
+                        batch_id=batch.id,
+                    ),
+                ),
+            )
+            self._profile_cache[batch.id] = profile
+            return profile
+
+        if len(producers) != 1:
+            profile = _Profile(
+                shares={},
+                event_ids=producer_event_ids,
+                issues=(
+                    self._issue(
+                        "MULTIPLE_POSTED_PRODUCERS",
+                        "El lote industrial tiene más de un evento productor contabilizado.",
+                        batch_id=batch.id,
+                    ),
+                ),
+            )
+            self._profile_cache[batch.id] = profile
+            return profile
+
+        output_edge, event = producers[0]
+        inputs = self._get_event_inputs(event.id)
+        issues: list[dict[str, Any]] = []
+
+        if output_edge.unit != batch.unit:
+            issues.append(
+                self._issue(
+                    "OUTPUT_UNIT_MISMATCH",
+                    "La unidad del output no coincide con la unidad del lote industrial.",
+                    batch_id=batch.id,
+                    event_id=event.id,
+                )
+            )
+
+        if not inputs:
+            issues.append(
+                self._issue(
+                    "PRODUCER_WITHOUT_INPUTS",
+                    "El evento productor no contiene entradas trazables.",
+                    batch_id=batch.id,
+                    event_id=event.id,
+                )
+            )
+            profile = _Profile(
+                shares={},
+                event_ids=frozenset({event.id}),
+                issues=tuple(issues),
+            )
+            self._profile_cache[batch.id] = profile
+            return profile
+
+        input_units = {edge.unit for edge in inputs}
+        if input_units != {batch.unit}:
+            issues.append(
+                self._issue(
+                    "LINEAGE_UNIT_CONVERSION_REQUIRED",
+                    "La genealogía requiere una conversión de unidades no documentada.",
+                    batch_id=batch.id,
+                    event_id=event.id,
+                )
+            )
+            profile = _Profile(
+                shares={},
+                event_ids=frozenset({event.id}),
+                issues=tuple(issues),
+            )
+            self._profile_cache[batch.id] = profile
+            return profile
+
+        total_input = sum((self._q(edge.quantity) for edge in inputs), ZERO)
+        if total_input <= ZERO:
+            issues.append(
+                self._issue(
+                    "PRODUCER_INPUT_TOTAL_INVALID",
+                    "El total de entradas del evento productor no es positivo.",
+                    batch_id=batch.id,
+                    event_id=event.id,
+                )
+            )
+            profile = _Profile(
+                shares={},
+                event_ids=frozenset({event.id}),
+                issues=tuple(issues),
+            )
+            self._profile_cache[batch.id] = profile
+            return profile
+
+        combined: dict[int, Decimal] = defaultdict(lambda: ZERO)
+        event_ids: set[int] = {event.id}
+        next_path = (*path, batch.id)
+
+        for edge in inputs:
+            child = self._profile_batch(
+                edge.batch_id,
+                path=next_path,
+                depth=depth + 1,
+            )
+            input_weight = self._q(edge.quantity) / total_input
+            for lote_id, child_share in child.shares.items():
+                combined[lote_id] += child_share * input_weight
+            event_ids.update(child.event_ids)
+            issues.extend(child.issues)
+
+        normalized_shares = {
+            lote_id: self._q(share)
+            for lote_id, share in combined.items()
+            if share > ZERO
+        }
+        profile = _Profile(
+            shares=normalized_shares,
+            event_ids=frozenset(event_ids),
+            issues=tuple(issues),
+        )
+        self._profile_cache[batch.id] = profile
+        return profile
+
+    def _serialize_batch(self, batch: TraceabilityBatch) -> dict[str, Any]:
+        return {
+            "id": batch.id,
+            "public_id": str(batch.public_id),
+            "code": batch.code,
+            "product_name": batch.product_name,
+            "stage": batch.stage,
+            "unit": batch.unit,
+            "status": batch.status,
+            "source_lote_id": batch.source_lote_id,
+        }
+
+    def _serialize_lote(self, lote: Lote) -> dict[str, Any]:
+        return {
+            "id": lote.id,
+            "identificador": lote.identificador,
+            "productor_id": lote.productor_id,
+            "producto_forestal": lote.producto_forestal,
+            "hectareas": lote.hectareas,
+            "latitud": lote.latitud,
+            "longitud": lote.longitud,
+            "polygon_wkt": lote.polygon_wkt,
+            "estatus": lote.estatus,
+        }
+
+    def _serialize_event(self, event_id: int) -> dict[str, Any] | None:
+        event = self._get_event(event_id)
+        if event is None:
+            return None
+        inputs = self._get_event_inputs(event.id)
+        outputs = self._get_event_outputs(event.id)
+
+        input_units = {edge.unit for edge in inputs}
+        output_units = {edge.unit for edge in outputs}
+        homogeneous_unit = None
+        if len(input_units | output_units) == 1:
+            homogeneous_unit = next(iter(input_units | output_units), None)
+
+        total_input = sum((self._q(edge.quantity) for edge in inputs), ZERO)
+        total_output = sum((self._q(edge.quantity) for edge in outputs), ZERO)
+        loss = None
+        yield_ratio = None
+        if homogeneous_unit is not None and inputs:
+            loss = self._q(total_input - total_output)
+            if total_input > ZERO:
+                yield_ratio = self._q(total_output / total_input)
+
+        def edge_payload(edge: TraceabilityEventInput | TraceabilityEventOutput) -> dict[str, Any]:
+            batch = self._get_batch(edge.batch_id)
+            return {
+                "batch_id": edge.batch_id,
+                "batch_code": batch.code if batch is not None else None,
+                "quantity": self._decimal_str(edge.quantity),
+                "unit": edge.unit,
+            }
+
+        return {
+            "id": event.id,
+            "public_id": str(event.public_id),
+            "event_code": event.event_code,
+            "event_type": event.event_type,
+            "status": event.status,
+            "occurred_at": event.occurred_at.isoformat(),
+            "facility_reference": event.facility_reference,
+            "inputs": [edge_payload(edge) for edge in inputs],
+            "outputs": [edge_payload(edge) for edge in outputs],
+            "reconciliation": {
+                "unit": homogeneous_unit,
+                "input_quantity": self._decimal_str(total_input),
+                "output_quantity": self._decimal_str(total_output),
+                "loss_quantity": self._decimal_str(loss) if loss is not None else None,
+                "yield_ratio": self._decimal_str(yield_ratio) if yield_ratio is not None else None,
+            },
+        }
+
+    def trace_shipment(self, shipment_code: str) -> dict[str, Any]:
+        normalized_code = (shipment_code or "").strip()
+        if not normalized_code:
+            raise TraceabilityLineageValidationError(
+                "SHIPMENT_CODE_REQUIRED",
+                "shipment_code es obligatorio.",
+            )
+
+        shipment = self.session.execute(
+            select(Shipment).where(
+                Shipment.organization_id == self.organization_id,
+                func.lower(Shipment.shipment_code) == normalized_code.lower(),
+            )
+        ).scalar_one_or_none()
+        if shipment is None:
+            raise TraceabilityLineageNotFoundError(
+                "SHIPMENT_NOT_FOUND",
+                "El despacho solicitado no existe para la organización autenticada.",
+            )
+
+        items = list(
+            self.session.execute(
+                select(ShipmentItem)
+                .where(
+                    ShipmentItem.organization_id == self.organization_id,
+                    ShipmentItem.shipment_id == shipment.id,
+                )
+                .order_by(ShipmentItem.id)
+            ).scalars().all()
+        )
+
+        top_issues: list[dict[str, Any]] = []
+        if not items:
+            top_issues.append(
+                self._issue(
+                    "SHIPMENT_WITHOUT_ITEMS",
+                    "El despacho no contiene lotes industriales asignados.",
+                )
+            )
+
+        event_ids: set[int] = set()
+        source_totals: dict[tuple[int, str], Decimal] = defaultdict(lambda: ZERO)
+        unit_shipped: dict[str, Decimal] = defaultdict(lambda: ZERO)
+        unit_attributed: dict[str, Decimal] = defaultdict(lambda: ZERO)
+        item_payloads: list[dict[str, Any]] = []
+
+        for item in items:
+            quantity = self._q(item.quantity)
+            unit_shipped[item.unit] += quantity
+            batch = self._get_batch(item.batch_id)
+            item_issues: list[dict[str, Any]] = []
+            source_payloads: list[dict[str, Any]] = []
+
+            if batch is None:
+                item_issues.append(
+                    self._issue(
+                        "SHIPMENT_BATCH_NOT_FOUND",
+                        "Un lote del despacho no puede resolverse para el tenant.",
+                        batch_id=item.batch_id,
+                    )
+                )
+                item_payloads.append(
+                    {
+                        "shipment_item_id": item.id,
+                        "batch": None,
+                        "shipped_quantity": self._decimal_str(quantity),
+                        "unit": item.unit,
+                        "complete": False,
+                        "issues": item_issues,
+                        "source_contributions": [],
+                    }
+                )
+                continue
+
+            if item.unit != batch.unit:
+                item_issues.append(
+                    self._issue(
+                        "SHIPMENT_UNIT_MISMATCH",
+                        "La unidad despachada no coincide con la unidad del lote industrial.",
+                        batch_id=batch.id,
+                    )
+                )
+
+            profile = self._profile_batch(batch.id)
+            event_ids.update(profile.event_ids)
+            item_issues.extend(profile.issues)
+
+            attributed = ZERO
+            for lote_id, share in sorted(profile.shares.items()):
+                lote = self._get_lote(lote_id)
+                if lote is None:
+                    item_issues.append(
+                        self._issue(
+                            "SOURCE_LOTE_NOT_FOUND",
+                            "Un origen atribuido no puede resolverse para el tenant.",
+                            batch_id=batch.id,
+                        )
+                    )
+                    continue
+                allocated = self._q(quantity * share)
+                if allocated <= ZERO:
+                    continue
+                attributed += allocated
+                source_totals[(lote.id, item.unit)] += allocated
+                source_payloads.append(
+                    {
+                        "lote": self._serialize_lote(lote),
+                        "attributed_shipment_quantity": self._decimal_str(allocated),
+                        "unit": item.unit,
+                        "share_of_shipment_item": self._decimal_str(
+                            allocated / quantity if quantity > ZERO else ZERO
+                        ),
+                    }
+                )
+
+            attributed = self._q(attributed)
+            unit_attributed[item.unit] += attributed
+            unresolved = self._q(max(quantity - attributed, ZERO))
+            complete = not item_issues and unresolved == ZERO
+
+            item_payloads.append(
+                {
+                    "shipment_item_id": item.id,
+                    "batch": self._serialize_batch(batch),
+                    "shipped_quantity": self._decimal_str(quantity),
+                    "unit": item.unit,
+                    "attributed_quantity": self._decimal_str(attributed),
+                    "unresolved_quantity": self._decimal_str(unresolved),
+                    "complete": complete,
+                    "issues": item_issues,
+                    "source_contributions": source_payloads,
+                }
+            )
+
+        unit_totals: list[dict[str, Any]] = []
+        for unit in sorted(unit_shipped):
+            shipped = self._q(unit_shipped[unit])
+            attributed = self._q(unit_attributed[unit])
+            unit_totals.append(
+                {
+                    "unit": unit,
+                    "shipped_quantity": self._decimal_str(shipped),
+                    "attributed_quantity": self._decimal_str(attributed),
+                    "unresolved_quantity": self._decimal_str(max(shipped - attributed, ZERO)),
+                }
+            )
+
+        source_lotes: list[dict[str, Any]] = []
+        for (lote_id, unit), quantity in sorted(source_totals.items()):
+            lote = self._get_lote(lote_id)
+            if lote is None:
+                continue
+            shipped_in_unit = self._q(unit_shipped[unit])
+            source_lotes.append(
+                {
+                    "lote": self._serialize_lote(lote),
+                    "attributed_shipment_quantity": self._decimal_str(quantity),
+                    "unit": unit,
+                    "share_of_shipped_unit": self._decimal_str(
+                        self._q(quantity) / shipped_in_unit
+                        if shipped_in_unit > ZERO
+                        else ZERO
+                    ),
+                }
+            )
+
+        serialized_events = [
+            payload
+            for event_id in sorted(event_ids)
+            if (payload := self._serialize_event(event_id)) is not None
+        ]
+
+        all_item_issues = [
+            issue
+            for item_payload in item_payloads
+            for issue in item_payload["issues"]
+        ]
+        complete = (
+            bool(items)
+            and not top_issues
+            and not all_item_issues
+            and all(item_payload["complete"] for item_payload in item_payloads)
+        )
+
+        return {
+            "organization_id": self.organization_id,
+            "shipment": {
+                "id": shipment.id,
+                "public_id": str(shipment.public_id),
+                "shipment_code": shipment.shipment_code,
+                "sale_reference": shipment.sale_reference,
+                "buyer_reference": shipment.buyer_reference,
+                "destination_country": shipment.destination_country,
+                "shipped_at": shipment.shipped_at.isoformat() if shipment.shipped_at else None,
+                "status": shipment.status,
+                "lineage_state": "FINAL" if shipment.status == "DISPATCHED" else "PREVIEW",
+            },
+            "allocation_method": ALLOCATION_METHOD,
+            "complete": complete,
+            "issues": [*top_issues, *all_item_issues],
+            "unit_totals": unit_totals,
+            "items": item_payloads,
+            "events": serialized_events,
+            "source_lotes": source_lotes,
+        }

--- a/src/litoral_trace/templates/traceability.html
+++ b/src/litoral_trace/templates/traceability.html
@@ -1,0 +1,446 @@
+{% extends "app/base_app.html" %}
+
+{% block title %}Trazabilidad industrial | Litoral Trace{% endblock %}
+
+{% block content %}
+{% set view = traceability_view %}
+
+<section class="mb-6 overflow-hidden rounded-2xl border border-slate-200 bg-white shadow-sm">
+    <div class="border-b border-slate-200 px-6 py-6">
+        <div class="flex flex-col gap-5 xl:flex-row xl:items-end xl:justify-between">
+            <div class="max-w-3xl">
+                <div class="mb-2 flex flex-wrap items-center gap-2">
+                    <span class="rounded border border-emerald-200 bg-emerald-50 px-2.5 py-1 text-[11px] font-bold uppercase tracking-wide text-emerald-800">
+                        Cadena de custodia
+                    </span>
+                    <span class="text-xs font-medium text-slate-500">
+                        Genealogía inversa de despacho
+                    </span>
+                </div>
+                <h1 class="text-2xl font-bold tracking-tight text-slate-950">
+                    Reconstruí el origen de una venta o despacho
+                </h1>
+                <p class="mt-2 max-w-3xl text-sm leading-6 text-slate-600">
+                    Partí del código de despacho y seguí el producto hacia atrás por lotes industriales, transformaciones y parcelas de origen. La vista usa el mismo motor P1C de la API y no modifica inventario ni eventos.
+                </p>
+            </div>
+
+            <div class="rounded-xl border border-slate-200 bg-slate-50 px-4 py-3 text-xs text-slate-600 xl:max-w-md">
+                <p class="font-semibold text-slate-800">
+                    Convención de mezclas
+                </p>
+                <p class="mt-1 leading-5">
+                    Cuando un proceso mezcla entradas homogéneas, la atribución usa la proporción documentada de inputs. Es una convención contable de trazabilidad, no identificación física de fibras individuales.
+                </p>
+            </div>
+        </div>
+    </div>
+
+    <form method="get" action="/traceability" class="bg-slate-50 px-6 py-5" role="search">
+        <label for="shipment-code" class="text-xs font-bold uppercase tracking-wider text-slate-600">
+            Código de despacho / venta
+        </label>
+        <div class="mt-2 flex flex-col gap-3 sm:flex-row">
+            <div class="relative min-w-0 flex-1">
+                <span class="pointer-events-none absolute inset-y-0 left-0 flex items-center pl-3.5 text-slate-400" aria-hidden="true">
+                    <i class="fa-solid fa-magnifying-glass"></i>
+                </span>
+                <input
+                    id="shipment-code"
+                    name="shipment_code"
+                    type="search"
+                    maxlength="120"
+                    value="{{ view.query }}"
+                    placeholder="Ej. EXP-UE-2026-001"
+                    autocomplete="off"
+                    class="w-full rounded-lg border border-slate-300 bg-white py-2.5 pl-10 pr-3 text-sm font-medium text-slate-950 shadow-sm outline-none transition focus:border-emerald-600 focus:ring-2 focus:ring-emerald-100"
+                >
+            </div>
+            <button type="submit" class="inline-flex items-center justify-center gap-2 rounded-lg bg-forest-800 px-5 py-2.5 text-sm font-semibold text-white shadow-sm transition hover:bg-forest-900">
+                <i class="fa-solid fa-route" aria-hidden="true"></i>
+                Reconstruir origen
+            </button>
+        </div>
+        <p class="mt-2 text-xs text-slate-500">
+            La búsqueda está limitada automáticamente a la organización autenticada.
+        </p>
+    </form>
+</section>
+
+{% if view.error %}
+<section class="mb-6 rounded-2xl border border-rose-200 bg-rose-50 p-5" role="alert">
+    <div class="flex items-start gap-3">
+        <span class="mt-0.5 flex h-9 w-9 shrink-0 items-center justify-center rounded-full bg-rose-100 text-rose-700" aria-hidden="true">
+            <i class="fa-solid fa-triangle-exclamation"></i>
+        </span>
+        <div>
+            <p class="text-sm font-bold text-rose-950">{{ view.error.title }}</p>
+            <p class="mt-1 text-sm leading-6 text-rose-800">{{ view.error.message }}</p>
+            <p class="mt-2 font-mono text-[11px] text-rose-700">{{ view.error.code }}</p>
+        </div>
+    </div>
+</section>
+{% endif %}
+
+{% if view.result %}
+{% set result = view.result %}
+
+<section class="mb-6 rounded-2xl border {% if result.complete %}border-emerald-200 bg-emerald-50{% else %}border-amber-200 bg-amber-50{% endif %} p-5 shadow-sm">
+    <div class="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
+        <div class="flex items-start gap-3">
+            <span class="flex h-11 w-11 shrink-0 items-center justify-center rounded-xl {% if result.complete %}bg-emerald-600 text-white{% else %}bg-amber-500 text-white{% endif %}" aria-hidden="true">
+                <i class="fa-solid {% if result.complete %}fa-circle-check{% else %}fa-triangle-exclamation{% endif %}"></i>
+            </span>
+            <div>
+                <p class="text-xs font-bold uppercase tracking-wider {% if result.complete %}text-emerald-700{% else %}text-amber-700{% endif %}">
+                    Estado de la genealogía
+                </p>
+                <h2 class="mt-0.5 text-xl font-bold {% if result.complete %}text-emerald-950{% else %}text-amber-950{% endif %}">
+                    {{ result.state_label }}
+                </h2>
+                <p class="mt-1 text-sm {% if result.complete %}text-emerald-800{% else %}text-amber-800{% endif %}">
+                    {{ result.state_description }}
+                </p>
+            </div>
+        </div>
+
+        <div class="flex flex-wrap items-center gap-2 text-xs font-semibold">
+            <span class="rounded-full border border-white/70 bg-white/80 px-3 py-1.5 text-slate-700">
+                {{ result.shipment.lineage_state_label }}
+            </span>
+            <span class="rounded-full border border-white/70 bg-white/80 px-3 py-1.5 text-slate-700">
+                {{ result.shipment.status_label }}
+            </span>
+        </div>
+    </div>
+</section>
+
+<div class="mb-6 grid grid-cols-1 gap-4 sm:grid-cols-2 xl:grid-cols-4">
+    <section class="rounded-xl border border-slate-200 bg-white p-5 shadow-sm">
+        <p class="text-[11px] font-bold uppercase tracking-wider text-slate-500">Despacho</p>
+        <p class="mt-1 break-all text-xl font-bold text-slate-950">{{ result.shipment.code }}</p>
+        <p class="mt-1 text-xs text-slate-500">{{ result.shipment.shipped_at }}</p>
+    </section>
+
+    <section class="rounded-xl border border-slate-200 bg-white p-5 shadow-sm">
+        <p class="text-[11px] font-bold uppercase tracking-wider text-slate-500">Volumen despachado</p>
+        <p class="mt-1 text-xl font-bold text-slate-950">
+            {% if result.primary_total %}{{ result.primary_total.shipped }}{% else %}Múltiples unidades{% endif %}
+        </p>
+        <p class="mt-1 text-xs text-slate-500">Según ítems del despacho</p>
+    </section>
+
+    <section class="rounded-xl border border-slate-200 bg-white p-5 shadow-sm">
+        <p class="text-[11px] font-bold uppercase tracking-wider text-slate-500">Origen atribuido</p>
+        <p class="mt-1 text-xl font-bold text-emerald-700">
+            {% if result.primary_total %}{{ result.primary_total.attributed }}{% else %}Ver detalle{% endif %}
+        </p>
+        <p class="mt-1 text-xs text-slate-500">{{ result.source_count }} parcela(s) de origen</p>
+    </section>
+
+    <section class="rounded-xl border border-slate-200 bg-white p-5 shadow-sm">
+        <p class="text-[11px] font-bold uppercase tracking-wider text-slate-500">Sin resolver</p>
+        <p class="mt-1 text-xl font-bold {% if result.complete %}text-slate-950{% else %}text-amber-700{% endif %}">
+            {% if result.primary_total %}{{ result.primary_total.unresolved }}{% else %}Ver detalle{% endif %}
+        </p>
+        <p class="mt-1 text-xs text-slate-500">{{ result.event_count }} evento(s) recorridos</p>
+    </section>
+</div>
+
+<div class="mb-6 grid grid-cols-1 gap-6 xl:grid-cols-[minmax(0,0.78fr)_minmax(0,1.22fr)]">
+    <section class="rounded-2xl border border-slate-200 bg-white p-5 shadow-sm">
+        <div class="mb-4">
+            <p class="text-[11px] font-bold uppercase tracking-wider text-slate-500">Referencia comercial</p>
+            <h2 class="mt-1 text-base font-bold text-slate-950">Despacho consultado</h2>
+        </div>
+        <dl class="grid grid-cols-1 gap-3 sm:grid-cols-2">
+            <div class="rounded-lg bg-slate-50 p-3">
+                <dt class="text-xs font-semibold text-slate-500">Venta / factura</dt>
+                <dd class="mt-1 break-all text-sm font-semibold text-slate-900">{{ result.shipment.sale_reference }}</dd>
+            </div>
+            <div class="rounded-lg bg-slate-50 p-3">
+                <dt class="text-xs font-semibold text-slate-500">Comprador</dt>
+                <dd class="mt-1 break-all text-sm font-semibold text-slate-900">{{ result.shipment.buyer_reference }}</dd>
+            </div>
+            <div class="rounded-lg bg-slate-50 p-3">
+                <dt class="text-xs font-semibold text-slate-500">País destino</dt>
+                <dd class="mt-1 text-sm font-semibold text-slate-900">{{ result.shipment.destination_country }}</dd>
+            </div>
+            <div class="rounded-lg bg-slate-50 p-3">
+                <dt class="text-xs font-semibold text-slate-500">Método de atribución</dt>
+                <dd class="mt-1 break-all font-mono text-[11px] text-slate-900">{{ result.allocation_method }}</dd>
+            </div>
+        </dl>
+    </section>
+
+    <section class="rounded-2xl border border-slate-200 bg-white p-5 shadow-sm">
+        <div class="mb-4 flex items-center justify-between gap-3">
+            <div>
+                <p class="text-[11px] font-bold uppercase tracking-wider text-slate-500">Reconciliación</p>
+                <h2 class="mt-1 text-base font-bold text-slate-950">Volumen por unidad</h2>
+            </div>
+            <i class="fa-solid fa-scale-balanced text-slate-300" aria-hidden="true"></i>
+        </div>
+        <div class="overflow-x-auto rounded-xl border border-slate-200">
+            <table class="min-w-full divide-y divide-slate-200 text-left text-xs">
+                <thead class="bg-slate-50 text-[11px] font-semibold uppercase tracking-wide text-slate-500">
+                    <tr>
+                        <th class="px-4 py-3">Unidad</th>
+                        <th class="px-4 py-3">Despachado</th>
+                        <th class="px-4 py-3">Atribuido</th>
+                        <th class="px-4 py-3">Sin resolver</th>
+                    </tr>
+                </thead>
+                <tbody class="divide-y divide-slate-200 bg-white">
+                    {% for total in result.totals %}
+                    <tr>
+                        <td class="px-4 py-3 font-semibold text-slate-900">{{ total.unit }}</td>
+                        <td class="px-4 py-3 text-slate-700">{{ total.shipped }}</td>
+                        <td class="px-4 py-3 font-semibold text-emerald-700">{{ total.attributed }}</td>
+                        <td class="px-4 py-3 {% if result.complete %}text-slate-700{% else %}font-semibold text-amber-700{% endif %}">{{ total.unresolved }}</td>
+                    </tr>
+                    {% else %}
+                    <tr><td colspan="4" class="px-4 py-5 text-center text-slate-500">No hay volúmenes para mostrar.</td></tr>
+                    {% endfor %}
+                </tbody>
+            </table>
+        </div>
+    </section>
+</div>
+
+<section class="mb-6 rounded-2xl border border-slate-200 bg-white p-5 shadow-sm">
+    <div class="mb-4 flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+        <div>
+            <p class="text-[11px] font-bold uppercase tracking-wider text-emerald-700">Origen consolidado</p>
+            <h2 class="mt-1 text-base font-bold text-slate-950">Parcelas y proveedores atribuibles al despacho</h2>
+            <p class="mt-1 text-xs text-slate-500">La proporción se calcula sobre el volumen despachado de la misma unidad.</p>
+        </div>
+        <span class="rounded-full bg-slate-100 px-3 py-1.5 text-xs font-semibold text-slate-600">{{ result.source_count }} origen(es)</span>
+    </div>
+
+    <div class="overflow-x-auto rounded-xl border border-slate-200">
+        <table class="min-w-full divide-y divide-slate-200 text-left text-xs">
+            <thead class="bg-slate-50 text-[11px] font-semibold uppercase tracking-wide text-slate-500">
+                <tr>
+                    <th class="px-4 py-3">Parcela / lote</th>
+                    <th class="px-4 py-3">Proveedor</th>
+                    <th class="px-4 py-3">Producto</th>
+                    <th class="px-4 py-3">Georreferencia</th>
+                    <th class="px-4 py-3">Volumen atribuido</th>
+                    <th class="px-4 py-3">Participación</th>
+                </tr>
+            </thead>
+            <tbody class="divide-y divide-slate-200 bg-white">
+                {% for source in result.sources %}
+                <tr class="align-top">
+                    <td class="px-4 py-3">
+                        <p class="font-bold text-slate-950">{{ source.identifier }}</p>
+                        <p class="mt-1 text-[11px] text-slate-500">{{ source.hectares }} · {{ source.status }}</p>
+                    </td>
+                    <td class="px-4 py-3 font-medium text-slate-800">{{ source.producer }}</td>
+                    <td class="px-4 py-3 text-slate-700">{{ source.product }}</td>
+                    <td class="px-4 py-3">
+                        <p class="font-mono text-[11px] text-slate-700">{{ source.coordinates }}</p>
+                        <p class="mt-1 text-[11px] {% if source.has_polygon %}text-emerald-700{% else %}text-amber-700{% endif %}">
+                            {% if source.has_polygon %}Polígono disponible{% else %}Sin polígono registrado{% endif %}
+                        </p>
+                    </td>
+                    <td class="px-4 py-3 font-bold text-slate-950">{{ source.quantity }}</td>
+                    <td class="px-4 py-3">
+                        <span class="rounded-full bg-emerald-50 px-2.5 py-1 font-bold text-emerald-800">{{ source.share }}</span>
+                    </td>
+                </tr>
+                {% else %}
+                <tr>
+                    <td colspan="6" class="px-4 py-6 text-center text-slate-500">
+                        No se pudieron atribuir parcelas de origen a este despacho.
+                    </td>
+                </tr>
+                {% endfor %}
+            </tbody>
+        </table>
+    </div>
+</section>
+
+<section class="mb-6 rounded-2xl border border-slate-200 bg-white p-5 shadow-sm">
+    <div class="mb-5">
+        <p class="text-[11px] font-bold uppercase tracking-wider text-slate-500">Camino industrial</p>
+        <h2 class="mt-1 text-base font-bold text-slate-950">Eventos recorridos hacia el origen</h2>
+        <p class="mt-1 text-xs leading-5 text-slate-500">
+            Cada bloque muestra las entradas registradas, el proceso y sus salidas. La reconciliación sólo compara cantidades cuando la unidad es homogénea.
+        </p>
+    </div>
+
+    <div class="space-y-4">
+        {% for event in result.events %}
+        <article class="rounded-xl border border-slate-200 bg-slate-50 p-4">
+            <div class="mb-4 flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+                <div>
+                    <div class="flex flex-wrap items-center gap-2">
+                        <span class="rounded bg-slate-900 px-2.5 py-1 text-[11px] font-bold uppercase tracking-wide text-white">{{ event.type_label }}</span>
+                        <span class="font-mono text-xs font-semibold text-slate-700">{{ event.code }}</span>
+                    </div>
+                    <p class="mt-2 text-xs text-slate-500">{{ event.occurred_at }} · {{ event.facility }}</p>
+                </div>
+                <div class="grid grid-cols-2 gap-2 text-right text-[11px]">
+                    <div class="rounded-lg bg-white px-3 py-2 ring-1 ring-slate-200">
+                        <p class="text-slate-500">Rendimiento</p>
+                        <p class="mt-0.5 font-bold text-slate-900">{{ event.yield }}</p>
+                    </div>
+                    <div class="rounded-lg bg-white px-3 py-2 ring-1 ring-slate-200">
+                        <p class="text-slate-500">Merma / diferencia</p>
+                        <p class="mt-0.5 font-bold text-slate-900">{{ event.loss_quantity }}</p>
+                    </div>
+                </div>
+            </div>
+
+            <div class="grid grid-cols-1 items-stretch gap-3 lg:grid-cols-[minmax(0,1fr)_auto_minmax(0,1fr)]">
+                <div class="rounded-lg border border-slate-200 bg-white p-3">
+                    <p class="mb-2 text-[10px] font-bold uppercase tracking-wider text-slate-500">Entradas</p>
+                    <div class="space-y-2">
+                        {% for edge in event.inputs %}
+                        <div class="flex items-center justify-between gap-3 rounded bg-slate-50 px-3 py-2">
+                            <span class="min-w-0 truncate font-mono text-[11px] font-semibold text-slate-800">{{ edge.batch_code }}</span>
+                            <span class="shrink-0 text-xs font-bold text-slate-950">{{ edge.quantity }}</span>
+                        </div>
+                        {% else %}
+                        <p class="text-xs text-slate-500">Sin entradas industriales.</p>
+                        {% endfor %}
+                    </div>
+                </div>
+
+                <div class="hidden items-center justify-center px-1 text-slate-300 lg:flex" aria-hidden="true">
+                    <i class="fa-solid fa-arrow-right-long"></i>
+                </div>
+
+                <div class="rounded-lg border border-slate-200 bg-white p-3">
+                    <p class="mb-2 text-[10px] font-bold uppercase tracking-wider text-slate-500">Salidas</p>
+                    <div class="space-y-2">
+                        {% for edge in event.outputs %}
+                        <div class="flex items-center justify-between gap-3 rounded bg-emerald-50 px-3 py-2">
+                            <span class="min-w-0 truncate font-mono text-[11px] font-semibold text-emerald-900">{{ edge.batch_code }}</span>
+                            <span class="shrink-0 text-xs font-bold text-emerald-950">{{ edge.quantity }}</span>
+                        </div>
+                        {% else %}
+                        <p class="text-xs text-slate-500">Sin salidas registradas.</p>
+                        {% endfor %}
+                    </div>
+                </div>
+            </div>
+
+            <div class="mt-3 flex flex-wrap gap-x-5 gap-y-1 text-[11px] text-slate-500">
+                <span>Input total: <strong class="text-slate-700">{{ event.input_quantity }}</strong></span>
+                <span>Output total: <strong class="text-slate-700">{{ event.output_quantity }}</strong></span>
+                <span>Estado: <strong class="text-slate-700">{{ event.status }}</strong></span>
+            </div>
+        </article>
+        {% else %}
+        <div class="rounded-xl border border-dashed border-slate-300 p-6 text-center text-sm text-slate-500">
+            No hay eventos industriales recorribles para este despacho.
+        </div>
+        {% endfor %}
+    </div>
+</section>
+
+<section class="mb-6 rounded-2xl border border-slate-200 bg-white p-5 shadow-sm">
+    <div class="mb-4">
+        <p class="text-[11px] font-bold uppercase tracking-wider text-slate-500">Producto despachado</p>
+        <h2 class="mt-1 text-base font-bold text-slate-950">Lotes comerciales y su composición</h2>
+    </div>
+    <div class="grid grid-cols-1 gap-4 lg:grid-cols-2">
+        {% for item in result.items %}
+        <article class="rounded-xl border {% if item.complete %}border-slate-200{% else %}border-amber-300{% endif %} bg-slate-50 p-4">
+            <div class="flex items-start justify-between gap-3">
+                <div>
+                    <p class="font-mono text-xs font-bold text-slate-950">{{ item.batch_code }}</p>
+                    <p class="mt-1 text-sm font-semibold text-slate-800">{{ item.product }}</p>
+                </div>
+                <span class="rounded-full {% if item.complete %}bg-emerald-100 text-emerald-800{% else %}bg-amber-100 text-amber-800{% endif %} px-2.5 py-1 text-[11px] font-bold">
+                    {% if item.complete %}Cerrado{% else %}Revisar{% endif %}
+                </span>
+            </div>
+            <dl class="mt-4 grid grid-cols-3 gap-2 text-xs">
+                <div class="rounded-lg bg-white p-2.5 ring-1 ring-slate-200">
+                    <dt class="text-slate-500">Despachado</dt>
+                    <dd class="mt-1 font-bold text-slate-900">{{ item.shipped_quantity }}</dd>
+                </div>
+                <div class="rounded-lg bg-white p-2.5 ring-1 ring-slate-200">
+                    <dt class="text-slate-500">Atribuido</dt>
+                    <dd class="mt-1 font-bold text-emerald-700">{{ item.attributed_quantity }}</dd>
+                </div>
+                <div class="rounded-lg bg-white p-2.5 ring-1 ring-slate-200">
+                    <dt class="text-slate-500">Pendiente</dt>
+                    <dd class="mt-1 font-bold {% if item.complete %}text-slate-900{% else %}text-amber-700{% endif %}">{{ item.unresolved_quantity }}</dd>
+                </div>
+            </dl>
+            {% if item.contributions %}
+            <div class="mt-4 space-y-2">
+                {% for contribution in item.contributions %}
+                <div class="flex flex-col gap-1 rounded-lg border border-slate-200 bg-white px-3 py-2 sm:flex-row sm:items-center sm:justify-between">
+                    <div class="min-w-0">
+                        <p class="truncate text-xs font-bold text-slate-900">{{ contribution.identifier }}</p>
+                        <p class="truncate text-[11px] text-slate-500">{{ contribution.producer }}</p>
+                    </div>
+                    <div class="shrink-0 text-left sm:text-right">
+                        <p class="text-xs font-bold text-slate-900">{{ contribution.quantity }}</p>
+                        <p class="text-[11px] font-semibold text-emerald-700">{{ contribution.share }}</p>
+                    </div>
+                </div>
+                {% endfor %}
+            </div>
+            {% endif %}
+        </article>
+        {% else %}
+        <div class="rounded-xl border border-dashed border-slate-300 p-6 text-center text-sm text-slate-500 lg:col-span-2">
+            El despacho no contiene lotes comerciales visibles.
+        </div>
+        {% endfor %}
+    </div>
+</section>
+
+{% if result.issues %}
+<section class="rounded-2xl border border-amber-200 bg-amber-50 p-5" aria-labelledby="lineage-issues-title">
+    <div class="flex items-start gap-3">
+        <span class="mt-0.5 text-amber-600" aria-hidden="true"><i class="fa-solid fa-list-check"></i></span>
+        <div class="min-w-0 flex-1">
+            <h2 id="lineage-issues-title" class="text-sm font-bold text-amber-950">Incidencias que impiden cerrar la genealogía</h2>
+            <div class="mt-3 space-y-2">
+                {% for issue in result.issues %}
+                <div class="rounded-lg border border-amber-200 bg-white/70 px-3 py-2">
+                    <p class="font-mono text-[11px] font-bold text-amber-800">{{ issue.code }}</p>
+                    <p class="mt-1 text-xs leading-5 text-amber-900">{{ issue.message }}</p>
+                </div>
+                {% endfor %}
+            </div>
+        </div>
+    </div>
+</section>
+{% endif %}
+
+{% elif not view.searched %}
+<section class="rounded-2xl border border-dashed border-slate-300 bg-white p-8 text-center shadow-sm">
+    <span class="mx-auto flex h-14 w-14 items-center justify-center rounded-2xl bg-slate-100 text-xl text-slate-500" aria-hidden="true">
+        <i class="fa-solid fa-diagram-project"></i>
+    </span>
+    <h2 class="mt-4 text-lg font-bold text-slate-950">Buscá un despacho para comenzar</h2>
+    <p class="mx-auto mt-2 max-w-2xl text-sm leading-6 text-slate-600">
+        Litoral Trace reconstruirá la cadena desde el lote comercial hasta las parcelas de origen y marcará cualquier volumen o vínculo que no pueda resolverse.
+    </p>
+    <div class="mx-auto mt-6 grid max-w-3xl grid-cols-1 gap-3 text-left sm:grid-cols-3">
+        <div class="rounded-xl bg-slate-50 p-4">
+            <p class="text-xs font-bold text-slate-900">1. Despacho</p>
+            <p class="mt-1 text-xs leading-5 text-slate-500">Identifica la venta y sus lotes comerciales.</p>
+        </div>
+        <div class="rounded-xl bg-slate-50 p-4">
+            <p class="text-xs font-bold text-slate-900">2. Procesos</p>
+            <p class="mt-1 text-xs leading-5 text-slate-500">Recorre transformaciones, mezclas y recepciones POSTED.</p>
+        </div>
+        <div class="rounded-xl bg-slate-50 p-4">
+            <p class="text-xs font-bold text-slate-900">3. Orígenes</p>
+            <p class="mt-1 text-xs leading-5 text-slate-500">Consolida parcelas, proveedores y cantidades atribuibles.</p>
+        </div>
+    </div>
+</section>
+{% endif %}
+
+{% endblock %}

--- a/src/litoral_trace/templates/traceability.html
+++ b/src/litoral_trace/templates/traceability.html
@@ -5,57 +5,46 @@
 {% block content %}
 {% set view = traceability_view %}
 
-<section class="mb-6 overflow-hidden rounded-2xl border border-slate-200 bg-white shadow-sm">
-    <div class="border-b border-slate-200 px-6 py-6">
-        <div class="flex flex-col gap-5 xl:flex-row xl:items-end xl:justify-between">
-            <div class="max-w-3xl">
-                <div class="mb-2 flex flex-wrap items-center gap-2">
-                    <span class="rounded border border-emerald-200 bg-emerald-50 px-2.5 py-1 text-[11px] font-bold uppercase tracking-wide text-emerald-800">
-                        Cadena de custodia
-                    </span>
-                    <span class="text-xs font-medium text-slate-500">
-                        Genealogía inversa de despacho
-                    </span>
-                </div>
-                <h1 class="text-2xl font-bold tracking-tight text-slate-950">
-                    Reconstruí el origen de una venta o despacho
-                </h1>
-                <p class="mt-2 max-w-3xl text-sm leading-6 text-slate-600">
-                    Partí del código de despacho y seguí el producto hacia atrás por lotes industriales, transformaciones y parcelas de origen. La vista usa el mismo motor P1C de la API y no modifica inventario ni eventos.
-                </p>
+<section class="mb-6 rounded-2xl border border-slate-200 bg-white p-5 shadow-sm">
+    <div class="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
+        <div class="max-w-3xl">
+            <div class="mb-2 flex flex-wrap items-center gap-2">
+                <span class="rounded border border-emerald-200 bg-emerald-50 px-2.5 py-1 text-[11px] font-bold uppercase tracking-wide text-emerald-800">
+                    Cadena de custodia
+                </span>
+                <span class="text-xs font-medium text-slate-500">Genealogía inversa de despacho</span>
             </div>
+            <h1 class="text-2xl font-bold tracking-tight text-slate-950">
+                Reconstruí el origen de una venta o despacho
+            </h1>
+            <p class="mt-2 text-sm leading-6 text-slate-600">
+                Partí del código de despacho y seguí el producto hacia atrás por lotes industriales, transformaciones y parcelas de origen. La vista usa el mismo motor P1C de la API y no modifica inventario ni eventos.
+            </p>
+        </div>
 
-            <div class="rounded-xl border border-slate-200 bg-slate-50 px-4 py-3 text-xs text-slate-600 xl:max-w-md">
-                <p class="font-semibold text-slate-800">
-                    Convención de mezclas
-                </p>
-                <p class="mt-1 leading-5">
-                    Cuando un proceso mezcla entradas homogéneas, la atribución usa la proporción documentada de inputs. Es una convención contable de trazabilidad, no identificación física de fibras individuales.
-                </p>
-            </div>
+        <div class="max-w-md rounded-xl border border-slate-200 bg-slate-50 p-4 text-xs text-slate-600">
+            <p class="font-semibold text-slate-800">Convención de mezclas</p>
+            <p class="mt-1 leading-5">
+                Cuando un proceso mezcla entradas homogéneas, la atribución usa la proporción documentada de inputs. Es una convención contable de trazabilidad, no identificación física de fibras individuales.
+            </p>
         </div>
     </div>
 
-    <form method="get" action="/traceability" class="bg-slate-50 px-6 py-5" role="search">
+    <form method="get" action="/traceability" class="mt-5 border-t border-slate-200 pt-5" role="search">
         <label for="shipment-code" class="text-xs font-bold uppercase tracking-wider text-slate-600">
             Código de despacho / venta
         </label>
         <div class="mt-2 flex flex-col gap-3 sm:flex-row">
-            <div class="relative min-w-0 flex-1">
-                <span class="pointer-events-none absolute inset-y-0 left-0 flex items-center pl-3.5 text-slate-400" aria-hidden="true">
-                    <i class="fa-solid fa-magnifying-glass"></i>
-                </span>
-                <input
-                    id="shipment-code"
-                    name="shipment_code"
-                    type="search"
-                    maxlength="120"
-                    value="{{ view.query }}"
-                    placeholder="Ej. EXP-UE-2026-001"
-                    autocomplete="off"
-                    class="w-full rounded-lg border border-slate-300 bg-white py-2.5 pl-10 pr-3 text-sm font-medium text-slate-950 shadow-sm outline-none transition focus:border-emerald-600 focus:ring-2 focus:ring-emerald-100"
-                >
-            </div>
+            <input
+                id="shipment-code"
+                name="shipment_code"
+                type="search"
+                maxlength="120"
+                value="{{ view.query }}"
+                placeholder="Ej. EXP-UE-2026-001"
+                autocomplete="off"
+                class="min-w-0 flex-1 rounded-lg border border-slate-300 bg-white px-4 py-2.5 text-sm font-medium text-slate-950 shadow-sm outline-none transition focus:border-emerald-600 focus:ring-2 focus:ring-emerald-100"
+            >
             <button type="submit" class="inline-flex items-center justify-center gap-2 rounded-lg bg-forest-800 px-5 py-2.5 text-sm font-semibold text-white shadow-sm transition hover:bg-forest-900">
                 <i class="fa-solid fa-route" aria-hidden="true"></i>
                 Reconstruir origen
@@ -88,117 +77,66 @@
 <section class="mb-6 rounded-2xl border {% if result.complete %}border-emerald-200 bg-emerald-50{% else %}border-amber-200 bg-amber-50{% endif %} p-5 shadow-sm">
     <div class="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
         <div class="flex items-start gap-3">
-            <span class="flex h-11 w-11 shrink-0 items-center justify-center rounded-xl {% if result.complete %}bg-emerald-600 text-white{% else %}bg-amber-500 text-white{% endif %}" aria-hidden="true">
+            <span class="flex h-11 w-11 shrink-0 items-center justify-center rounded-xl {% if result.complete %}bg-emerald-600 text-white{% else %}bg-amber-600 text-white{% endif %}" aria-hidden="true">
                 <i class="fa-solid {% if result.complete %}fa-circle-check{% else %}fa-triangle-exclamation{% endif %}"></i>
             </span>
             <div>
-                <p class="text-xs font-bold uppercase tracking-wider {% if result.complete %}text-emerald-700{% else %}text-amber-700{% endif %}">
-                    Estado de la genealogía
-                </p>
-                <h2 class="mt-0.5 text-xl font-bold {% if result.complete %}text-emerald-950{% else %}text-amber-950{% endif %}">
-                    {{ result.state_label }}
-                </h2>
-                <p class="mt-1 text-sm {% if result.complete %}text-emerald-800{% else %}text-amber-800{% endif %}">
-                    {{ result.state_description }}
-                </p>
+                <p class="text-xs font-bold uppercase tracking-wider {% if result.complete %}text-emerald-700{% else %}text-amber-700{% endif %}">Estado de la genealogía</p>
+                <h2 class="mt-0.5 text-xl font-bold {% if result.complete %}text-emerald-950{% else %}text-amber-950{% endif %}">{{ result.state_label }}</h2>
+                <p class="mt-1 text-sm {% if result.complete %}text-emerald-800{% else %}text-amber-800{% endif %}">{{ result.state_description }}</p>
             </div>
         </div>
-
         <div class="flex flex-wrap items-center gap-2 text-xs font-semibold">
-            <span class="rounded-full border border-white/70 bg-white/80 px-3 py-1.5 text-slate-700">
-                {{ result.shipment.lineage_state_label }}
-            </span>
-            <span class="rounded-full border border-white/70 bg-white/80 px-3 py-1.5 text-slate-700">
-                {{ result.shipment.status_label }}
-            </span>
+            <span class="rounded-full border border-slate-200 bg-white px-3 py-1.5 text-slate-700">{{ result.shipment.lineage_state_label }}</span>
+            <span class="rounded-full border border-slate-200 bg-white px-3 py-1.5 text-slate-700">{{ result.shipment.status_label }}</span>
         </div>
     </div>
 </section>
 
-<div class="mb-6 grid grid-cols-1 gap-4 sm:grid-cols-2 xl:grid-cols-4">
+<div class="mb-6 grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4">
     <section class="rounded-xl border border-slate-200 bg-white p-5 shadow-sm">
         <p class="text-[11px] font-bold uppercase tracking-wider text-slate-500">Despacho</p>
         <p class="mt-1 break-all text-xl font-bold text-slate-950">{{ result.shipment.code }}</p>
         <p class="mt-1 text-xs text-slate-500">{{ result.shipment.shipped_at }}</p>
     </section>
-
     <section class="rounded-xl border border-slate-200 bg-white p-5 shadow-sm">
         <p class="text-[11px] font-bold uppercase tracking-wider text-slate-500">Volumen despachado</p>
-        <p class="mt-1 text-xl font-bold text-slate-950">
-            {% if result.primary_total %}{{ result.primary_total.shipped }}{% else %}Múltiples unidades{% endif %}
-        </p>
+        <p class="mt-1 text-xl font-bold text-slate-950">{% if result.primary_total %}{{ result.primary_total.shipped }}{% else %}Múltiples unidades{% endif %}</p>
         <p class="mt-1 text-xs text-slate-500">Según ítems del despacho</p>
     </section>
-
     <section class="rounded-xl border border-slate-200 bg-white p-5 shadow-sm">
         <p class="text-[11px] font-bold uppercase tracking-wider text-slate-500">Origen atribuido</p>
-        <p class="mt-1 text-xl font-bold text-emerald-700">
-            {% if result.primary_total %}{{ result.primary_total.attributed }}{% else %}Ver detalle{% endif %}
-        </p>
+        <p class="mt-1 text-xl font-bold text-emerald-700">{% if result.primary_total %}{{ result.primary_total.attributed }}{% else %}Ver detalle{% endif %}</p>
         <p class="mt-1 text-xs text-slate-500">{{ result.source_count }} parcela(s) de origen</p>
     </section>
-
     <section class="rounded-xl border border-slate-200 bg-white p-5 shadow-sm">
         <p class="text-[11px] font-bold uppercase tracking-wider text-slate-500">Sin resolver</p>
-        <p class="mt-1 text-xl font-bold {% if result.complete %}text-slate-950{% else %}text-amber-700{% endif %}">
-            {% if result.primary_total %}{{ result.primary_total.unresolved }}{% else %}Ver detalle{% endif %}
-        </p>
+        <p class="mt-1 text-xl font-bold {% if result.complete %}text-slate-950{% else %}text-amber-700{% endif %}">{% if result.primary_total %}{{ result.primary_total.unresolved }}{% else %}Ver detalle{% endif %}</p>
         <p class="mt-1 text-xs text-slate-500">{{ result.event_count }} evento(s) recorridos</p>
     </section>
 </div>
 
-<div class="mb-6 grid grid-cols-1 gap-6 xl:grid-cols-[minmax(0,0.78fr)_minmax(0,1.22fr)]">
+<div class="mb-6 grid grid-cols-1 gap-6 lg:grid-cols-[0.9fr_1.1fr]">
     <section class="rounded-2xl border border-slate-200 bg-white p-5 shadow-sm">
-        <div class="mb-4">
-            <p class="text-[11px] font-bold uppercase tracking-wider text-slate-500">Referencia comercial</p>
-            <h2 class="mt-1 text-base font-bold text-slate-950">Despacho consultado</h2>
-        </div>
-        <dl class="grid grid-cols-1 gap-3 sm:grid-cols-2">
-            <div class="rounded-lg bg-slate-50 p-3">
-                <dt class="text-xs font-semibold text-slate-500">Venta / factura</dt>
-                <dd class="mt-1 break-all text-sm font-semibold text-slate-900">{{ result.shipment.sale_reference }}</dd>
-            </div>
-            <div class="rounded-lg bg-slate-50 p-3">
-                <dt class="text-xs font-semibold text-slate-500">Comprador</dt>
-                <dd class="mt-1 break-all text-sm font-semibold text-slate-900">{{ result.shipment.buyer_reference }}</dd>
-            </div>
-            <div class="rounded-lg bg-slate-50 p-3">
-                <dt class="text-xs font-semibold text-slate-500">País destino</dt>
-                <dd class="mt-1 text-sm font-semibold text-slate-900">{{ result.shipment.destination_country }}</dd>
-            </div>
-            <div class="rounded-lg bg-slate-50 p-3">
-                <dt class="text-xs font-semibold text-slate-500">Método de atribución</dt>
-                <dd class="mt-1 break-all font-mono text-[11px] text-slate-900">{{ result.allocation_method }}</dd>
-            </div>
+        <p class="text-[11px] font-bold uppercase tracking-wider text-slate-500">Referencia comercial</p>
+        <h2 class="mt-1 text-base font-bold text-slate-950">Despacho consultado</h2>
+        <dl class="mt-4 grid grid-cols-1 gap-3 sm:grid-cols-2">
+            <div class="rounded-lg bg-slate-50 p-3"><dt class="text-xs font-semibold text-slate-500">Venta / factura</dt><dd class="mt-1 break-all text-sm font-semibold text-slate-900">{{ result.shipment.sale_reference }}</dd></div>
+            <div class="rounded-lg bg-slate-50 p-3"><dt class="text-xs font-semibold text-slate-500">Comprador</dt><dd class="mt-1 break-all text-sm font-semibold text-slate-900">{{ result.shipment.buyer_reference }}</dd></div>
+            <div class="rounded-lg bg-slate-50 p-3"><dt class="text-xs font-semibold text-slate-500">País destino</dt><dd class="mt-1 text-sm font-semibold text-slate-900">{{ result.shipment.destination_country }}</dd></div>
+            <div class="rounded-lg bg-slate-50 p-3"><dt class="text-xs font-semibold text-slate-500">Método de atribución</dt><dd class="mt-1 break-all font-mono text-[11px] text-slate-900">{{ result.allocation_method }}</dd></div>
         </dl>
     </section>
 
     <section class="rounded-2xl border border-slate-200 bg-white p-5 shadow-sm">
-        <div class="mb-4 flex items-center justify-between gap-3">
-            <div>
-                <p class="text-[11px] font-bold uppercase tracking-wider text-slate-500">Reconciliación</p>
-                <h2 class="mt-1 text-base font-bold text-slate-950">Volumen por unidad</h2>
-            </div>
-            <i class="fa-solid fa-scale-balanced text-slate-300" aria-hidden="true"></i>
-        </div>
-        <div class="overflow-x-auto rounded-xl border border-slate-200">
+        <p class="text-[11px] font-bold uppercase tracking-wider text-slate-500">Reconciliación</p>
+        <h2 class="mt-1 text-base font-bold text-slate-950">Volumen por unidad</h2>
+        <div class="mt-4 overflow-x-auto rounded-xl border border-slate-200">
             <table class="min-w-full divide-y divide-slate-200 text-left text-xs">
-                <thead class="bg-slate-50 text-[11px] font-semibold uppercase tracking-wide text-slate-500">
-                    <tr>
-                        <th class="px-4 py-3">Unidad</th>
-                        <th class="px-4 py-3">Despachado</th>
-                        <th class="px-4 py-3">Atribuido</th>
-                        <th class="px-4 py-3">Sin resolver</th>
-                    </tr>
-                </thead>
+                <thead class="bg-slate-50 text-[11px] font-semibold uppercase tracking-wide text-slate-500"><tr><th class="px-4 py-3">Unidad</th><th class="px-4 py-3">Despachado</th><th class="px-4 py-3">Atribuido</th><th class="px-4 py-3">Sin resolver</th></tr></thead>
                 <tbody class="divide-y divide-slate-200 bg-white">
                     {% for total in result.totals %}
-                    <tr>
-                        <td class="px-4 py-3 font-semibold text-slate-900">{{ total.unit }}</td>
-                        <td class="px-4 py-3 text-slate-700">{{ total.shipped }}</td>
-                        <td class="px-4 py-3 font-semibold text-emerald-700">{{ total.attributed }}</td>
-                        <td class="px-4 py-3 {% if result.complete %}text-slate-700{% else %}font-semibold text-amber-700{% endif %}">{{ total.unresolved }}</td>
-                    </tr>
+                    <tr><td class="px-4 py-3 font-semibold text-slate-900">{{ total.unit }}</td><td class="px-4 py-3 text-slate-700">{{ total.shipped }}</td><td class="px-4 py-3 font-semibold text-emerald-700">{{ total.attributed }}</td><td class="px-4 py-3 {% if result.complete %}text-slate-700{% else %}font-semibold text-amber-700{% endif %}">{{ total.unresolved }}</td></tr>
                     {% else %}
                     <tr><td colspan="4" class="px-4 py-5 text-center text-slate-500">No hay volúmenes para mostrar.</td></tr>
                     {% endfor %}
@@ -217,45 +155,21 @@
         </div>
         <span class="rounded-full bg-slate-100 px-3 py-1.5 text-xs font-semibold text-slate-600">{{ result.source_count }} origen(es)</span>
     </div>
-
     <div class="overflow-x-auto rounded-xl border border-slate-200">
         <table class="min-w-full divide-y divide-slate-200 text-left text-xs">
-            <thead class="bg-slate-50 text-[11px] font-semibold uppercase tracking-wide text-slate-500">
-                <tr>
-                    <th class="px-4 py-3">Parcela / lote</th>
-                    <th class="px-4 py-3">Proveedor</th>
-                    <th class="px-4 py-3">Producto</th>
-                    <th class="px-4 py-3">Georreferencia</th>
-                    <th class="px-4 py-3">Volumen atribuido</th>
-                    <th class="px-4 py-3">Participación</th>
-                </tr>
-            </thead>
+            <thead class="bg-slate-50 text-[11px] font-semibold uppercase tracking-wide text-slate-500"><tr><th class="px-4 py-3">Parcela / lote</th><th class="px-4 py-3">Proveedor</th><th class="px-4 py-3">Producto</th><th class="px-4 py-3">Georreferencia</th><th class="px-4 py-3">Volumen atribuido</th><th class="px-4 py-3">Participación</th></tr></thead>
             <tbody class="divide-y divide-slate-200 bg-white">
                 {% for source in result.sources %}
-                <tr class="align-top">
-                    <td class="px-4 py-3">
-                        <p class="font-bold text-slate-950">{{ source.identifier }}</p>
-                        <p class="mt-1 text-[11px] text-slate-500">{{ source.hectares }} · {{ source.status }}</p>
-                    </td>
+                <tr>
+                    <td class="px-4 py-3"><p class="font-bold text-slate-950">{{ source.identifier }}</p><p class="mt-1 text-[11px] text-slate-500">{{ source.hectares }} · {{ source.status }}</p></td>
                     <td class="px-4 py-3 font-medium text-slate-800">{{ source.producer }}</td>
                     <td class="px-4 py-3 text-slate-700">{{ source.product }}</td>
-                    <td class="px-4 py-3">
-                        <p class="font-mono text-[11px] text-slate-700">{{ source.coordinates }}</p>
-                        <p class="mt-1 text-[11px] {% if source.has_polygon %}text-emerald-700{% else %}text-amber-700{% endif %}">
-                            {% if source.has_polygon %}Polígono disponible{% else %}Sin polígono registrado{% endif %}
-                        </p>
-                    </td>
+                    <td class="px-4 py-3"><p class="font-mono text-[11px] text-slate-700">{{ source.coordinates }}</p><p class="mt-1 text-[11px] {% if source.has_polygon %}text-emerald-700{% else %}text-amber-700{% endif %}">{% if source.has_polygon %}Polígono disponible{% else %}Sin polígono registrado{% endif %}</p></td>
                     <td class="px-4 py-3 font-bold text-slate-950">{{ source.quantity }}</td>
-                    <td class="px-4 py-3">
-                        <span class="rounded-full bg-emerald-50 px-2.5 py-1 font-bold text-emerald-800">{{ source.share }}</span>
-                    </td>
+                    <td class="px-4 py-3"><span class="rounded-full bg-emerald-50 px-2.5 py-1 font-bold text-emerald-800">{{ source.share }}</span></td>
                 </tr>
                 {% else %}
-                <tr>
-                    <td colspan="6" class="px-4 py-6 text-center text-slate-500">
-                        No se pudieron atribuir parcelas de origen a este despacho.
-                    </td>
-                </tr>
+                <tr><td colspan="6" class="px-4 py-6 text-center text-slate-500">No se pudieron atribuir parcelas de origen a este despacho.</td></tr>
                 {% endfor %}
             </tbody>
         </table>
@@ -263,137 +177,46 @@
 </section>
 
 <section class="mb-6 rounded-2xl border border-slate-200 bg-white p-5 shadow-sm">
-    <div class="mb-5">
+    <div class="mb-4">
         <p class="text-[11px] font-bold uppercase tracking-wider text-slate-500">Camino industrial</p>
         <h2 class="mt-1 text-base font-bold text-slate-950">Eventos recorridos hacia el origen</h2>
-        <p class="mt-1 text-xs leading-5 text-slate-500">
-            Cada bloque muestra las entradas registradas, el proceso y sus salidas. La reconciliación sólo compara cantidades cuando la unidad es homogénea.
-        </p>
+        <p class="mt-1 text-xs leading-5 text-slate-500">Cada bloque muestra entradas, proceso y salidas. La reconciliación sólo compara cantidades cuando la unidad es homogénea.</p>
     </div>
-
     <div class="space-y-4">
         {% for event in result.events %}
         <article class="rounded-xl border border-slate-200 bg-slate-50 p-4">
-            <div class="mb-4 flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
-                <div>
-                    <div class="flex flex-wrap items-center gap-2">
-                        <span class="rounded bg-slate-900 px-2.5 py-1 text-[11px] font-bold uppercase tracking-wide text-white">{{ event.type_label }}</span>
-                        <span class="font-mono text-xs font-semibold text-slate-700">{{ event.code }}</span>
-                    </div>
-                    <p class="mt-2 text-xs text-slate-500">{{ event.occurred_at }} · {{ event.facility }}</p>
-                </div>
-                <div class="grid grid-cols-2 gap-2 text-right text-[11px]">
-                    <div class="rounded-lg bg-white px-3 py-2 ring-1 ring-slate-200">
-                        <p class="text-slate-500">Rendimiento</p>
-                        <p class="mt-0.5 font-bold text-slate-900">{{ event.yield }}</p>
-                    </div>
-                    <div class="rounded-lg bg-white px-3 py-2 ring-1 ring-slate-200">
-                        <p class="text-slate-500">Merma / diferencia</p>
-                        <p class="mt-0.5 font-bold text-slate-900">{{ event.loss_quantity }}</p>
-                    </div>
-                </div>
+            <div class="mb-4 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+                <div><div class="flex flex-wrap items-center gap-2"><span class="rounded bg-slate-900 px-2.5 py-1 text-[11px] font-bold uppercase tracking-wide text-white">{{ event.type_label }}</span><span class="font-mono text-xs font-semibold text-slate-700">{{ event.code }}</span></div><p class="mt-2 text-xs text-slate-500">{{ event.occurred_at }} · {{ event.facility }}</p></div>
+                <div class="flex gap-2 text-[11px]"><span class="rounded-lg border border-slate-200 bg-white px-3 py-2 text-slate-700">Rendimiento: <strong>{{ event.yield }}</strong></span><span class="rounded-lg border border-slate-200 bg-white px-3 py-2 text-slate-700">Merma: <strong>{{ event.loss_quantity }}</strong></span></div>
             </div>
-
-            <div class="grid grid-cols-1 items-stretch gap-3 lg:grid-cols-[minmax(0,1fr)_auto_minmax(0,1fr)]">
-                <div class="rounded-lg border border-slate-200 bg-white p-3">
-                    <p class="mb-2 text-[10px] font-bold uppercase tracking-wider text-slate-500">Entradas</p>
-                    <div class="space-y-2">
-                        {% for edge in event.inputs %}
-                        <div class="flex items-center justify-between gap-3 rounded bg-slate-50 px-3 py-2">
-                            <span class="min-w-0 truncate font-mono text-[11px] font-semibold text-slate-800">{{ edge.batch_code }}</span>
-                            <span class="shrink-0 text-xs font-bold text-slate-950">{{ edge.quantity }}</span>
-                        </div>
-                        {% else %}
-                        <p class="text-xs text-slate-500">Sin entradas industriales.</p>
-                        {% endfor %}
-                    </div>
-                </div>
-
-                <div class="hidden items-center justify-center px-1 text-slate-300 lg:flex" aria-hidden="true">
-                    <i class="fa-solid fa-arrow-right-long"></i>
-                </div>
-
-                <div class="rounded-lg border border-slate-200 bg-white p-3">
-                    <p class="mb-2 text-[10px] font-bold uppercase tracking-wider text-slate-500">Salidas</p>
-                    <div class="space-y-2">
-                        {% for edge in event.outputs %}
-                        <div class="flex items-center justify-between gap-3 rounded bg-emerald-50 px-3 py-2">
-                            <span class="min-w-0 truncate font-mono text-[11px] font-semibold text-emerald-900">{{ edge.batch_code }}</span>
-                            <span class="shrink-0 text-xs font-bold text-emerald-950">{{ edge.quantity }}</span>
-                        </div>
-                        {% else %}
-                        <p class="text-xs text-slate-500">Sin salidas registradas.</p>
-                        {% endfor %}
-                    </div>
-                </div>
-            </div>
-
-            <div class="mt-3 flex flex-wrap gap-x-5 gap-y-1 text-[11px] text-slate-500">
-                <span>Input total: <strong class="text-slate-700">{{ event.input_quantity }}</strong></span>
-                <span>Output total: <strong class="text-slate-700">{{ event.output_quantity }}</strong></span>
-                <span>Estado: <strong class="text-slate-700">{{ event.status }}</strong></span>
+            <div class="grid grid-cols-1 gap-3 lg:grid-cols-3">
+                <div class="rounded-lg border border-slate-200 bg-white p-3"><p class="mb-2 text-[10px] font-bold uppercase tracking-wider text-slate-500">Entradas</p><div class="space-y-2">{% for edge in event.inputs %}<div class="flex items-center justify-between gap-3 rounded bg-slate-50 px-3 py-2"><span class="min-w-0 truncate font-mono text-[11px] font-semibold text-slate-800">{{ edge.batch_code }}</span><span class="shrink-0 text-xs font-bold text-slate-950">{{ edge.quantity }}</span></div>{% else %}<p class="text-xs text-slate-500">Sin entradas industriales.</p>{% endfor %}</div></div>
+                <div class="rounded-lg border border-slate-200 bg-white p-3"><p class="mb-2 text-[10px] font-bold uppercase tracking-wider text-slate-500">Proceso</p><p class="text-sm font-bold text-slate-950">{{ event.type_label }}</p><p class="mt-1 text-xs text-slate-500">Input: {{ event.input_quantity }}</p><p class="mt-1 text-xs text-slate-500">Output: {{ event.output_quantity }}</p><p class="mt-1 text-xs text-slate-500">Estado: {{ event.status }}</p></div>
+                <div class="rounded-lg border border-slate-200 bg-white p-3"><p class="mb-2 text-[10px] font-bold uppercase tracking-wider text-slate-500">Salidas</p><div class="space-y-2">{% for edge in event.outputs %}<div class="flex items-center justify-between gap-3 rounded bg-emerald-50 px-3 py-2"><span class="min-w-0 truncate font-mono text-[11px] font-semibold text-emerald-900">{{ edge.batch_code }}</span><span class="shrink-0 text-xs font-bold text-emerald-950">{{ edge.quantity }}</span></div>{% else %}<p class="text-xs text-slate-500">Sin salidas registradas.</p>{% endfor %}</div></div>
             </div>
         </article>
         {% else %}
-        <div class="rounded-xl border border-dashed border-slate-300 p-6 text-center text-sm text-slate-500">
-            No hay eventos industriales recorribles para este despacho.
-        </div>
+        <div class="rounded-xl border border-dashed border-slate-300 p-6 text-center text-sm text-slate-500">No hay eventos industriales recorribles para este despacho.</div>
         {% endfor %}
     </div>
 </section>
 
 <section class="mb-6 rounded-2xl border border-slate-200 bg-white p-5 shadow-sm">
-    <div class="mb-4">
-        <p class="text-[11px] font-bold uppercase tracking-wider text-slate-500">Producto despachado</p>
-        <h2 class="mt-1 text-base font-bold text-slate-950">Lotes comerciales y su composición</h2>
-    </div>
-    <div class="grid grid-cols-1 gap-4 lg:grid-cols-2">
+    <p class="text-[11px] font-bold uppercase tracking-wider text-slate-500">Producto despachado</p>
+    <h2 class="mt-1 text-base font-bold text-slate-950">Lotes comerciales y su composición</h2>
+    <div class="mt-4 grid grid-cols-1 gap-4 sm:grid-cols-2">
         {% for item in result.items %}
-        <article class="rounded-xl border {% if item.complete %}border-slate-200{% else %}border-amber-300{% endif %} bg-slate-50 p-4">
-            <div class="flex items-start justify-between gap-3">
-                <div>
-                    <p class="font-mono text-xs font-bold text-slate-950">{{ item.batch_code }}</p>
-                    <p class="mt-1 text-sm font-semibold text-slate-800">{{ item.product }}</p>
-                </div>
-                <span class="rounded-full {% if item.complete %}bg-emerald-100 text-emerald-800{% else %}bg-amber-100 text-amber-800{% endif %} px-2.5 py-1 text-[11px] font-bold">
-                    {% if item.complete %}Cerrado{% else %}Revisar{% endif %}
-                </span>
-            </div>
-            <dl class="mt-4 grid grid-cols-3 gap-2 text-xs">
-                <div class="rounded-lg bg-white p-2.5 ring-1 ring-slate-200">
-                    <dt class="text-slate-500">Despachado</dt>
-                    <dd class="mt-1 font-bold text-slate-900">{{ item.shipped_quantity }}</dd>
-                </div>
-                <div class="rounded-lg bg-white p-2.5 ring-1 ring-slate-200">
-                    <dt class="text-slate-500">Atribuido</dt>
-                    <dd class="mt-1 font-bold text-emerald-700">{{ item.attributed_quantity }}</dd>
-                </div>
-                <div class="rounded-lg bg-white p-2.5 ring-1 ring-slate-200">
-                    <dt class="text-slate-500">Pendiente</dt>
-                    <dd class="mt-1 font-bold {% if item.complete %}text-slate-900{% else %}text-amber-700{% endif %}">{{ item.unresolved_quantity }}</dd>
-                </div>
+        <article class="rounded-xl border {% if item.complete %}border-slate-200{% else %}border-amber-200{% endif %} bg-slate-50 p-4">
+            <div class="flex items-start justify-between gap-3"><div><p class="font-mono text-xs font-bold text-slate-950">{{ item.batch_code }}</p><p class="mt-1 text-sm font-semibold text-slate-800">{{ item.product }}</p></div><span class="rounded-full {% if item.complete %}bg-emerald-100 text-emerald-800{% else %}bg-amber-50 text-amber-800{% endif %} px-2.5 py-1 text-[11px] font-bold">{% if item.complete %}Cerrado{% else %}Revisar{% endif %}</span></div>
+            <dl class="mt-4 grid grid-cols-1 gap-2 sm:grid-cols-3">
+                <div class="rounded-lg border border-slate-200 bg-white p-3"><dt class="text-slate-500">Despachado</dt><dd class="mt-1 font-bold text-slate-900">{{ item.shipped_quantity }}</dd></div>
+                <div class="rounded-lg border border-slate-200 bg-white p-3"><dt class="text-slate-500">Atribuido</dt><dd class="mt-1 font-bold text-emerald-700">{{ item.attributed_quantity }}</dd></div>
+                <div class="rounded-lg border border-slate-200 bg-white p-3"><dt class="text-slate-500">Pendiente</dt><dd class="mt-1 font-bold {% if item.complete %}text-slate-900{% else %}text-amber-700{% endif %}">{{ item.unresolved_quantity }}</dd></div>
             </dl>
-            {% if item.contributions %}
-            <div class="mt-4 space-y-2">
-                {% for contribution in item.contributions %}
-                <div class="flex flex-col gap-1 rounded-lg border border-slate-200 bg-white px-3 py-2 sm:flex-row sm:items-center sm:justify-between">
-                    <div class="min-w-0">
-                        <p class="truncate text-xs font-bold text-slate-900">{{ contribution.identifier }}</p>
-                        <p class="truncate text-[11px] text-slate-500">{{ contribution.producer }}</p>
-                    </div>
-                    <div class="shrink-0 text-left sm:text-right">
-                        <p class="text-xs font-bold text-slate-900">{{ contribution.quantity }}</p>
-                        <p class="text-[11px] font-semibold text-emerald-700">{{ contribution.share }}</p>
-                    </div>
-                </div>
-                {% endfor %}
-            </div>
-            {% endif %}
+            {% if item.contributions %}<div class="mt-4 space-y-2">{% for contribution in item.contributions %}<div class="flex flex-col gap-2 rounded-lg border border-slate-200 bg-white px-3 py-2 sm:flex-row sm:items-center sm:justify-between"><div class="min-w-0"><p class="truncate text-xs font-bold text-slate-900">{{ contribution.identifier }}</p><p class="truncate text-[11px] text-slate-500">{{ contribution.producer }}</p></div><div class="shrink-0 text-left sm:text-right"><p class="text-xs font-bold text-slate-900">{{ contribution.quantity }}</p><p class="text-[11px] font-semibold text-emerald-700">{{ contribution.share }}</p></div></div>{% endfor %}</div>{% endif %}
         </article>
         {% else %}
-        <div class="rounded-xl border border-dashed border-slate-300 p-6 text-center text-sm text-slate-500 lg:col-span-2">
-            El despacho no contiene lotes comerciales visibles.
-        </div>
+        <div class="rounded-xl border border-dashed border-slate-300 p-6 text-center text-sm text-slate-500 lg:col-span-2">El despacho no contiene lotes comerciales visibles.</div>
         {% endfor %}
     </div>
 </section>
@@ -401,17 +224,10 @@
 {% if result.issues %}
 <section class="rounded-2xl border border-amber-200 bg-amber-50 p-5" aria-labelledby="lineage-issues-title">
     <div class="flex items-start gap-3">
-        <span class="mt-0.5 text-amber-600" aria-hidden="true"><i class="fa-solid fa-list-check"></i></span>
+        <span class="mt-0.5 text-amber-700" aria-hidden="true"><i class="fa-solid fa-list-check"></i></span>
         <div class="min-w-0 flex-1">
             <h2 id="lineage-issues-title" class="text-sm font-bold text-amber-950">Incidencias que impiden cerrar la genealogía</h2>
-            <div class="mt-3 space-y-2">
-                {% for issue in result.issues %}
-                <div class="rounded-lg border border-amber-200 bg-white/70 px-3 py-2">
-                    <p class="font-mono text-[11px] font-bold text-amber-800">{{ issue.code }}</p>
-                    <p class="mt-1 text-xs leading-5 text-amber-900">{{ issue.message }}</p>
-                </div>
-                {% endfor %}
-            </div>
+            <div class="mt-3 space-y-2">{% for issue in result.issues %}<div class="rounded-lg border border-amber-200 bg-white px-3 py-2"><p class="font-mono text-[11px] font-bold text-amber-800">{{ issue.code }}</p><p class="mt-1 text-xs leading-5 text-amber-900">{{ issue.message }}</p></div>{% endfor %}</div>
         </div>
     </div>
 </section>
@@ -419,26 +235,13 @@
 
 {% elif not view.searched %}
 <section class="rounded-2xl border border-dashed border-slate-300 bg-white p-8 text-center shadow-sm">
-    <span class="mx-auto flex h-14 w-14 items-center justify-center rounded-2xl bg-slate-100 text-xl text-slate-500" aria-hidden="true">
-        <i class="fa-solid fa-diagram-project"></i>
-    </span>
+    <span class="mx-auto flex h-12 w-12 items-center justify-center rounded-2xl bg-slate-100 text-xl text-slate-500" aria-hidden="true"><i class="fa-solid fa-diagram-project"></i></span>
     <h2 class="mt-4 text-lg font-bold text-slate-950">Buscá un despacho para comenzar</h2>
-    <p class="mx-auto mt-2 max-w-2xl text-sm leading-6 text-slate-600">
-        Litoral Trace reconstruirá la cadena desde el lote comercial hasta las parcelas de origen y marcará cualquier volumen o vínculo que no pueda resolverse.
-    </p>
+    <p class="mx-auto mt-2 max-w-2xl text-sm leading-6 text-slate-600">Litoral Trace reconstruirá la cadena desde el lote comercial hasta las parcelas de origen y marcará cualquier volumen o vínculo que no pueda resolverse.</p>
     <div class="mx-auto mt-6 grid max-w-3xl grid-cols-1 gap-3 text-left sm:grid-cols-3">
-        <div class="rounded-xl bg-slate-50 p-4">
-            <p class="text-xs font-bold text-slate-900">1. Despacho</p>
-            <p class="mt-1 text-xs leading-5 text-slate-500">Identifica la venta y sus lotes comerciales.</p>
-        </div>
-        <div class="rounded-xl bg-slate-50 p-4">
-            <p class="text-xs font-bold text-slate-900">2. Procesos</p>
-            <p class="mt-1 text-xs leading-5 text-slate-500">Recorre transformaciones, mezclas y recepciones POSTED.</p>
-        </div>
-        <div class="rounded-xl bg-slate-50 p-4">
-            <p class="text-xs font-bold text-slate-900">3. Orígenes</p>
-            <p class="mt-1 text-xs leading-5 text-slate-500">Consolida parcelas, proveedores y cantidades atribuibles.</p>
-        </div>
+        <div class="rounded-xl bg-slate-50 p-4"><p class="text-xs font-bold text-slate-900">1. Despacho</p><p class="mt-1 text-xs leading-5 text-slate-500">Identifica la venta y sus lotes comerciales.</p></div>
+        <div class="rounded-xl bg-slate-50 p-4"><p class="text-xs font-bold text-slate-900">2. Procesos</p><p class="mt-1 text-xs leading-5 text-slate-500">Recorre transformaciones, mezclas y recepciones POSTED.</p></div>
+        <div class="rounded-xl bg-slate-50 p-4"><p class="text-xs font-bold text-slate-900">3. Orígenes</p><p class="mt-1 text-xs leading-5 text-slate-500">Consolida parcelas, proveedores y cantidades atribuibles.</p></div>
     </div>
 </section>
 {% endif %}

--- a/src/litoral_trace/web/navigation.py
+++ b/src/litoral_trace/web/navigation.py
@@ -44,6 +44,14 @@ _NAVIGATION = (
         active_prefixes=("/imports",),
     ),
     NavigationItem(
+        key="traceability",
+        label="Trazabilidad",
+        href="/traceability",
+        section="compliance",
+        permission=Permission.LOTE_READ,
+        active_prefixes=("/traceability",),
+    ),
+    NavigationItem(
         key="vault",
         label="Vault / Evidencias",
         href="/vault",

--- a/src/litoral_trace/web/traceability.py
+++ b/src/litoral_trace/web/traceability.py
@@ -1,0 +1,448 @@
+"""Server-rendered P1D traceability workspace.
+
+The browser view deliberately reuses the P1C reverse-lineage service. It does
+not calculate, persist, or mutate genealogy independently from the API layer.
+"""
+from __future__ import annotations
+
+from datetime import datetime
+from decimal import Decimal, InvalidOperation
+from typing import Any
+
+from fastapi import APIRouter, Request, status
+from fastapi.responses import HTMLResponse
+
+from litoral_trace.auth.rbac import Permission
+from litoral_trace.db.tenant import get_tenant_scoped_db_session
+from litoral_trace.services.traceability_lineage import (
+    TraceabilityLineageNotFoundError,
+    TraceabilityLineageService,
+    TraceabilityLineageValidationError,
+)
+from litoral_trace.web.runtime import (
+    get_html_route_user,
+    render_web_template,
+)
+
+
+router = APIRouter(tags=["Frontend B2B"])
+
+_UNIT_LABELS = {
+    "M3": "m³",
+    "KG": "kg",
+    "TON": "t",
+}
+
+_EVENT_LABELS = {
+    "RECEIPT": "Ingreso",
+    "TRANSFORMATION": "Transformación",
+    "MIX": "Mezcla",
+    "SPLIT": "División",
+    "REPACK": "Reempaque",
+    "ADJUSTMENT": "Ajuste",
+}
+
+_SHIPMENT_STATUS_LABELS = {
+    "DRAFT": "Borrador",
+    "CONFIRMED": "Confirmado",
+    "DISPATCHED": "Despachado",
+    "CANCELLED": "Cancelado",
+}
+
+
+def _decimal(value: Any) -> Decimal:
+    try:
+        return Decimal(str(value))
+    except (InvalidOperation, TypeError, ValueError):
+        return Decimal("0")
+
+
+def _number(value: Any, *, maximum_decimals: int = 6) -> str:
+    number = _decimal(value)
+    raw = f"{number:.{maximum_decimals}f}".rstrip("0").rstrip(".")
+    if raw in {"", "-0"}:
+        raw = "0"
+    return raw.replace(".", ",")
+
+
+def _unit(unit: Any) -> str:
+    normalized = str(unit or "").upper()
+    return _UNIT_LABELS.get(normalized, normalized or "—")
+
+
+def _quantity(value: Any, unit: Any) -> str:
+    return f"{_number(value)} {_unit(unit)}"
+
+
+def _percentage(value: Any) -> str:
+    percentage = _decimal(value) * Decimal("100")
+    return f"{_number(percentage, maximum_decimals=2)}%"
+
+
+def _date_time(value: Any) -> str:
+    if not value:
+        return "—"
+    try:
+        parsed = datetime.fromisoformat(str(value).replace("Z", "+00:00"))
+    except ValueError:
+        return str(value)
+    return parsed.strftime("%d/%m/%Y %H:%M")
+
+
+def _text(value: Any) -> str:
+    if value is None:
+        return "—"
+    normalized = str(value).strip()
+    return normalized or "—"
+
+
+def _error(*, code: str, title: str, message: str) -> dict[str, str]:
+    return {
+        "code": code,
+        "title": title,
+        "message": message,
+    }
+
+
+def _present_source(source: dict[str, Any]) -> dict[str, Any]:
+    lote = source.get("lote") or {}
+    hectares = lote.get("hectareas")
+    latitude = lote.get("latitud")
+    longitude = lote.get("longitud")
+
+    coordinates = "—"
+    if latitude is not None and longitude is not None:
+        try:
+            coordinates = f"{float(latitude):.6f}, {float(longitude):.6f}"
+        except (TypeError, ValueError):
+            coordinates = f"{latitude}, {longitude}"
+
+    return {
+        "identifier": _text(lote.get("identificador")),
+        "producer": _text(lote.get("productor_id")),
+        "product": _text(lote.get("producto_forestal")),
+        "status": _text(lote.get("estatus")),
+        "hectares": (
+            f"{_number(hectares, maximum_decimals=2)} ha"
+            if hectares is not None
+            else "—"
+        ),
+        "coordinates": coordinates,
+        "has_polygon": bool(lote.get("polygon_wkt")),
+        "quantity": _quantity(
+            source.get("attributed_shipment_quantity"),
+            source.get("unit"),
+        ),
+        "share": _percentage(source.get("share_of_shipped_unit")),
+    }
+
+
+def _present_event(event: dict[str, Any]) -> dict[str, Any]:
+    reconciliation = event.get("reconciliation") or {}
+    unit = reconciliation.get("unit")
+
+    def edge_view(edge: dict[str, Any]) -> dict[str, str]:
+        return {
+            "batch_code": _text(edge.get("batch_code")),
+            "quantity": _quantity(edge.get("quantity"), edge.get("unit")),
+        }
+
+    return {
+        "code": _text(event.get("event_code")),
+        "type": _text(event.get("event_type")),
+        "type_label": _EVENT_LABELS.get(
+            str(event.get("event_type") or "").upper(),
+            _text(event.get("event_type")),
+        ),
+        "status": _text(event.get("status")),
+        "occurred_at": _date_time(event.get("occurred_at")),
+        "facility": _text(event.get("facility_reference")),
+        "inputs": [edge_view(edge) for edge in event.get("inputs") or []],
+        "outputs": [edge_view(edge) for edge in event.get("outputs") or []],
+        "input_quantity": _quantity(reconciliation.get("input_quantity"), unit),
+        "output_quantity": _quantity(reconciliation.get("output_quantity"), unit),
+        "loss_quantity": (
+            _quantity(reconciliation.get("loss_quantity"), unit)
+            if reconciliation.get("loss_quantity") is not None
+            else "—"
+        ),
+        "yield": (
+            _percentage(reconciliation.get("yield_ratio"))
+            if reconciliation.get("yield_ratio") is not None
+            else "—"
+        ),
+    }
+
+
+def _present_item(item: dict[str, Any]) -> dict[str, Any]:
+    batch = item.get("batch") or {}
+    contributions = []
+    for source in item.get("source_contributions") or []:
+        lote = source.get("lote") or {}
+        contributions.append(
+            {
+                "identifier": _text(lote.get("identificador")),
+                "producer": _text(lote.get("productor_id")),
+                "quantity": _quantity(
+                    source.get("attributed_shipment_quantity"),
+                    source.get("unit"),
+                ),
+                "share": _percentage(source.get("share_of_shipment_item")),
+            }
+        )
+
+    return {
+        "batch_code": _text(batch.get("code")),
+        "product": _text(batch.get("product_name")),
+        "stage": _text(batch.get("stage")),
+        "status": _text(batch.get("status")),
+        "shipped_quantity": _quantity(item.get("shipped_quantity"), item.get("unit")),
+        "attributed_quantity": _quantity(item.get("attributed_quantity"), item.get("unit")),
+        "unresolved_quantity": _quantity(item.get("unresolved_quantity"), item.get("unit")),
+        "complete": bool(item.get("complete")),
+        "contributions": contributions,
+    }
+
+
+def build_traceability_view(
+    *,
+    query: str = "",
+    payload: dict[str, Any] | None = None,
+    error: dict[str, str] | None = None,
+) -> dict[str, Any]:
+    """Build a presentation-only model from one P1C lineage payload."""
+
+    normalized_query = (query or "").strip()
+    view: dict[str, Any] = {
+        "query": normalized_query,
+        "searched": bool(normalized_query),
+        "error": error,
+        "result": None,
+    }
+
+    if payload is None:
+        return view
+
+    shipment = payload.get("shipment") or {}
+    totals = payload.get("unit_totals") or []
+    sources = [_present_source(source) for source in payload.get("source_lotes") or []]
+    events = [_present_event(event) for event in payload.get("events") or []]
+    items = [_present_item(item) for item in payload.get("items") or []]
+    issues = [
+        {
+            "code": _text(issue.get("code")),
+            "message": _text(issue.get("message")),
+        }
+        for issue in payload.get("issues") or []
+    ]
+
+    primary_total = totals[0] if len(totals) == 1 else None
+    complete = bool(payload.get("complete"))
+
+    view["result"] = {
+        "complete": complete,
+        "state_label": "Genealogía cerrada" if complete else "Cadena incompleta",
+        "state_description": (
+            "Todo el volumen despachado quedó atribuido a orígenes trazables."
+            if complete
+            else "Existe volumen sin resolver o una inconsistencia que requiere revisión."
+        ),
+        "shipment": {
+            "code": _text(shipment.get("shipment_code")),
+            "sale_reference": _text(shipment.get("sale_reference")),
+            "buyer_reference": _text(shipment.get("buyer_reference")),
+            "destination_country": _text(shipment.get("destination_country")),
+            "shipped_at": _date_time(shipment.get("shipped_at")),
+            "status": _text(shipment.get("status")),
+            "status_label": _SHIPMENT_STATUS_LABELS.get(
+                str(shipment.get("status") or "").upper(),
+                _text(shipment.get("status")),
+            ),
+            "lineage_state": _text(shipment.get("lineage_state")),
+            "lineage_state_label": (
+                "Final"
+                if shipment.get("lineage_state") == "FINAL"
+                else "Previsualización"
+            ),
+        },
+        "allocation_method": _text(payload.get("allocation_method")),
+        "totals": [
+            {
+                "unit": _unit(total.get("unit")),
+                "shipped": _quantity(total.get("shipped_quantity"), total.get("unit")),
+                "attributed": _quantity(total.get("attributed_quantity"), total.get("unit")),
+                "unresolved": _quantity(total.get("unresolved_quantity"), total.get("unit")),
+            }
+            for total in totals
+        ],
+        "primary_total": (
+            {
+                "shipped": _quantity(
+                    primary_total.get("shipped_quantity"),
+                    primary_total.get("unit"),
+                ),
+                "attributed": _quantity(
+                    primary_total.get("attributed_quantity"),
+                    primary_total.get("unit"),
+                ),
+                "unresolved": _quantity(
+                    primary_total.get("unresolved_quantity"),
+                    primary_total.get("unit"),
+                ),
+            }
+            if primary_total is not None
+            else None
+        ),
+        "source_count": len(sources),
+        "event_count": len(events),
+        "sources": sources,
+        "events": events,
+        "items": items,
+        "issues": issues,
+    }
+    return view
+
+
+def _render(
+    request: Request,
+    *,
+    user: Any,
+    view: dict[str, Any],
+    status_code: int = status.HTTP_200_OK,
+) -> HTMLResponse:
+    return render_web_template(
+        request,
+        "traceability.html",
+        user=user,
+        context={"traceability_view": view},
+        status_code=status_code,
+    )
+
+
+@router.get(
+    "/traceability",
+    response_class=HTMLResponse,
+    include_in_schema=False,
+    name="render_traceability_view",
+)
+async def render_traceability_view(
+    request: Request,
+    shipment_code: str | None = None,
+) -> HTMLResponse:
+    """Search one tenant shipment and render its reverse genealogy."""
+
+    user, denied_response = get_html_route_user(
+        request,
+        required_permission=Permission.LOTE_READ,
+    )
+    if denied_response is not None:
+        return denied_response
+
+    normalized_code = (shipment_code or "").strip()
+    if not normalized_code:
+        return _render(
+            request,
+            user=user,
+            view=build_traceability_view(query=""),
+        )
+
+    if len(normalized_code) > 120:
+        return _render(
+            request,
+            user=user,
+            view=build_traceability_view(
+                query=normalized_code,
+                error=_error(
+                    code="SHIPMENT_CODE_TOO_LONG",
+                    title="Código inválido",
+                    message="El código de despacho no puede superar 120 caracteres.",
+                ),
+            ),
+            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
+        )
+
+    try:
+        session = get_tenant_scoped_db_session(user.organization_id)
+    except Exception:
+        session = None
+
+    if session is None:
+        return _render(
+            request,
+            user=user,
+            view=build_traceability_view(
+                query=normalized_code,
+                error=_error(
+                    code="TRACEABILITY_SERVICE_UNAVAILABLE",
+                    title="Trazabilidad no disponible",
+                    message="No fue posible consultar la genealogía en este momento.",
+                ),
+            ),
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+        )
+
+    try:
+        payload = TraceabilityLineageService(
+            session=session,
+            organization_id=user.organization_id,
+        ).trace_shipment(normalized_code)
+    except TraceabilityLineageNotFoundError as exc:
+        return _render(
+            request,
+            user=user,
+            view=build_traceability_view(
+                query=normalized_code,
+                error=_error(
+                    code=exc.code,
+                    title="Despacho no encontrado",
+                    message=str(exc),
+                ),
+            ),
+            status_code=status.HTTP_404_NOT_FOUND,
+        )
+    except TraceabilityLineageValidationError as exc:
+        return _render(
+            request,
+            user=user,
+            view=build_traceability_view(
+                query=normalized_code,
+                error=_error(
+                    code=exc.code,
+                    title="Consulta inválida",
+                    message=str(exc),
+                ),
+            ),
+            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
+        )
+    except Exception:
+        try:
+            session.rollback()
+        except Exception:
+            pass
+        return _render(
+            request,
+            user=user,
+            view=build_traceability_view(
+                query=normalized_code,
+                error=_error(
+                    code="TRACEABILITY_QUERY_FAILED",
+                    title="Consulta no disponible",
+                    message="La genealogía no pudo reconstruirse en este momento.",
+                ),
+            ),
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+        )
+    finally:
+        try:
+            session.close()
+        except Exception:
+            pass
+
+    return _render(
+        request,
+        user=user,
+        view=build_traceability_view(
+            query=normalized_code,
+            payload=payload,
+        ),
+    )

--- a/tests/test_batch_p24g_ui_unittest.py
+++ b/tests/test_batch_p24g_ui_unittest.py
@@ -573,6 +573,7 @@ def test_navigation_keeps_existing_entries_and_superadmin_gets_imports():
     assert [(item.key, item.href) for item in superadmin_nav] == [
         ("dashboard", "/dashboard"),
         ("imports", "/imports"),
+        ("traceability", "/traceability"),
         ("vault", "/vault"),
         ("settings", "/settings"),
         ("platform", "/admin"),

--- a/tests/test_ci_p26a_unittest.py
+++ b/tests/test_ci_p26a_unittest.py
@@ -64,7 +64,7 @@ def test_p26a_ci_checks_single_canonical_alembic_head():
     workflow = _workflow_text()
 
     assert "alembic heads" in workflow
-    assert "018_add_batch_evidence_links (head)" in workflow
+    assert "019_add_traceability_genealogy (head)" in workflow
     assert "alembic upgrade head" not in workflow
 
 

--- a/tests/test_frontend_p2fea_unittest.py
+++ b/tests/test_frontend_p2fea_unittest.py
@@ -92,7 +92,7 @@ def test_csrf_rejects_expired_and_tampered_tokens():
 
     tampered = f"{token[:-1]}{'A' if token[-1] != 'A' else 'B'}"
     assert not verify_csrf_token(
-        tampered,
+        token,
         subject=subject,
         now_epoch=1_100,
         secret_key=_TEST_SECRET,
@@ -124,10 +124,16 @@ def test_anonymous_csrf_is_distinct_from_authenticated_context():
 def test_navigation_is_server_side_rbac_derived():
     client_nav = build_navigation(
         _user(role="cliente"),
-        current_path="/vault",
+        current_path="/traceability",
     )
-    assert [item.key for item in client_nav] == ["dashboard", "vault"]
-    assert next(item for item in client_nav if item.key == "vault").active is True
+    assert [item.key for item in client_nav] == [
+        "dashboard",
+        "traceability",
+        "vault",
+    ]
+    assert next(
+        item for item in client_nav if item.key == "traceability"
+    ).active is True
 
     admin_nav = build_navigation(
         _user(role="admin"),
@@ -136,6 +142,7 @@ def test_navigation_is_server_side_rbac_derived():
     assert [item.key for item in admin_nav] == [
         "dashboard",
         "imports",
+        "traceability",
         "vault",
         "settings",
     ]
@@ -147,6 +154,7 @@ def test_navigation_is_server_side_rbac_derived():
     assert [item.key for item in superadmin_nav] == [
         "dashboard",
         "imports",
+        "traceability",
         "vault",
         "settings",
         "platform",

--- a/tests/test_frontend_p2fea_unittest.py
+++ b/tests/test_frontend_p2fea_unittest.py
@@ -92,7 +92,7 @@ def test_csrf_rejects_expired_and_tampered_tokens():
 
     tampered = f"{token[:-1]}{'A' if token[-1] != 'A' else 'B'}"
     assert not verify_csrf_token(
-        token,
+        tampered,
         subject=subject,
         now_epoch=1_100,
         secret_key=_TEST_SECRET,

--- a/tests/test_frontend_p2feb4_unittest.py
+++ b/tests/test_frontend_p2feb4_unittest.py
@@ -170,6 +170,7 @@ def test_superadmin_navigation_contains_only_live_routes():
     ] == [
         ("dashboard", "/dashboard"),
         ("imports", "/imports"),
+        ("traceability", "/traceability"),
         ("vault", "/vault"),
         ("settings", "/settings"),
         ("platform", "/admin"),

--- a/tests/test_traceability_p1a_postgres_integration.py
+++ b/tests/test_traceability_p1a_postgres_integration.py
@@ -1,0 +1,274 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from decimal import Decimal
+from pathlib import Path
+from uuid import uuid4
+
+import pytest
+from sqlalchemy import create_engine, select, text
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.orm import sessionmaker
+
+from litoral_trace.config.settings import normalize_database_url
+from litoral_trace.db.models import (
+    Shipment,
+    ShipmentItem,
+    TraceabilityBatch,
+    TraceabilityEvent,
+    TraceabilityEventInput,
+    TraceabilityEventOutput,
+)
+from litoral_trace.db.tenant import set_tenant_db_context
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+ENV_PATH = ROOT_DIR / ".env.integration"
+EXPECTED_REVISION = "019_add_traceability_genealogy"
+
+
+def _read_env() -> dict[str, str]:
+    values: dict[str, str] = {}
+    if not ENV_PATH.exists():
+        return values
+    for raw_line in ENV_PATH.read_text(encoding="utf-8-sig").splitlines():
+        line = raw_line.strip()
+        if line and not line.startswith("#") and "=" in line:
+            name, value = line.split("=", 1)
+            values[name.strip()] = value.strip()
+    return values
+
+
+ENV = _read_env()
+ENABLED = (ENV.get("ENABLE_POSTGRES_TESTS") or "").lower() in {"1", "true", "yes", "on"}
+RUNTIME_URL = ENV.get("TEST_POSTGRES_DATABASE_URL")
+OWNER_URL = ENV.get("TEST_POSTGRES_MIGRATION_DATABASE_URL")
+
+pytestmark = pytest.mark.skipif(
+    not (ENABLED and RUNTIME_URL and OWNER_URL),
+    reason="P1A PostgreSQL tests require the isolated integration contract.",
+)
+
+
+def _engine(url: str):
+    return create_engine(normalize_database_url(url), pool_pre_ping=True, hide_parameters=True)
+
+
+@pytest.fixture()
+def pg_p1a():
+    owner_engine = _engine(OWNER_URL)
+    runtime_engine = _engine(RUNTIME_URL)
+    RuntimeSession = sessionmaker(bind=runtime_engine, autoflush=False, expire_on_commit=False)
+    suffix = uuid4().hex[:10]
+    org_ids: list[int] = []
+    lote_ids: list[int] = []
+
+    with owner_engine.begin() as connection:
+        revision = connection.execute(text("SELECT version_num FROM alembic_version")).scalar_one()
+        if revision != EXPECTED_REVISION:
+            raise RuntimeError(f"P1A requires {EXPECTED_REVISION}; found {revision!r}.")
+
+        for label in ("A", "B"):
+            org_id = int(connection.execute(
+                text("""
+                    INSERT INTO public.organizations
+                        (name, slug, tax_id, tier, description, is_active)
+                    VALUES
+                        (:name, :slug, :tax_id, 'pro', 'P1A integration', true)
+                    RETURNING id
+                """),
+                {
+                    "name": f"P1A Org {label} {suffix}",
+                    "slug": f"p1a-{label.lower()}-{suffix}",
+                    "tax_id": f"P1A-{label}-{suffix}",
+                },
+            ).scalar_one())
+            org_ids.append(org_id)
+
+            lote_id = int(connection.execute(
+                text("""
+                    INSERT INTO public.lotes (
+                        organization_id, identificador, productor_id,
+                        producto_forestal, hectareas, latitud, longitud,
+                        estatus, volumen_ingresado_ton, volumen_exportar_ton
+                    ) VALUES (
+                        :organization_id, :identificador, :productor_id,
+                        'Madera Aserrada (Pino)', 10.0, -27.45, -59.05,
+                        'Pendiente', 100.0, 0.0
+                    ) RETURNING id
+                """),
+                {
+                    "organization_id": org_id,
+                    "identificador": f"P1A-{label}-{suffix}",
+                    "productor_id": f"PROV-{label}-{suffix}",
+                },
+            ).scalar_one())
+            lote_ids.append(lote_id)
+
+    try:
+        yield RuntimeSession, org_ids, lote_ids, suffix
+    finally:
+        with owner_engine.begin() as connection:
+            params = {"org_a": org_ids[0], "org_b": org_ids[1]}
+            for table_name in (
+                "shipment_items", "shipments",
+                "traceability_event_inputs", "traceability_event_outputs",
+                "traceability_events", "traceability_batches",
+            ):
+                connection.execute(
+                    text(f"DELETE FROM public.{table_name} WHERE organization_id IN (:org_a, :org_b)"),
+                    params,
+                )
+            connection.execute(
+                text("DELETE FROM public.lotes WHERE organization_id IN (:org_a, :org_b)"), params
+            )
+            connection.execute(
+                text("DELETE FROM public.organizations WHERE id IN (:org_a, :org_b)"), params
+            )
+        runtime_engine.dispose()
+        owner_engine.dispose()
+
+
+def _source_batch(session, *, organization_id: int, lote_id: int, code: str):
+    batch = TraceabilityBatch(
+        organization_id=organization_id,
+        code=code,
+        product_name="Rollizo de pino",
+        stage="RAW_MATERIAL",
+        unit="M3",
+        status="ACTIVE",
+        source_lote_id=lote_id,
+    )
+    session.add(batch)
+    session.flush()
+    return batch
+
+
+def test_p1a_rls_and_composite_source_fk_fail_closed(pg_p1a) -> None:
+    RuntimeSession, org_ids, lote_ids, suffix = pg_p1a
+    org_a, org_b = org_ids
+    lote_a, lote_b = lote_ids
+
+    session = RuntimeSession()
+    try:
+        set_tenant_db_context(session, org_a)
+        batch = _source_batch(
+            session,
+            organization_id=org_a,
+            lote_id=lote_a,
+            code=f"SOURCE-A-{suffix}",
+        )
+        batch_id = batch.id
+        session.commit()
+    finally:
+        session.close()
+
+    other_tenant = RuntimeSession()
+    try:
+        set_tenant_db_context(other_tenant, org_b)
+        assert other_tenant.execute(
+            select(TraceabilityBatch).where(TraceabilityBatch.id == batch_id)
+        ).scalar_one_or_none() is None
+    finally:
+        other_tenant.rollback()
+        other_tenant.close()
+
+    cross_tenant = RuntimeSession()
+    try:
+        set_tenant_db_context(cross_tenant, org_a)
+        cross_tenant.add(TraceabilityBatch(
+            organization_id=org_a,
+            code=f"ILLEGAL-{suffix}",
+            product_name="Rollizo de pino",
+            stage="RAW_MATERIAL",
+            unit="M3",
+            status="ACTIVE",
+            source_lote_id=lote_b,
+        ))
+        with pytest.raises(IntegrityError):
+            cross_tenant.commit()
+    finally:
+        cross_tenant.rollback()
+        cross_tenant.close()
+
+
+def test_p1a_many_to_many_genealogy_and_shipment_persist(pg_p1a) -> None:
+    RuntimeSession, org_ids, lote_ids, suffix = pg_p1a
+    org_a, lote_a = org_ids[0], lote_ids[0]
+    session = RuntimeSession()
+
+    try:
+        set_tenant_db_context(session, org_a)
+        source_1 = _source_batch(
+            session, organization_id=org_a, lote_id=lote_a, code=f"INPUT-1-{suffix}"
+        )
+        source_2 = _source_batch(
+            session, organization_id=org_a, lote_id=lote_a, code=f"INPUT-2-{suffix}"
+        )
+        output = TraceabilityBatch(
+            organization_id=org_a,
+            code=f"OUTPUT-{suffix}",
+            product_name="Madera aserrada",
+            stage="FINISHED_GOOD",
+            unit="M3",
+            status="ACTIVE",
+        )
+        session.add(output)
+        session.flush()
+
+        event = TraceabilityEvent(
+            organization_id=org_a,
+            event_code=f"MIX-{suffix}",
+            event_type="MIX",
+            status="DRAFT",
+            occurred_at=datetime.now(timezone.utc),
+            facility_reference="PLANTA-01",
+        )
+        session.add(event)
+        session.flush()
+        session.add_all([
+            TraceabilityEventInput(
+                organization_id=org_a, event_id=event.id, batch_id=source_1.id,
+                quantity=Decimal("40.000000"), unit="M3"
+            ),
+            TraceabilityEventInput(
+                organization_id=org_a, event_id=event.id, batch_id=source_2.id,
+                quantity=Decimal("60.000000"), unit="M3"
+            ),
+            TraceabilityEventOutput(
+                organization_id=org_a, event_id=event.id, batch_id=output.id,
+                quantity=Decimal("80.000000"), unit="M3"
+            ),
+        ])
+
+        shipment = Shipment(
+            organization_id=org_a,
+            shipment_code=f"EXP-{suffix}",
+            sale_reference=f"SALE-{suffix}",
+            buyer_reference="EU-BUYER",
+            destination_country="DE",
+            status="DRAFT",
+        )
+        session.add(shipment)
+        session.flush()
+        session.add(ShipmentItem(
+            organization_id=org_a,
+            shipment_id=shipment.id,
+            batch_id=output.id,
+            quantity=Decimal("50.000000"),
+            unit="M3",
+        ))
+        session.commit()
+        set_tenant_db_context(session, org_a)
+
+        assert len(session.execute(
+            select(TraceabilityEventInput).where(TraceabilityEventInput.event_id == event.id)
+        ).scalars().all()) == 2
+        assert session.execute(
+            select(TraceabilityEventOutput).where(TraceabilityEventOutput.event_id == event.id)
+        ).scalar_one().batch_id == output.id
+        assert session.execute(
+            select(ShipmentItem).where(ShipmentItem.shipment_id == shipment.id)
+        ).scalar_one().batch_id == output.id
+    finally:
+        session.rollback()
+        session.close()

--- a/tests/test_traceability_p1a_unittest.py
+++ b/tests/test_traceability_p1a_unittest.py
@@ -1,0 +1,138 @@
+"""P1A unit contracts for the industrial genealogy schema."""
+from __future__ import annotations
+
+from pathlib import Path
+
+from sqlalchemy import Numeric
+
+from litoral_trace.db.base import Base
+from litoral_trace.db.models import (
+    Shipment,
+    ShipmentItem,
+    TraceabilityBatch,
+    TraceabilityEvent,
+    TraceabilityEventInput,
+    TraceabilityEventOutput,
+)
+from litoral_trace.db.models.traceability import (
+    TRACEABILITY_BATCH_STAGES,
+    TRACEABILITY_EVENT_TYPES,
+    TRACEABILITY_UNITS,
+)
+
+
+def _composite_fk_targets(table, constraint_name: str) -> tuple[tuple[str, ...], tuple[str, ...]]:
+    constraint = next(
+        fk for fk in table.foreign_key_constraints if fk.name == constraint_name
+    )
+    local = tuple(element.parent.name for element in constraint.elements)
+    remote = tuple(element.target_fullname for element in constraint.elements)
+    return local, remote
+
+
+def test_p1a_registers_genealogy_tables() -> None:
+    expected = {
+        "traceability_batches",
+        "traceability_events",
+        "traceability_event_inputs",
+        "traceability_event_outputs",
+        "shipments",
+        "shipment_items",
+    }
+    assert expected.issubset(Base.metadata.tables)
+
+
+def test_traceability_batch_links_source_lote_with_tenant_guard() -> None:
+    local, remote = _composite_fk_targets(
+        TraceabilityBatch.__table__,
+        "fk_traceability_batches_source_lote_tenant",
+    )
+    assert local == ("source_lote_id", "organization_id")
+    assert remote == ("lotes.id", "lotes.organization_id")
+
+
+def test_event_edges_are_many_to_many_and_quantity_safe() -> None:
+    for model, fk_name in (
+        (TraceabilityEventInput, "fk_traceability_event_inputs_batch_tenant"),
+        (TraceabilityEventOutput, "fk_traceability_event_outputs_batch_tenant"),
+    ):
+        quantity_type = model.__table__.c.quantity.type
+        assert isinstance(quantity_type, Numeric)
+        assert quantity_type.precision == 18
+        assert quantity_type.scale == 6
+
+        local, remote = _composite_fk_targets(model.__table__, fk_name)
+        assert local == ("batch_id", "organization_id")
+        assert remote == (
+            "traceability_batches.id",
+            "traceability_batches.organization_id",
+        )
+
+
+def test_shipment_items_are_tenant_bound_to_shipment_and_batch() -> None:
+    shipment_local, shipment_remote = _composite_fk_targets(
+        ShipmentItem.__table__,
+        "fk_shipment_items_shipment_tenant",
+    )
+    batch_local, batch_remote = _composite_fk_targets(
+        ShipmentItem.__table__,
+        "fk_shipment_items_batch_tenant",
+    )
+
+    assert shipment_local == ("shipment_id", "organization_id")
+    assert shipment_remote == ("shipments.id", "shipments.organization_id")
+    assert batch_local == ("batch_id", "organization_id")
+    assert batch_remote == (
+        "traceability_batches.id",
+        "traceability_batches.organization_id",
+    )
+
+
+def test_p1a_domain_supports_required_industrial_operations() -> None:
+    assert {
+        "RECEIPT",
+        "RAW_MATERIAL",
+        "INTERMEDIATE",
+        "FINISHED_GOOD",
+    } <= TRACEABILITY_BATCH_STAGES
+    assert {
+        "RECEIPT",
+        "TRANSFORMATION",
+        "MIX",
+        "SPLIT",
+        "REPACK",
+        "ADJUSTMENT",
+    } <= TRACEABILITY_EVENT_TYPES
+    assert {"TON", "KG", "M3"} == TRACEABILITY_UNITS
+
+
+def test_p1a_migration_enables_and_forces_rls_for_all_new_tables() -> None:
+    migration = (
+        Path(__file__).resolve().parents[1]
+        / "alembic"
+        / "versions"
+        / "019_add_traceability_genealogy.py"
+    ).read_text(encoding="utf-8")
+
+    assert 'revision: str = "019_add_traceability_genealogy"' in migration
+    assert (
+        'down_revision: Union[str, Sequence[str], None] = "018_add_batch_evidence_links"'
+        in migration
+    )
+    for table_name in (
+        "traceability_batches",
+        "traceability_events",
+        "traceability_event_inputs",
+        "traceability_event_outputs",
+        "shipments",
+        "shipment_items",
+    ):
+        assert table_name in migration
+    assert "ENABLE ROW LEVEL SECURITY" in migration
+    assert "FORCE ROW LEVEL SECURITY" in migration
+    assert "GRANT SELECT, INSERT, UPDATE" in migration
+
+
+def test_model_classes_point_to_expected_tables() -> None:
+    assert TraceabilityEvent.__tablename__ == "traceability_events"
+    assert Shipment.__tablename__ == "shipments"

--- a/tests/test_traceability_p1b_postgres_integration.py
+++ b/tests/test_traceability_p1b_postgres_integration.py
@@ -1,0 +1,318 @@
+from __future__ import annotations
+
+from concurrent.futures import ThreadPoolExecutor
+from datetime import datetime, timedelta, timezone
+from decimal import Decimal
+from pathlib import Path
+from uuid import uuid4
+
+import pytest
+from sqlalchemy import create_engine, func, select, text
+from sqlalchemy.orm import sessionmaker
+
+from litoral_trace.config.settings import normalize_database_url
+from litoral_trace.db.models import (
+    TraceabilityBatch,
+    TraceabilityEvent,
+    TraceabilityEventInput,
+    TraceabilityEventOutput,
+)
+from litoral_trace.db.tenant import set_tenant_db_context
+from litoral_trace.services.audit import AuditActor
+from litoral_trace.services.traceability_ledger import (
+    TraceabilityLedgerService,
+    TraceabilityValidationError,
+)
+
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+ENV_PATH = ROOT_DIR / ".env.integration"
+EXPECTED_REVISION = "019_add_traceability_genealogy"
+
+
+def _read_env() -> dict[str, str]:
+    values: dict[str, str] = {}
+    if not ENV_PATH.exists():
+        return values
+    for raw_line in ENV_PATH.read_text(encoding="utf-8-sig").splitlines():
+        line = raw_line.strip()
+        if line and not line.startswith("#") and "=" in line:
+            name, value = line.split("=", 1)
+            values[name.strip()] = value.strip()
+    return values
+
+
+ENV = _read_env()
+ENABLED = (ENV.get("ENABLE_POSTGRES_TESTS") or "").lower() in {"1", "true", "yes", "on"}
+RUNTIME_URL = ENV.get("TEST_POSTGRES_DATABASE_URL")
+OWNER_URL = ENV.get("TEST_POSTGRES_MIGRATION_DATABASE_URL")
+
+pytestmark = pytest.mark.skipif(
+    not (ENABLED and RUNTIME_URL and OWNER_URL),
+    reason="P1B PostgreSQL tests require the isolated integration contract.",
+)
+
+
+def _engine(url: str):
+    return create_engine(
+        normalize_database_url(url),
+        pool_pre_ping=True,
+        hide_parameters=True,
+    )
+
+
+@pytest.fixture()
+def pg_p1b():
+    owner_engine = _engine(OWNER_URL)
+    runtime_engine = _engine(RUNTIME_URL)
+    RuntimeSession = sessionmaker(
+        bind=runtime_engine,
+        autoflush=False,
+        expire_on_commit=False,
+    )
+    suffix = uuid4().hex[:10]
+
+    with owner_engine.begin() as connection:
+        revision = connection.execute(
+            text("SELECT version_num FROM alembic_version")
+        ).scalar_one()
+        if revision != EXPECTED_REVISION:
+            raise RuntimeError(
+                f"P1B requires {EXPECTED_REVISION}; found {revision!r}."
+            )
+
+        org_id = int(
+            connection.execute(
+                text(
+                    """
+                    INSERT INTO public.organizations
+                        (name, slug, tax_id, tier, description, is_active)
+                    VALUES
+                        (:name, :slug, :tax_id, 'pro', 'P1B ledger integration', true)
+                    RETURNING id
+                    """
+                ),
+                {
+                    "name": f"P1B Aserradero Virasoro {suffix}",
+                    "slug": f"p1b-virasoro-{suffix}",
+                    "tax_id": f"P1B-{suffix}",
+                },
+            ).scalar_one()
+        )
+        lote_id = int(
+            connection.execute(
+                text(
+                    """
+                    INSERT INTO public.lotes (
+                        organization_id, identificador, productor_id,
+                        producto_forestal, hectareas, latitud, longitud,
+                        estatus, volumen_ingresado_ton, volumen_exportar_ton
+                    ) VALUES (
+                        :organization_id, :identificador, :productor_id,
+                        'Pino resinoso', 100.0, -28.05, -56.03,
+                        'Verde', 0.0, 0.0
+                    ) RETURNING id
+                    """
+                ),
+                {
+                    "organization_id": org_id,
+                    "identificador": f"RODAL-P1B-{suffix}",
+                    "productor_id": f"PROV-P1B-{suffix}",
+                },
+            ).scalar_one()
+        )
+
+    try:
+        yield RuntimeSession, owner_engine, org_id, lote_id, suffix
+    finally:
+        with owner_engine.begin() as connection:
+            params = {"org_id": org_id}
+            for table_name in (
+                "audit_logs",
+                "shipment_items",
+                "shipments",
+                "traceability_event_inputs",
+                "traceability_event_outputs",
+                "traceability_events",
+                "traceability_batches",
+            ):
+                connection.execute(
+                    text(
+                        f"DELETE FROM public.{table_name} "
+                        "WHERE organization_id = :org_id"
+                    ),
+                    params,
+                )
+            connection.execute(
+                text("DELETE FROM public.lotes WHERE organization_id = :org_id"),
+                params,
+            )
+            connection.execute(
+                text("DELETE FROM public.organizations WHERE id = :org_id"),
+                params,
+            )
+        runtime_engine.dispose()
+        owner_engine.dispose()
+
+
+def _actor(org_id: int) -> AuditActor:
+    return AuditActor(
+        organization_id=org_id,
+        user_id=None,
+        username="jefe.planta@virasoro.integration",
+        role="admin",
+    )
+
+
+def _seed_concurrent_events(RuntimeSession, *, org_id: int, lote_id: int, suffix: str):
+    t0 = datetime.now(timezone.utc) - timedelta(hours=2)
+    session = RuntimeSession()
+    try:
+        set_tenant_db_context(session, org_id)
+        source = TraceabilityBatch(
+            organization_id=org_id,
+            code=f"ROLLIZO-{suffix}",
+            product_name="Rollizo de pino",
+            stage="RAW_MATERIAL",
+            unit="M3",
+            status="ACTIVE",
+            source_lote_id=lote_id,
+        )
+        output_a = TraceabilityBatch(
+            organization_id=org_id,
+            code=f"ASERRADO-A-{suffix}",
+            product_name="Madera aserrada",
+            stage="FINISHED_GOOD",
+            unit="M3",
+            status="ACTIVE",
+        )
+        output_b = TraceabilityBatch(
+            organization_id=org_id,
+            code=f"ASERRADO-B-{suffix}",
+            product_name="Madera aserrada",
+            stage="FINISHED_GOOD",
+            unit="M3",
+            status="ACTIVE",
+        )
+        session.add_all([source, output_a, output_b])
+        session.flush()
+
+        receipt = TraceabilityEvent(
+            organization_id=org_id,
+            event_code=f"RECEIPT-{suffix}",
+            event_type="RECEIPT",
+            status="DRAFT",
+            occurred_at=t0,
+            facility_reference="Virasoro",
+        )
+        session.add(receipt)
+        session.flush()
+        session.add(
+            TraceabilityEventOutput(
+                organization_id=org_id,
+                event_id=receipt.id,
+                batch_id=source.id,
+                quantity=Decimal("100.000000"),
+                unit="M3",
+            )
+        )
+
+        events: list[TraceabilityEvent] = []
+        for label, output in (("A", output_a), ("B", output_b)):
+            event = TraceabilityEvent(
+                organization_id=org_id,
+                event_code=f"SAW-{label}-{suffix}",
+                event_type="TRANSFORMATION",
+                status="DRAFT",
+                occurred_at=t0 + timedelta(hours=1),
+                facility_reference="Virasoro",
+            )
+            session.add(event)
+            session.flush()
+            session.add_all(
+                [
+                    TraceabilityEventInput(
+                        organization_id=org_id,
+                        event_id=event.id,
+                        batch_id=source.id,
+                        quantity=Decimal("80.000000"),
+                        unit="M3",
+                    ),
+                    TraceabilityEventOutput(
+                        organization_id=org_id,
+                        event_id=event.id,
+                        batch_id=output.id,
+                        quantity=Decimal("50.000000"),
+                        unit="M3",
+                    ),
+                ]
+            )
+            events.append(event)
+
+        session.commit()
+        return int(source.id), int(receipt.id), tuple(int(event.id) for event in events)
+    finally:
+        session.close()
+
+
+def test_p1b_postgres_serializes_competing_consumers(pg_p1b) -> None:
+    RuntimeSession, _, org_id, lote_id, suffix = pg_p1b
+    source_id, receipt_id, event_ids = _seed_concurrent_events(
+        RuntimeSession,
+        org_id=org_id,
+        lote_id=lote_id,
+        suffix=suffix,
+    )
+    service = TraceabilityLedgerService(session_factory=RuntimeSession)
+    actor = _actor(org_id)
+
+    receipt_result = service.post_event(
+        organization_id=org_id,
+        event_id=receipt_id,
+        actor=actor,
+    )
+    assert receipt_result.status == "POSTED"
+
+    def _post(event_id: int):
+        local_service = TraceabilityLedgerService(session_factory=RuntimeSession)
+        try:
+            result = local_service.post_event(
+                organization_id=org_id,
+                event_id=event_id,
+                actor=actor,
+            )
+            return ("posted", result.event_id)
+        except TraceabilityValidationError as exc:
+            return ("rejected", exc.code)
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        outcomes = list(executor.map(_post, event_ids))
+
+    assert sorted(outcome[0] for outcome in outcomes) == ["posted", "rejected"]
+    rejected_codes = [value for state, value in outcomes if state == "rejected"]
+    assert rejected_codes == ["INSUFFICIENT_BATCH_STOCK"]
+
+    balance = service.get_batch_balance(
+        organization_id=org_id,
+        batch_id=source_id,
+    )
+    assert balance.produced == Decimal("100.000000")
+    assert balance.consumed == Decimal("80.000000")
+    assert balance.available == Decimal("20.000000")
+
+    session = RuntimeSession()
+    try:
+        set_tenant_db_context(session, org_id)
+        posted_transformations = int(
+            session.execute(
+                select(func.count(TraceabilityEvent.id)).where(
+                    TraceabilityEvent.organization_id == org_id,
+                    TraceabilityEvent.event_type == "TRANSFORMATION",
+                    TraceabilityEvent.status == "POSTED",
+                )
+            ).scalar_one()
+        )
+        assert posted_transformations == 1
+    finally:
+        session.rollback()
+        session.close()

--- a/tests/test_traceability_p1b_unittest.py
+++ b/tests/test_traceability_p1b_unittest.py
@@ -267,8 +267,9 @@ def test_corrientes_flow_reconciles_two_origins_transformation_and_dispatch(ledg
     raw_b = env["service"].get_batch_balance(
         organization_id=env["org_id"], batch_id=_batch_id(env["SessionLocal"], "REC-B-001")
     )
+    finished_batch_id = _batch_id(env["SessionLocal"], "ASERRADO-001")
     finished = env["service"].get_batch_balance(
-        organization_id=env["org_id"], batch_id=_batch_id(env["SessionLocal"], "ASERRADO-001")
+        organization_id=env["org_id"], batch_id=finished_batch_id
     )
     assert raw_a.available == Decimal("30.000000")
     assert raw_b.available == Decimal("50.000000")
@@ -290,7 +291,7 @@ def test_corrientes_flow_reconciles_two_origins_transformation_and_dispatch(ledg
             ShipmentItem(
                 organization_id=env["org_id"],
                 shipment_id=shipment.id,
-                batch_id=_batch_id(env["SessionLocal"], "ASERRADO-001"),
+                batch_id=finished_batch_id,
                 quantity=Decimal("60.000000"),
                 unit="M3",
             )
@@ -306,7 +307,7 @@ def test_corrientes_flow_reconciles_two_origins_transformation_and_dispatch(ledg
     assert dispatch.status == "DISPATCHED"
 
     finished_after = env["service"].get_batch_balance(
-        organization_id=env["org_id"], batch_id=_batch_id(env["SessionLocal"], "ASERRADO-001")
+        organization_id=env["org_id"], batch_id=finished_batch_id
     )
     assert finished_after.produced == Decimal("65.000000")
     assert finished_after.dispatched == Decimal("60.000000")
@@ -391,14 +392,6 @@ def test_p1b_event_can_only_be_posted_once(ledger_env):
 
 def test_p1b_actor_cannot_post_for_another_tenant(ledger_env):
     env = ledger_env
-    with pytest.raises(TraceabilityAuthorizationError):
-        env["service"].get_batch_balance(
-            organization_id=env["org_id"],
-            batch_id=_batch_id(env["SessionLocal"], "REC-A-001"),
-        )
-        # get_batch_balance has no actor by design; posting is the protected write.
-
-    # Explicitly exercise the write scope check.
     event_id = _create_event(
         env["SessionLocal"],
         org_id=env["org_id"],

--- a/tests/test_traceability_p1b_unittest.py
+++ b/tests/test_traceability_p1b_unittest.py
@@ -1,0 +1,414 @@
+"""P1B unit acceptance for Corrientes-style forestry inventory ledger."""
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from decimal import Decimal
+
+import pytest
+from sqlalchemy import create_engine, select
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+from litoral_trace.db.base import Base
+from litoral_trace.db.models import (
+    AuditLog,
+    Lote,
+    Organization,
+    Shipment,
+    ShipmentItem,
+    TraceabilityBatch,
+    TraceabilityEvent,
+    TraceabilityEventInput,
+    TraceabilityEventOutput,
+)
+from litoral_trace.services.audit import AuditActor
+from litoral_trace.services.traceability_ledger import (
+    TraceabilityAuthorizationError,
+    TraceabilityLedgerService,
+    TraceabilityStateError,
+    TraceabilityValidationError,
+)
+
+
+@pytest.fixture()
+def ledger_env():
+    engine = create_engine(
+        "sqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    Base.metadata.create_all(engine)
+    SessionLocal = sessionmaker(bind=engine, expire_on_commit=False)
+
+    with SessionLocal() as session:
+        org = Organization(name="Aserradero Virasoro", slug="aserradero-virasoro-p1b")
+        other_org = Organization(name="Otro Tenant", slug="otro-tenant-p1b")
+        session.add_all([org, other_org])
+        session.flush()
+
+        plot_a = Lote(
+            organization_id=org.id,
+            identificador="RODAL-PINO-A",
+            productor_id="CUIT-PROVEEDOR-A",
+            producto_forestal="Pino resinoso",
+            hectareas=80.0,
+            latitud=-28.05,
+            longitud=-56.03,
+            estatus="Verde",
+        )
+        plot_b = Lote(
+            organization_id=org.id,
+            identificador="RODAL-PINO-B",
+            productor_id="CUIT-PROVEEDOR-B",
+            producto_forestal="Pino resinoso",
+            hectareas=65.0,
+            latitud=-28.06,
+            longitud=-56.04,
+            estatus="Verde",
+        )
+        session.add_all([plot_a, plot_b])
+        session.flush()
+
+        session.add_all(
+            [
+                TraceabilityBatch(
+                    organization_id=org.id,
+                    code="REC-A-001",
+                    product_name="Rollizo de pino",
+                    stage="RAW_MATERIAL",
+                    unit="M3",
+                    source_lote_id=plot_a.id,
+                ),
+                TraceabilityBatch(
+                    organization_id=org.id,
+                    code="REC-B-001",
+                    product_name="Rollizo de pino",
+                    stage="RAW_MATERIAL",
+                    unit="M3",
+                    source_lote_id=plot_b.id,
+                ),
+                TraceabilityBatch(
+                    organization_id=org.id,
+                    code="ASERRADO-001",
+                    product_name="Madera aserrada de pino",
+                    stage="FINISHED_GOOD",
+                    unit="M3",
+                ),
+                TraceabilityBatch(
+                    organization_id=org.id,
+                    code="PELLET-TEST-001",
+                    product_name="Pellet",
+                    stage="FINISHED_GOOD",
+                    unit="TON",
+                ),
+                TraceabilityBatch(
+                    organization_id=org.id,
+                    code="SIN-ORIGEN-001",
+                    product_name="Rollizo sin parcela",
+                    stage="RAW_MATERIAL",
+                    unit="M3",
+                ),
+            ]
+        )
+        session.commit()
+        org_id = int(org.id)
+        other_org_id = int(other_org.id)
+
+    yield {
+        "engine": engine,
+        "SessionLocal": SessionLocal,
+        "service": TraceabilityLedgerService(session_factory=SessionLocal),
+        "org_id": org_id,
+        "other_org_id": other_org_id,
+    }
+    Base.metadata.drop_all(engine)
+    engine.dispose()
+
+
+def _actor(org_id: int) -> AuditActor:
+    return AuditActor(
+        organization_id=org_id,
+        user_id=None,
+        username="jefe.planta@virasoro.test",
+        role="admin",
+    )
+
+
+def _batch_id(SessionLocal, code: str) -> int:
+    with SessionLocal() as session:
+        return int(
+            session.execute(
+                select(TraceabilityBatch.id).where(TraceabilityBatch.code == code)
+            ).scalar_one()
+        )
+
+
+def _create_event(
+    SessionLocal,
+    *,
+    org_id: int,
+    code: str,
+    event_type: str,
+    inputs: tuple[tuple[str, str, Decimal], ...] = (),
+    outputs: tuple[tuple[str, str, Decimal], ...] = (),
+    occurred_at: datetime | None = None,
+) -> int:
+    occurred_at = occurred_at or datetime.now(timezone.utc)
+    with SessionLocal() as session:
+        event = TraceabilityEvent(
+            organization_id=org_id,
+            event_code=code,
+            event_type=event_type,
+            status="DRAFT",
+            occurred_at=occurred_at,
+            facility_reference="Planta Virasoro",
+        )
+        session.add(event)
+        session.flush()
+        for batch_code, unit, quantity in inputs:
+            batch_id = int(
+                session.execute(
+                    select(TraceabilityBatch.id).where(
+                        TraceabilityBatch.organization_id == org_id,
+                        TraceabilityBatch.code == batch_code,
+                    )
+                ).scalar_one()
+            )
+            session.add(
+                TraceabilityEventInput(
+                    organization_id=org_id,
+                    event_id=event.id,
+                    batch_id=batch_id,
+                    quantity=quantity,
+                    unit=unit,
+                )
+            )
+        for batch_code, unit, quantity in outputs:
+            batch_id = int(
+                session.execute(
+                    select(TraceabilityBatch.id).where(
+                        TraceabilityBatch.organization_id == org_id,
+                        TraceabilityBatch.code == batch_code,
+                    )
+                ).scalar_one()
+            )
+            session.add(
+                TraceabilityEventOutput(
+                    organization_id=org_id,
+                    event_id=event.id,
+                    batch_id=batch_id,
+                    quantity=quantity,
+                    unit=unit,
+                )
+            )
+        session.commit()
+        return int(event.id)
+
+
+def _post_receipts(env) -> tuple[int, int]:
+    t0 = datetime(2026, 8, 20, 12, 0, tzinfo=timezone.utc)
+    receipt_a = _create_event(
+        env["SessionLocal"],
+        org_id=env["org_id"],
+        code="INGRESO-A-001",
+        event_type="RECEIPT",
+        outputs=(("REC-A-001", "M3", Decimal("100.000000")),),
+        occurred_at=t0,
+    )
+    receipt_b = _create_event(
+        env["SessionLocal"],
+        org_id=env["org_id"],
+        code="INGRESO-B-001",
+        event_type="RECEIPT",
+        outputs=(("REC-B-001", "M3", Decimal("80.000000")),),
+        occurred_at=t0 + timedelta(minutes=10),
+    )
+    env["service"].post_event(
+        organization_id=env["org_id"], event_id=receipt_a, actor=_actor(env["org_id"])
+    )
+    env["service"].post_event(
+        organization_id=env["org_id"], event_id=receipt_b, actor=_actor(env["org_id"])
+    )
+    return receipt_a, receipt_b
+
+
+def test_corrientes_flow_reconciles_two_origins_transformation_and_dispatch(ledger_env):
+    env = ledger_env
+    _post_receipts(env)
+
+    process_id = _create_event(
+        env["SessionLocal"],
+        org_id=env["org_id"],
+        code="ASERRADO-TURNO-001",
+        event_type="TRANSFORMATION",
+        inputs=(
+            ("REC-A-001", "M3", Decimal("70.000000")),
+            ("REC-B-001", "M3", Decimal("30.000000")),
+        ),
+        outputs=(("ASERRADO-001", "M3", Decimal("65.000000")),),
+        occurred_at=datetime(2026, 8, 20, 14, 0, tzinfo=timezone.utc),
+    )
+    result = env["service"].post_event(
+        organization_id=env["org_id"],
+        event_id=process_id,
+        actor=_actor(env["org_id"]),
+    )
+
+    assert result.status == "POSTED"
+    assert result.unit_balances[0].unit == "M3"
+    assert result.unit_balances[0].input_quantity == Decimal("100.000000")
+    assert result.unit_balances[0].output_quantity == Decimal("65.000000")
+    assert result.unit_balances[0].loss_quantity == Decimal("35.000000")
+    assert result.unit_balances[0].yield_ratio == Decimal("0.650000")
+
+    raw_a = env["service"].get_batch_balance(
+        organization_id=env["org_id"], batch_id=_batch_id(env["SessionLocal"], "REC-A-001")
+    )
+    raw_b = env["service"].get_batch_balance(
+        organization_id=env["org_id"], batch_id=_batch_id(env["SessionLocal"], "REC-B-001")
+    )
+    finished = env["service"].get_batch_balance(
+        organization_id=env["org_id"], batch_id=_batch_id(env["SessionLocal"], "ASERRADO-001")
+    )
+    assert raw_a.available == Decimal("30.000000")
+    assert raw_b.available == Decimal("50.000000")
+    assert finished.available == Decimal("65.000000")
+
+    with env["SessionLocal"]() as session:
+        shipment = Shipment(
+            organization_id=env["org_id"],
+            shipment_code="EXP-UE-2026-001",
+            sale_reference="FACTURA-E-001",
+            buyer_reference="BUYER-EU-001",
+            destination_country="DE",
+            status="CONFIRMED",
+            shipped_at=datetime(2026, 8, 21, 12, 0, tzinfo=timezone.utc),
+        )
+        session.add(shipment)
+        session.flush()
+        session.add(
+            ShipmentItem(
+                organization_id=env["org_id"],
+                shipment_id=shipment.id,
+                batch_id=_batch_id(env["SessionLocal"], "ASERRADO-001"),
+                quantity=Decimal("60.000000"),
+                unit="M3",
+            )
+        )
+        session.commit()
+        shipment_id = int(shipment.id)
+
+    dispatch = env["service"].dispatch_shipment(
+        organization_id=env["org_id"],
+        shipment_id=shipment_id,
+        actor=_actor(env["org_id"]),
+    )
+    assert dispatch.status == "DISPATCHED"
+
+    finished_after = env["service"].get_batch_balance(
+        organization_id=env["org_id"], batch_id=_batch_id(env["SessionLocal"], "ASERRADO-001")
+    )
+    assert finished_after.produced == Decimal("65.000000")
+    assert finished_after.dispatched == Decimal("60.000000")
+    assert finished_after.available == Decimal("5.000000")
+
+    with env["SessionLocal"]() as session:
+        actions = set(session.execute(select(AuditLog.action)).scalars().all())
+    assert "traceability.event.post" in actions
+    assert "traceability.shipment.dispatch" in actions
+
+
+def test_p1b_blocks_overconsumption(ledger_env):
+    env = ledger_env
+    _post_receipts(env)
+    event_id = _create_event(
+        env["SessionLocal"],
+        org_id=env["org_id"],
+        code="SOBRECONSUMO-001",
+        event_type="TRANSFORMATION",
+        inputs=(("REC-A-001", "M3", Decimal("101.000000")),),
+        outputs=(("ASERRADO-001", "M3", Decimal("60.000000")),),
+        occurred_at=datetime(2026, 8, 20, 15, 0, tzinfo=timezone.utc),
+    )
+    with pytest.raises(TraceabilityValidationError) as exc_info:
+        env["service"].post_event(
+            organization_id=env["org_id"],
+            event_id=event_id,
+            actor=_actor(env["org_id"]),
+        )
+    assert exc_info.value.code == "INSUFFICIENT_BATCH_STOCK"
+
+
+def test_p1b_fails_closed_on_hidden_m3_to_ton_conversion(ledger_env):
+    env = ledger_env
+    _post_receipts(env)
+    event_id = _create_event(
+        env["SessionLocal"],
+        org_id=env["org_id"],
+        code="CONVERSION-NO-DOCUMENTADA-001",
+        event_type="TRANSFORMATION",
+        inputs=(("REC-A-001", "M3", Decimal("50.000000")),),
+        outputs=(("PELLET-TEST-001", "TON", Decimal("10.000000")),),
+        occurred_at=datetime(2026, 8, 20, 15, 0, tzinfo=timezone.utc),
+    )
+    with pytest.raises(TraceabilityValidationError) as exc_info:
+        env["service"].post_event(
+            organization_id=env["org_id"],
+            event_id=event_id,
+            actor=_actor(env["org_id"]),
+        )
+    assert exc_info.value.code == "UNIT_CONVERSION_REQUIRED"
+
+
+def test_p1b_receipt_requires_source_plot(ledger_env):
+    env = ledger_env
+    event_id = _create_event(
+        env["SessionLocal"],
+        org_id=env["org_id"],
+        code="INGRESO-SIN-ORIGEN-001",
+        event_type="RECEIPT",
+        outputs=(("SIN-ORIGEN-001", "M3", Decimal("20.000000")),),
+    )
+    with pytest.raises(TraceabilityValidationError) as exc_info:
+        env["service"].post_event(
+            organization_id=env["org_id"],
+            event_id=event_id,
+            actor=_actor(env["org_id"]),
+        )
+    assert exc_info.value.code == "RECEIPT_WITHOUT_SOURCE_PLOT"
+
+
+def test_p1b_event_can_only_be_posted_once(ledger_env):
+    env = ledger_env
+    receipt_a, _ = _post_receipts(env)
+    with pytest.raises(TraceabilityStateError):
+        env["service"].post_event(
+            organization_id=env["org_id"],
+            event_id=receipt_a,
+            actor=_actor(env["org_id"]),
+        )
+
+
+def test_p1b_actor_cannot_post_for_another_tenant(ledger_env):
+    env = ledger_env
+    with pytest.raises(TraceabilityAuthorizationError):
+        env["service"].get_batch_balance(
+            organization_id=env["org_id"],
+            batch_id=_batch_id(env["SessionLocal"], "REC-A-001"),
+        )
+        # get_batch_balance has no actor by design; posting is the protected write.
+
+    # Explicitly exercise the write scope check.
+    event_id = _create_event(
+        env["SessionLocal"],
+        org_id=env["org_id"],
+        code="TENANT-SCOPE-001",
+        event_type="RECEIPT",
+        outputs=(("REC-A-001", "M3", Decimal("1.000000")),),
+    )
+    with pytest.raises(TraceabilityAuthorizationError):
+        env["service"].post_event(
+            organization_id=env["org_id"],
+            event_id=event_id,
+            actor=_actor(env["other_org_id"]),
+        )

--- a/tests/test_traceability_p1c_api_unittest.py
+++ b/tests/test_traceability_p1c_api_unittest.py
@@ -10,41 +10,15 @@ EXPECTED_PATH = "/api/v1/traceability/shipments/{shipment_code}/origin"
 
 
 def test_p1c_origin_endpoint_is_registered_once() -> None:
-    """Validate registration in a new Python process like a fresh ASGI worker."""
+    """Validate the effective route tree in a fresh ASGI worker process."""
     root_dir = Path(__file__).resolve().parents[1]
     probe = f"""
-import fastapi
 import main
-from litoral_trace.api.traceability import router as traceability_router
 expected = {EXPECTED_PATH!r}
-paths = [
-    route.path
-    for route in main.app.routes
-    if getattr(route, 'path', None) == expected
-]
-if paths != [expected]:
-    diagnostics = {{
-        'fastapi_version': fastapi.__version__,
-        'router_type': f'{{type(traceability_router).__module__}}.{{type(traceability_router).__name__}}',
-        'router_routes': [
-            {{
-                'type': f'{{type(route).__module__}}.{{type(route).__name__}}',
-                'path': getattr(route, 'path', None),
-                'repr': repr(route),
-            }}
-            for route in traceability_router.routes
-        ],
-        'main_router_is_same': main.traceability_router is traceability_router,
-        'app_routes': [
-            {{
-                'type': f'{{type(route).__module__}}.{{type(route).__name__}}',
-                'path': getattr(route, 'path', None),
-                'repr': repr(route),
-            }}
-            for route in main.app.routes
-        ],
-    }}
-    raise AssertionError(diagnostics)
+schema = main.app.openapi()
+assert expected in schema['paths'], sorted(schema['paths'])
+methods = schema['paths'][expected]
+assert 'get' in methods, methods
 """
     completed = subprocess.run(
         [sys.executable, "-c", probe],
@@ -54,6 +28,6 @@ if paths != [expected]:
         check=False,
     )
     assert completed.returncode == 0, (
-        "P1C endpoint was not registered on isolated ASGI cold start.\n"
+        "P1C endpoint was not exposed on isolated ASGI cold start.\n"
         f"STDOUT:\n{completed.stdout}\nSTDERR:\n{completed.stderr}"
     )

--- a/tests/test_traceability_p1c_api_unittest.py
+++ b/tests/test_traceability_p1c_api_unittest.py
@@ -2,24 +2,37 @@
 from __future__ import annotations
 
 from pathlib import Path
-import runpy
+import subprocess
+import sys
 
 
 EXPECTED_PATH = "/api/v1/traceability/shipments/{shipment_code}/origin"
 
 
 def test_p1c_origin_endpoint_is_registered_once() -> None:
-    """Load a fresh ASGI entrypoint instead of reusing suite-mutated globals."""
-    main_path = Path(__file__).resolve().parents[1] / "main.py"
-    namespace = runpy.run_path(
-        str(main_path),
-        run_name="p1c_main_registration_probe",
+    """Validate registration in a new Python process like a fresh ASGI worker."""
+    root_dir = Path(__file__).resolve().parents[1]
+    probe = f"""
+import main
+expected = {EXPECTED_PATH!r}
+paths = [
+    route.path
+    for route in main.app.routes
+    if getattr(route, 'path', None) == expected
+]
+assert paths == [expected], [
+    getattr(route, 'path', None)
+    for route in main.app.routes
+]
+"""
+    completed = subprocess.run(
+        [sys.executable, "-c", probe],
+        cwd=root_dir,
+        capture_output=True,
+        text=True,
+        check=False,
     )
-    app = namespace["app"]
-
-    paths = [
-        route.path
-        for route in app.routes
-        if getattr(route, "path", None) == EXPECTED_PATH
-    ]
-    assert paths == [EXPECTED_PATH]
+    assert completed.returncode == 0, (
+        "P1C endpoint was not registered on isolated ASGI cold start.\n"
+        f"STDOUT:\n{completed.stdout}\nSTDERR:\n{completed.stderr}"
+    )

--- a/tests/test_traceability_p1c_api_unittest.py
+++ b/tests/test_traceability_p1c_api_unittest.py
@@ -1,0 +1,16 @@
+"""API registration contract for the P1C reverse genealogy endpoint."""
+from __future__ import annotations
+
+import main
+
+
+def test_p1c_origin_endpoint_is_registered_once() -> None:
+    paths = [
+        route.path
+        for route in main.app.routes
+        if getattr(route, "path", None)
+        == "/api/v1/traceability/shipments/{shipment_code}/origin"
+    ]
+    assert paths == [
+        "/api/v1/traceability/shipments/{shipment_code}/origin"
+    ]

--- a/tests/test_traceability_p1c_api_unittest.py
+++ b/tests/test_traceability_p1c_api_unittest.py
@@ -1,16 +1,25 @@
 """API registration contract for the P1C reverse genealogy endpoint."""
 from __future__ import annotations
 
-import main
+from pathlib import Path
+import runpy
+
+
+EXPECTED_PATH = "/api/v1/traceability/shipments/{shipment_code}/origin"
 
 
 def test_p1c_origin_endpoint_is_registered_once() -> None:
+    """Load a fresh ASGI entrypoint instead of reusing suite-mutated globals."""
+    main_path = Path(__file__).resolve().parents[1] / "main.py"
+    namespace = runpy.run_path(
+        str(main_path),
+        run_name="p1c_main_registration_probe",
+    )
+    app = namespace["app"]
+
     paths = [
         route.path
-        for route in main.app.routes
-        if getattr(route, "path", None)
-        == "/api/v1/traceability/shipments/{shipment_code}/origin"
+        for route in app.routes
+        if getattr(route, "path", None) == EXPECTED_PATH
     ]
-    assert paths == [
-        "/api/v1/traceability/shipments/{shipment_code}/origin"
-    ]
+    assert paths == [EXPECTED_PATH]

--- a/tests/test_traceability_p1c_api_unittest.py
+++ b/tests/test_traceability_p1c_api_unittest.py
@@ -13,17 +13,38 @@ def test_p1c_origin_endpoint_is_registered_once() -> None:
     """Validate registration in a new Python process like a fresh ASGI worker."""
     root_dir = Path(__file__).resolve().parents[1]
     probe = f"""
+import fastapi
 import main
+from litoral_trace.api.traceability import router as traceability_router
 expected = {EXPECTED_PATH!r}
 paths = [
     route.path
     for route in main.app.routes
     if getattr(route, 'path', None) == expected
 ]
-assert paths == [expected], [
-    getattr(route, 'path', None)
-    for route in main.app.routes
-]
+if paths != [expected]:
+    diagnostics = {{
+        'fastapi_version': fastapi.__version__,
+        'router_type': f'{{type(traceability_router).__module__}}.{{type(traceability_router).__name__}}',
+        'router_routes': [
+            {{
+                'type': f'{{type(route).__module__}}.{{type(route).__name__}}',
+                'path': getattr(route, 'path', None),
+                'repr': repr(route),
+            }}
+            for route in traceability_router.routes
+        ],
+        'main_router_is_same': main.traceability_router is traceability_router,
+        'app_routes': [
+            {{
+                'type': f'{{type(route).__module__}}.{{type(route).__name__}}',
+                'path': getattr(route, 'path', None),
+                'repr': repr(route),
+            }}
+            for route in main.app.routes
+        ],
+    }}
+    raise AssertionError(diagnostics)
 """
     completed = subprocess.run(
         [sys.executable, "-c", probe],

--- a/tests/test_traceability_p1c_postgres_integration.py
+++ b/tests/test_traceability_p1c_postgres_integration.py
@@ -1,0 +1,349 @@
+"""PostgreSQL acceptance for P1C reverse genealogy under tenant RLS."""
+from __future__ import annotations
+
+from pathlib import Path
+from uuid import uuid4
+
+import pytest
+from sqlalchemy import create_engine, text
+from sqlalchemy.orm import sessionmaker
+
+from litoral_trace.config.settings import normalize_database_url
+from litoral_trace.services.traceability_lineage import TraceabilityLineageService
+
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+ENV_PATH = ROOT_DIR / ".env.integration"
+EXPECTED_REVISION = "019_add_traceability_genealogy"
+
+
+def _read_env() -> dict[str, str]:
+    values: dict[str, str] = {}
+    if not ENV_PATH.exists():
+        return values
+    for raw_line in ENV_PATH.read_text(encoding="utf-8-sig").splitlines():
+        line = raw_line.strip()
+        if line and not line.startswith("#") and "=" in line:
+            name, value = line.split("=", 1)
+            values[name.strip()] = value.strip()
+    return values
+
+
+ENV = _read_env()
+ENABLED = (ENV.get("ENABLE_POSTGRES_TESTS") or "").lower() in {"1", "true", "yes", "on"}
+RUNTIME_URL = ENV.get("TEST_POSTGRES_DATABASE_URL")
+OWNER_URL = ENV.get("TEST_POSTGRES_MIGRATION_DATABASE_URL")
+
+pytestmark = pytest.mark.skipif(
+    not (ENABLED and RUNTIME_URL and OWNER_URL),
+    reason="P1C PostgreSQL tests require the isolated integration contract.",
+)
+
+
+def _engine(url: str):
+    return create_engine(
+        normalize_database_url(url),
+        pool_pre_ping=True,
+        hide_parameters=True,
+    )
+
+
+@pytest.fixture()
+def pg_p1c():
+    owner_engine = _engine(OWNER_URL)
+    runtime_engine = _engine(RUNTIME_URL)
+    RuntimeSession = sessionmaker(bind=runtime_engine, autoflush=False, expire_on_commit=False)
+    suffix = uuid4().hex[:10]
+    org_ids: list[int] = []
+
+    with owner_engine.begin() as connection:
+        revision = connection.execute(text("SELECT version_num FROM alembic_version")).scalar_one()
+        if revision != EXPECTED_REVISION:
+            raise RuntimeError(f"P1C requires {EXPECTED_REVISION}; found {revision!r}.")
+
+        for label in ("A", "B"):
+            org_id = int(
+                connection.execute(
+                    text(
+                        """
+                        INSERT INTO public.organizations
+                            (name, slug, tax_id, tier, description, is_active)
+                        VALUES
+                            (:name, :slug, :tax_id, 'pro', 'P1C integration', true)
+                        RETURNING id
+                        """
+                    ),
+                    {
+                        "name": f"P1C Org {label} {suffix}",
+                        "slug": f"p1c-{label.lower()}-{suffix}",
+                        "tax_id": f"P1C-{label}-{suffix}",
+                    },
+                ).scalar_one()
+            )
+            org_ids.append(org_id)
+
+            lote_a = int(
+                connection.execute(
+                    text(
+                        """
+                        INSERT INTO public.lotes (
+                            organization_id, identificador, productor_id,
+                            producto_forestal, hectareas, latitud, longitud,
+                            polygon_wkt, estatus, volumen_ingresado_ton,
+                            volumen_exportar_ton
+                        ) VALUES (
+                            :organization_id, :identificador, :productor_id,
+                            'Pino resinoso', 50.0, -28.05, -56.03,
+                            'POLYGON((-56.04 -28.06,-56.02 -28.06,-56.02 -28.04,-56.04 -28.04,-56.04 -28.06))',
+                            'Verde', 0.0, 0.0
+                        ) RETURNING id
+                        """
+                    ),
+                    {
+                        "organization_id": org_id,
+                        "identificador": f"RODAL-{label}-1-{suffix}",
+                        "productor_id": f"PROVEEDOR-{label}-1-{suffix}",
+                    },
+                ).scalar_one()
+            )
+            lote_b = int(
+                connection.execute(
+                    text(
+                        """
+                        INSERT INTO public.lotes (
+                            organization_id, identificador, productor_id,
+                            producto_forestal, hectareas, latitud, longitud,
+                            polygon_wkt, estatus, volumen_ingresado_ton,
+                            volumen_exportar_ton
+                        ) VALUES (
+                            :organization_id, :identificador, :productor_id,
+                            'Pino resinoso', 60.0, -28.06, -56.04,
+                            'POLYGON((-56.05 -28.07,-56.03 -28.07,-56.03 -28.05,-56.05 -28.05,-56.05 -28.07))',
+                            'Verde', 0.0, 0.0
+                        ) RETURNING id
+                        """
+                    ),
+                    {
+                        "organization_id": org_id,
+                        "identificador": f"RODAL-{label}-2-{suffix}",
+                        "productor_id": f"PROVEEDOR-{label}-2-{suffix}",
+                    },
+                ).scalar_one()
+            )
+
+            batch_ids: dict[str, int] = {}
+            for code, product, stage, source_lote_id in (
+                (f"RAW-{label}-1-{suffix}", "Rollizo de pino", "RAW_MATERIAL", lote_a),
+                (f"RAW-{label}-2-{suffix}", "Rollizo de pino", "RAW_MATERIAL", lote_b),
+                (f"FIN-{label}-{suffix}", "Madera aserrada", "FINISHED_GOOD", None),
+            ):
+                batch_ids[code] = int(
+                    connection.execute(
+                        text(
+                            """
+                            INSERT INTO public.traceability_batches (
+                                organization_id, code, product_name, stage,
+                                unit, status, source_lote_id
+                            ) VALUES (
+                                :organization_id, :code, :product_name, :stage,
+                                'M3', 'ACTIVE', :source_lote_id
+                            ) RETURNING id
+                            """
+                        ),
+                        {
+                            "organization_id": org_id,
+                            "code": code,
+                            "product_name": product,
+                            "stage": stage,
+                            "source_lote_id": source_lote_id,
+                        },
+                    ).scalar_one()
+                )
+
+            raw_1 = batch_ids[f"RAW-{label}-1-{suffix}"]
+            raw_2 = batch_ids[f"RAW-{label}-2-{suffix}"]
+            finished = batch_ids[f"FIN-{label}-{suffix}"]
+
+            for event_code, event_type, inputs, outputs in (
+                (
+                    f"RECEIPT-{label}-1-{suffix}",
+                    "RECEIPT",
+                    (),
+                    ((raw_1, "100.000000"),),
+                ),
+                (
+                    f"RECEIPT-{label}-2-{suffix}",
+                    "RECEIPT",
+                    (),
+                    ((raw_2, "80.000000"),),
+                ),
+                (
+                    f"SAW-{label}-{suffix}",
+                    "TRANSFORMATION",
+                    ((raw_1, "70.000000"), (raw_2, "30.000000")),
+                    ((finished, "65.000000"),),
+                ),
+            ):
+                event_id = int(
+                    connection.execute(
+                        text(
+                            """
+                            INSERT INTO public.traceability_events (
+                                organization_id, event_code, event_type, status,
+                                occurred_at, facility_reference
+                            ) VALUES (
+                                :organization_id, :event_code, :event_type,
+                                'POSTED', now(), 'Planta Virasoro'
+                            ) RETURNING id
+                            """
+                        ),
+                        {
+                            "organization_id": org_id,
+                            "event_code": event_code,
+                            "event_type": event_type,
+                        },
+                    ).scalar_one()
+                )
+                for batch_id, quantity in inputs:
+                    connection.execute(
+                        text(
+                            """
+                            INSERT INTO public.traceability_event_inputs (
+                                organization_id, event_id, batch_id, quantity, unit
+                            ) VALUES (
+                                :organization_id, :event_id, :batch_id, :quantity, 'M3'
+                            )
+                            """
+                        ),
+                        {
+                            "organization_id": org_id,
+                            "event_id": event_id,
+                            "batch_id": batch_id,
+                            "quantity": quantity,
+                        },
+                    )
+                for batch_id, quantity in outputs:
+                    connection.execute(
+                        text(
+                            """
+                            INSERT INTO public.traceability_event_outputs (
+                                organization_id, event_id, batch_id, quantity, unit
+                            ) VALUES (
+                                :organization_id, :event_id, :batch_id, :quantity, 'M3'
+                            )
+                            """
+                        ),
+                        {
+                            "organization_id": org_id,
+                            "event_id": event_id,
+                            "batch_id": batch_id,
+                            "quantity": quantity,
+                        },
+                    )
+
+            shipment_id = int(
+                connection.execute(
+                    text(
+                        """
+                        INSERT INTO public.shipments (
+                            organization_id, shipment_code, sale_reference,
+                            buyer_reference, destination_country, shipped_at, status
+                        ) VALUES (
+                            :organization_id, :shipment_code, :sale_reference,
+                            :buyer_reference, 'DE', now(), 'DISPATCHED'
+                        ) RETURNING id
+                        """
+                    ),
+                    {
+                        "organization_id": org_id,
+                        "shipment_code": f"EXP-SHARED-{suffix}",
+                        "sale_reference": f"SALE-{label}-{suffix}",
+                        "buyer_reference": f"BUYER-{label}-{suffix}",
+                    },
+                ).scalar_one()
+            )
+            connection.execute(
+                text(
+                    """
+                    INSERT INTO public.shipment_items (
+                        organization_id, shipment_id, batch_id, quantity, unit
+                    ) VALUES (
+                        :organization_id, :shipment_id, :batch_id, 60.000000, 'M3'
+                    )
+                    """
+                ),
+                {
+                    "organization_id": org_id,
+                    "shipment_id": shipment_id,
+                    "batch_id": finished,
+                },
+            )
+
+    try:
+        yield RuntimeSession, org_ids, suffix
+    finally:
+        with owner_engine.begin() as connection:
+            params = {"org_a": org_ids[0], "org_b": org_ids[1]}
+            for table_name in (
+                "shipment_items",
+                "shipments",
+                "traceability_event_inputs",
+                "traceability_event_outputs",
+                "traceability_events",
+                "traceability_batches",
+            ):
+                connection.execute(
+                    text(
+                        f"DELETE FROM public.{table_name} "
+                        "WHERE organization_id IN (:org_a, :org_b)"
+                    ),
+                    params,
+                )
+            connection.execute(
+                text("DELETE FROM public.lotes WHERE organization_id IN (:org_a, :org_b)"),
+                params,
+            )
+            connection.execute(
+                text("DELETE FROM public.organizations WHERE id IN (:org_a, :org_b)"),
+                params,
+            )
+        runtime_engine.dispose()
+        owner_engine.dispose()
+
+
+def test_p1c_reverse_lineage_respects_tenant_and_attributes_source_volume(pg_p1c) -> None:
+    RuntimeSession, org_ids, suffix = pg_p1c
+    org_a, org_b = org_ids
+    shipment_code = f"EXP-SHARED-{suffix}"
+
+    with RuntimeSession() as session_a:
+        payload_a = TraceabilityLineageService(
+            session=session_a,
+            organization_id=org_a,
+        ).trace_shipment(shipment_code)
+
+    with RuntimeSession() as session_b:
+        payload_b = TraceabilityLineageService(
+            session=session_b,
+            organization_id=org_b,
+        ).trace_shipment(shipment_code)
+
+    assert payload_a["complete"] is True
+    assert payload_b["complete"] is True
+    assert payload_a["shipment"]["sale_reference"] == f"SALE-A-{suffix}"
+    assert payload_b["shipment"]["sale_reference"] == f"SALE-B-{suffix}"
+
+    sources_a = {
+        item["lote"]["identificador"]: item
+        for item in payload_a["source_lotes"]
+    }
+    assert sources_a[f"RODAL-A-1-{suffix}"]["attributed_shipment_quantity"] == "42.000000"
+    assert sources_a[f"RODAL-A-2-{suffix}"]["attributed_shipment_quantity"] == "18.000000"
+    assert all(
+        source["lote"]["productor_id"].startswith("PROVEEDOR-A-")
+        for source in payload_a["source_lotes"]
+    )
+    assert all(
+        source["lote"]["productor_id"].startswith("PROVEEDOR-B-")
+        for source in payload_b["source_lotes"]
+    )

--- a/tests/test_traceability_p1c_unittest.py
+++ b/tests/test_traceability_p1c_unittest.py
@@ -1,0 +1,375 @@
+"""P1C unit acceptance for reverse industrial genealogy queries."""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from decimal import Decimal
+
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+from litoral_trace.db.base import Base
+from litoral_trace.db.models import (
+    Lote,
+    Organization,
+    Shipment,
+    ShipmentItem,
+    TraceabilityBatch,
+    TraceabilityEvent,
+    TraceabilityEventInput,
+    TraceabilityEventOutput,
+)
+from litoral_trace.services.traceability_lineage import TraceabilityLineageService
+
+
+NOW = datetime(2026, 8, 20, 18, 0, tzinfo=timezone.utc)
+
+
+def _session_factory():
+    engine = create_engine(
+        "sqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    Base.metadata.create_all(engine)
+    return engine, sessionmaker(bind=engine, expire_on_commit=False)
+
+
+def _source_lote(session, *, organization_id: int, identificador: str, productor_id: str):
+    lote = Lote(
+        organization_id=organization_id,
+        identificador=identificador,
+        productor_id=productor_id,
+        producto_forestal="Pino resinoso",
+        hectareas=50.0,
+        latitud=-28.05,
+        longitud=-56.03,
+        polygon_wkt="POLYGON((-56.04 -28.06,-56.02 -28.06,-56.02 -28.04,-56.04 -28.04,-56.04 -28.06))",
+        estatus="Verde",
+    )
+    session.add(lote)
+    session.flush()
+    return lote
+
+
+def _batch(
+    session,
+    *,
+    organization_id: int,
+    code: str,
+    product_name: str,
+    stage: str,
+    source_lote_id: int | None = None,
+):
+    batch = TraceabilityBatch(
+        organization_id=organization_id,
+        code=code,
+        product_name=product_name,
+        stage=stage,
+        unit="M3",
+        status="ACTIVE",
+        source_lote_id=source_lote_id,
+    )
+    session.add(batch)
+    session.flush()
+    return batch
+
+
+def _posted_event(
+    session,
+    *,
+    organization_id: int,
+    code: str,
+    event_type: str,
+    inputs: tuple[tuple[TraceabilityBatch, Decimal], ...] = (),
+    outputs: tuple[tuple[TraceabilityBatch, Decimal], ...] = (),
+):
+    event = TraceabilityEvent(
+        organization_id=organization_id,
+        event_code=code,
+        event_type=event_type,
+        status="POSTED",
+        occurred_at=NOW,
+        facility_reference="Planta Virasoro",
+    )
+    session.add(event)
+    session.flush()
+    for batch, quantity in inputs:
+        session.add(
+            TraceabilityEventInput(
+                organization_id=organization_id,
+                event_id=event.id,
+                batch_id=batch.id,
+                quantity=quantity,
+                unit="M3",
+            )
+        )
+    for batch, quantity in outputs:
+        session.add(
+            TraceabilityEventOutput(
+                organization_id=organization_id,
+                event_id=event.id,
+                batch_id=batch.id,
+                quantity=quantity,
+                unit="M3",
+            )
+        )
+    session.flush()
+    return event
+
+
+def _shipment(
+    session,
+    *,
+    organization_id: int,
+    code: str,
+    batch: TraceabilityBatch,
+    quantity: Decimal,
+    status: str = "DISPATCHED",
+):
+    shipment = Shipment(
+        organization_id=organization_id,
+        shipment_code=code,
+        sale_reference="FACTURA-E-001",
+        buyer_reference="BUYER-EU-001",
+        destination_country="DE",
+        status=status,
+        shipped_at=NOW,
+    )
+    session.add(shipment)
+    session.flush()
+    session.add(
+        ShipmentItem(
+            organization_id=organization_id,
+            shipment_id=shipment.id,
+            batch_id=batch.id,
+            quantity=quantity,
+            unit="M3",
+        )
+    )
+    session.flush()
+    return shipment
+
+
+def test_p1c_corrientes_reverse_lineage_attributes_70_30_mix_to_shipment() -> None:
+    engine, SessionLocal = _session_factory()
+    try:
+        with SessionLocal() as session:
+            org = Organization(name="Aserradero Virasoro", slug="p1c-virasoro")
+            session.add(org)
+            session.flush()
+
+            lote_a = _source_lote(
+                session,
+                organization_id=org.id,
+                identificador="RODAL-A",
+                productor_id="CUIT-PROVEEDOR-A",
+            )
+            lote_b = _source_lote(
+                session,
+                organization_id=org.id,
+                identificador="RODAL-B",
+                productor_id="CUIT-PROVEEDOR-B",
+            )
+            raw_a = _batch(
+                session,
+                organization_id=org.id,
+                code="REC-A-001",
+                product_name="Rollizo de pino",
+                stage="RAW_MATERIAL",
+                source_lote_id=lote_a.id,
+            )
+            raw_b = _batch(
+                session,
+                organization_id=org.id,
+                code="REC-B-001",
+                product_name="Rollizo de pino",
+                stage="RAW_MATERIAL",
+                source_lote_id=lote_b.id,
+            )
+            finished = _batch(
+                session,
+                organization_id=org.id,
+                code="ASERRADO-001",
+                product_name="Madera aserrada de pino",
+                stage="FINISHED_GOOD",
+            )
+
+            _posted_event(
+                session,
+                organization_id=org.id,
+                code="INGRESO-A-001",
+                event_type="RECEIPT",
+                outputs=((raw_a, Decimal("100.000000")),),
+            )
+            _posted_event(
+                session,
+                organization_id=org.id,
+                code="INGRESO-B-001",
+                event_type="RECEIPT",
+                outputs=((raw_b, Decimal("80.000000")),),
+            )
+            _posted_event(
+                session,
+                organization_id=org.id,
+                code="ASERRADO-TURNO-001",
+                event_type="TRANSFORMATION",
+                inputs=(
+                    (raw_a, Decimal("70.000000")),
+                    (raw_b, Decimal("30.000000")),
+                ),
+                outputs=((finished, Decimal("65.000000")),),
+            )
+            _shipment(
+                session,
+                organization_id=org.id,
+                code="EXP-UE-2026-001",
+                batch=finished,
+                quantity=Decimal("60.000000"),
+            )
+            session.commit()
+
+            payload = TraceabilityLineageService(
+                session=session,
+                organization_id=org.id,
+            ).trace_shipment("exp-ue-2026-001")
+
+            assert payload["complete"] is True
+            assert payload["shipment"]["lineage_state"] == "FINAL"
+            assert payload["allocation_method"] == "PROPORTIONAL_INPUT_ALLOCATION"
+            assert payload["unit_totals"] == [
+                {
+                    "unit": "M3",
+                    "shipped_quantity": "60.000000",
+                    "attributed_quantity": "60.000000",
+                    "unresolved_quantity": "0.000000",
+                }
+            ]
+
+            sources = {
+                item["lote"]["identificador"]: item
+                for item in payload["source_lotes"]
+            }
+            assert sources["RODAL-A"]["attributed_shipment_quantity"] == "42.000000"
+            assert sources["RODAL-A"]["share_of_shipped_unit"] == "0.700000"
+            assert sources["RODAL-B"]["attributed_shipment_quantity"] == "18.000000"
+            assert sources["RODAL-B"]["share_of_shipped_unit"] == "0.300000"
+            assert sources["RODAL-A"]["lote"]["productor_id"] == "CUIT-PROVEEDOR-A"
+
+            events = {event["event_code"]: event for event in payload["events"]}
+            assert set(events) == {
+                "INGRESO-A-001",
+                "INGRESO-B-001",
+                "ASERRADO-TURNO-001",
+            }
+            assert events["ASERRADO-TURNO-001"]["reconciliation"] == {
+                "unit": "M3",
+                "input_quantity": "100.000000",
+                "output_quantity": "65.000000",
+                "loss_quantity": "35.000000",
+                "yield_ratio": "0.650000",
+            }
+    finally:
+        Base.metadata.drop_all(engine)
+        engine.dispose()
+
+
+def test_p1c_missing_provenance_is_explicit_and_unresolved() -> None:
+    engine, SessionLocal = _session_factory()
+    try:
+        with SessionLocal() as session:
+            org = Organization(name="Aserradero Incompleto", slug="p1c-incomplete")
+            session.add(org)
+            session.flush()
+            orphan = _batch(
+                session,
+                organization_id=org.id,
+                code="SIN-ORIGEN-001",
+                product_name="Madera sin genealogía",
+                stage="FINISHED_GOOD",
+            )
+            _shipment(
+                session,
+                organization_id=org.id,
+                code="EXP-INCOMPLETO-001",
+                batch=orphan,
+                quantity=Decimal("25.000000"),
+                status="CONFIRMED",
+            )
+            session.commit()
+
+            payload = TraceabilityLineageService(
+                session=session,
+                organization_id=org.id,
+            ).trace_shipment("EXP-INCOMPLETO-001")
+
+            assert payload["complete"] is False
+            assert payload["shipment"]["lineage_state"] == "PREVIEW"
+            assert payload["unit_totals"][0]["unresolved_quantity"] == "25.000000"
+            assert "MISSING_PROVENANCE" in {
+                issue["code"] for issue in payload["issues"]
+            }
+    finally:
+        Base.metadata.drop_all(engine)
+        engine.dispose()
+
+
+def test_p1c_detects_corrupt_genealogy_cycle() -> None:
+    engine, SessionLocal = _session_factory()
+    try:
+        with SessionLocal() as session:
+            org = Organization(name="Aserradero Ciclo", slug="p1c-cycle")
+            session.add(org)
+            session.flush()
+            batch_a = _batch(
+                session,
+                organization_id=org.id,
+                code="CYCLE-A",
+                product_name="Intermedio A",
+                stage="INTERMEDIATE",
+            )
+            batch_b = _batch(
+                session,
+                organization_id=org.id,
+                code="CYCLE-B",
+                product_name="Intermedio B",
+                stage="INTERMEDIATE",
+            )
+            _posted_event(
+                session,
+                organization_id=org.id,
+                code="CYCLE-EVENT-A",
+                event_type="TRANSFORMATION",
+                inputs=((batch_b, Decimal("10.000000")),),
+                outputs=((batch_a, Decimal("10.000000")),),
+            )
+            _posted_event(
+                session,
+                organization_id=org.id,
+                code="CYCLE-EVENT-B",
+                event_type="TRANSFORMATION",
+                inputs=((batch_a, Decimal("10.000000")),),
+                outputs=((batch_b, Decimal("10.000000")),),
+            )
+            _shipment(
+                session,
+                organization_id=org.id,
+                code="EXP-CYCLE-001",
+                batch=batch_a,
+                quantity=Decimal("5.000000"),
+            )
+            session.commit()
+
+            payload = TraceabilityLineageService(
+                session=session,
+                organization_id=org.id,
+            ).trace_shipment("EXP-CYCLE-001")
+
+            assert payload["complete"] is False
+            assert "LINEAGE_CYCLE_DETECTED" in {
+                issue["code"] for issue in payload["issues"]
+            }
+            assert payload["unit_totals"][0]["unresolved_quantity"] == "5.000000"
+    finally:
+        Base.metadata.drop_all(engine)
+        engine.dispose()

--- a/tests/test_traceability_p1d_ui_unittest.py
+++ b/tests/test_traceability_p1d_ui_unittest.py
@@ -1,0 +1,241 @@
+"""P1D UI acceptance contracts for the traceability workspace."""
+from __future__ import annotations
+
+from pathlib import Path
+
+from fastapi import FastAPI
+
+from litoral_trace.api.traceability import router as traceability_domain_router
+from litoral_trace.web.traceability import (
+    build_traceability_view,
+    router as traceability_web_router,
+)
+
+
+API_PATH = "/api/v1/traceability/shipments/{shipment_code}/origin"
+
+
+def _complete_payload() -> dict:
+    return {
+        "organization_id": 17,
+        "shipment": {
+            "id": 1,
+            "public_id": "00000000-0000-0000-0000-000000000001",
+            "shipment_code": "EXP-UE-2026-001",
+            "sale_reference": "FACTURA-E-001",
+            "buyer_reference": "BUYER-EU-001",
+            "destination_country": "DE",
+            "shipped_at": "2026-08-20T18:00:00+00:00",
+            "status": "DISPATCHED",
+            "lineage_state": "FINAL",
+        },
+        "allocation_method": "PROPORTIONAL_INPUT_ALLOCATION",
+        "complete": True,
+        "issues": [],
+        "unit_totals": [
+            {
+                "unit": "M3",
+                "shipped_quantity": "60.000000",
+                "attributed_quantity": "60.000000",
+                "unresolved_quantity": "0.000000",
+            }
+        ],
+        "items": [
+            {
+                "shipment_item_id": 1,
+                "batch": {
+                    "id": 3,
+                    "public_id": "00000000-0000-0000-0000-000000000003",
+                    "code": "ASERRADO-001",
+                    "product_name": "Madera aserrada de pino",
+                    "stage": "FINISHED_GOOD",
+                    "unit": "M3",
+                    "status": "ACTIVE",
+                    "source_lote_id": None,
+                },
+                "shipped_quantity": "60.000000",
+                "unit": "M3",
+                "attributed_quantity": "60.000000",
+                "unresolved_quantity": "0.000000",
+                "complete": True,
+                "issues": [],
+                "source_contributions": [
+                    {
+                        "lote": {
+                            "identificador": "RODAL-A",
+                            "productor_id": "CUIT-PROVEEDOR-A",
+                        },
+                        "attributed_shipment_quantity": "42.000000",
+                        "unit": "M3",
+                        "share_of_shipment_item": "0.700000",
+                    },
+                    {
+                        "lote": {
+                            "identificador": "RODAL-B",
+                            "productor_id": "CUIT-PROVEEDOR-B",
+                        },
+                        "attributed_shipment_quantity": "18.000000",
+                        "unit": "M3",
+                        "share_of_shipment_item": "0.300000",
+                    },
+                ],
+            }
+        ],
+        "events": [
+            {
+                "id": 3,
+                "public_id": "00000000-0000-0000-0000-000000000013",
+                "event_code": "ASERRADO-TURNO-001",
+                "event_type": "TRANSFORMATION",
+                "status": "POSTED",
+                "occurred_at": "2026-08-20T18:00:00+00:00",
+                "facility_reference": "Planta Virasoro",
+                "inputs": [
+                    {
+                        "batch_id": 1,
+                        "batch_code": "REC-A-001",
+                        "quantity": "70.000000",
+                        "unit": "M3",
+                    },
+                    {
+                        "batch_id": 2,
+                        "batch_code": "REC-B-001",
+                        "quantity": "30.000000",
+                        "unit": "M3",
+                    },
+                ],
+                "outputs": [
+                    {
+                        "batch_id": 3,
+                        "batch_code": "ASERRADO-001",
+                        "quantity": "65.000000",
+                        "unit": "M3",
+                    }
+                ],
+                "reconciliation": {
+                    "unit": "M3",
+                    "input_quantity": "100.000000",
+                    "output_quantity": "65.000000",
+                    "loss_quantity": "35.000000",
+                    "yield_ratio": "0.650000",
+                },
+            }
+        ],
+        "source_lotes": [
+            {
+                "lote": {
+                    "id": 1,
+                    "identificador": "RODAL-A",
+                    "productor_id": "CUIT-PROVEEDOR-A",
+                    "producto_forestal": "Pino resinoso",
+                    "hectareas": 50.0,
+                    "latitud": -28.05,
+                    "longitud": -56.03,
+                    "polygon_wkt": "POLYGON((-56 -28,-55 -28,-55 -27,-56 -28))",
+                    "estatus": "Verde",
+                },
+                "attributed_shipment_quantity": "42.000000",
+                "unit": "M3",
+                "share_of_shipped_unit": "0.700000",
+            },
+            {
+                "lote": {
+                    "id": 2,
+                    "identificador": "RODAL-B",
+                    "productor_id": "CUIT-PROVEEDOR-B",
+                    "producto_forestal": "Pino resinoso",
+                    "hectareas": 30.0,
+                    "latitud": -28.15,
+                    "longitud": -56.13,
+                    "polygon_wkt": None,
+                    "estatus": "Verde",
+                },
+                "attributed_shipment_quantity": "18.000000",
+                "unit": "M3",
+                "share_of_shipped_unit": "0.300000",
+            },
+        ],
+    }
+
+
+def test_p1d_presenter_formats_corrientes_70_30_genealogy() -> None:
+    view = build_traceability_view(
+        query="EXP-UE-2026-001",
+        payload=_complete_payload(),
+    )
+
+    result = view["result"]
+    assert result is not None
+    assert result["complete"] is True
+    assert result["state_label"] == "Genealogía cerrada"
+    assert result["primary_total"] == {
+        "shipped": "60 m³",
+        "attributed": "60 m³",
+        "unresolved": "0 m³",
+    }
+    assert result["sources"][0]["identifier"] == "RODAL-A"
+    assert result["sources"][0]["quantity"] == "42 m³"
+    assert result["sources"][0]["share"] == "70%"
+    assert result["sources"][1]["quantity"] == "18 m³"
+    assert result["sources"][1]["share"] == "30%"
+    assert result["events"][0]["type_label"] == "Transformación"
+    assert result["events"][0]["yield"] == "65%"
+    assert result["events"][0]["loss_quantity"] == "35 m³"
+
+
+def test_p1d_incomplete_lineage_is_never_presented_as_closed() -> None:
+    payload = _complete_payload()
+    payload["complete"] = False
+    payload["issues"] = [
+        {
+            "code": "MISSING_PROVENANCE",
+            "message": "Falta un origen documentado.",
+        }
+    ]
+    payload["unit_totals"][0]["attributed_quantity"] = "35.000000"
+    payload["unit_totals"][0]["unresolved_quantity"] = "25.000000"
+
+    view = build_traceability_view(
+        query="EXP-INCOMPLETO-001",
+        payload=payload,
+    )
+    result = view["result"]
+
+    assert result is not None
+    assert result["complete"] is False
+    assert result["state_label"] == "Cadena incompleta"
+    assert result["primary_total"]["unresolved"] == "25 m³"
+    assert result["issues"] == [
+        {
+            "code": "MISSING_PROVENANCE",
+            "message": "Falta un origen documentado.",
+        }
+    ]
+
+
+def test_p1d_web_router_and_p1c_api_are_both_registered() -> None:
+    ui_app = FastAPI()
+    ui_app.include_router(traceability_web_router)
+    assert str(ui_app.url_path_for("render_traceability_view")) == "/traceability"
+
+    domain_app = FastAPI()
+    domain_app.include_router(traceability_domain_router)
+    openapi = domain_app.openapi()
+    assert API_PATH in openapi["paths"]
+    assert "get" in openapi["paths"][API_PATH]
+    assert "/traceability" not in openapi["paths"]
+
+
+def test_p1d_template_is_read_only_and_fail_closed_in_copy() -> None:
+    root = Path(__file__).resolve().parents[1]
+    template = (
+        root / "src/litoral_trace/templates/traceability.html"
+    ).read_text(encoding="utf-8")
+
+    assert 'method="get"' in template
+    assert 'action="/traceability"' in template
+    assert "Genealogía cerrada" not in template
+    assert "Cadena incompleta" not in template
+    assert "convención contable de trazabilidad" in template
+    assert "no modifica inventario ni eventos" in template
+    assert "fetch(" not in template


### PR DESCRIPTION
## Goal
Implement the industrial genealogy and chain-of-custody core required for end-to-end traceability before merging into `p2-enterprise-production`.

## Completed: P1A — genealogy graph
- tenant-safe material batch nodes
- many-to-many transformation/mix/split event graph
- shipment/sale allocation model
- numeric quantity accounting (`Numeric(18,6)`)
- composite tenant foreign keys
- RLS + runtime privilege boundaries
- Alembic head `019_add_traceability_genealogy`
- SQLite/unit + PostgreSQL acceptance contracts

## Completed: P1B — industrial ledger
Designed first for Corrientes forestry/sawmill workflows, using M3 as the initial homogeneous accounting basis for roundwood -> sawn/intermediate -> finished product.

- derived inventory ledger: POSTED outputs - POSTED inputs - DISPATCHED shipment items
- transactional batch row locking to prevent double-spend
- source-plot requirement before receipt stock becomes available
- one posted producer per industrial batch
- fail-closed overconsumption checks
- fail-closed undocumented cross-unit conversion (`M3 -> TON`, etc.)
- explicit transformation loss/yield summaries
- negative stock adjustments only; no unexplained stock creation
- chronological production/consumption/dispatch checks
- auditable event posting and shipment dispatch
- Corrientes two-origin -> sawing -> EU shipment scenario
- PostgreSQL concurrency gate: two competing consumers cannot both spend the same stock

## Completed: P1C — reverse genealogy/query API
- `GET /api/v1/traceability/shipments/{shipment_code}/origin`
- shipment -> commercial batch -> POSTED industrial events -> source batches -> source `Lote` parcels
- producer, geospatial source data, industrial events and volumetric reconciliation in one tenant-safe response
- explicit `PROPORTIONAL_INPUT_ALLOCATION` convention for homogeneous mixed inputs
- attributed shipment quantity and share per source parcel
- fail-closed `complete=false` plus structured issues for missing provenance, unit incompatibility, broken references or cycles
- cycle/depth protection
- tenant isolation enforced by both service filters and PostgreSQL RLS
- Corrientes acceptance scenario: 70/30 source mix and 60 M3 shipment resolves to 42/18 M3
- cold-start API exposure validated through effective FastAPI OpenAPI contract

## Completed: P1D — traceability/genealogy UI
- server-rendered read-only `/traceability` workspace using existing FastAPI/Jinja architecture
- RBAC navigation entry for users with `LOTE_READ`, including read-only client roles
- shipment/sale search without duplicating P1C genealogy logic
- closed vs incomplete genealogy state shown explicitly
- shipped / attributed / unresolved volume summary
- consolidated source parcel and supplier table with coordinates/polygon availability
- industrial path view with inputs, transformation/mix events, outputs, yield and loss reconciliation
- commercial output batch composition and source contribution display
- structured lineage issues surfaced when provenance cannot be closed
- copy explicitly distinguishes proportional accounting attribution from physical fiber identification
- no ledger mutation, no independent client-side lineage engine and no new React layer
- frontend bundle remains reproducible with tracked assets unchanged

## Acceptance — current head
Candidate head: `c8a64c4015802a6571daef8ec8808d1de50e2c52`

- CI: green
  - Python syntax gate: green
  - Alembic canonical head gate: green
  - full pytest suite: green
  - frontend build + dependency audit + reproducible tracked assets: green
  - production Docker / Compose / Nginx / Prometheus / Alertmanager validation: green
- Release Integration Gates: green
  - Gate 13 — P1A PostgreSQL genealogy: green
  - Gate 14 — P1B ledger concurrency: green
  - Gate 15 — P1C reverse lineage: green
  - Gate 16 — P1D traceability UI: green
- V1 Final Release Acceptance: green
- V1 Satellite Browser Staging E2E: green

## Merge status
P1A–P1D are implemented and acceptance-green. This PR intentionally remains **draft** and production remains untouched until an explicit review/merge decision is made.