### PR TITLE
P1E Origin Dossier

### DIFF
--- a/.github/workflows/p1e-origin-dossier-gate.yml
+++ b/.github/workflows/p1e-origin-dossier-gate.yml
@@ -46,7 +46,8 @@ jobs:
           python -m pytest -q \
             --junitxml=gate17-origin-dossier.xml \
             tests/test_traceability_p1e_dossier_unittest.py \
-            tests/test_traceability_p1e_api_unittest.py
+            tests/test_traceability_p1e_api_unittest.py \
+            tests/test_traceability_p1e_ui_unittest.py
           python - <<'PY'
           import xml.etree.ElementTree as ET
 

--- a/.github/workflows/p1e-origin-dossier-gate.yml
+++ b/.github/workflows/p1e-origin-dossier-gate.yml
@@ -1,0 +1,62 @@
+name: P1E Origin Dossier Gate
+
+on:
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: p1e-origin-dossier-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  gate17-origin-dossier:
+    name: gate17-origin-dossier
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    env:
+      ENVIRONMENT: test
+      ENABLE_POSTGRES_TESTS: "0"
+      TEST_DATABASE_URL: sqlite:///litoral_trace_test.db
+      JWT_SECRET_KEY: ci-only-p1e-jwt-secret-key-2026
+      LITORAL_TRACE_BOOTSTRAP_SUPERADMIN_PASSWORD: CiP1EBootstrapPassword2026
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: "pip"
+          cache-dependency-path: requirements.txt
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -r requirements.txt pytest alembic
+
+      - name: Gate 17 - P1E deterministic origin dossier acceptance
+        shell: bash
+        run: |
+          set -euo pipefail
+          python -m pytest -q \
+            --junitxml=gate17-origin-dossier.xml \
+            tests/test_traceability_p1e_dossier_unittest.py \
+            tests/test_traceability_p1e_api_unittest.py
+          python - <<'PY'
+          import xml.etree.ElementTree as ET
+
+          root = ET.parse("gate17-origin-dossier.xml").getroot()
+          skipped = int(root.attrib.get("skipped", "0"))
+          failures = int(root.attrib.get("failures", "0"))
+          errors = int(root.attrib.get("errors", "0"))
+          if skipped or failures or errors:
+              raise SystemExit(
+                  "Gate 17 is fail-closed: "
+                  f"skipped={skipped}, failures={failures}, errors={errors}"
+              )
+          PY

--- a/src/litoral_trace/api/traceability.py
+++ b/src/litoral_trace/api/traceability.py
@@ -7,6 +7,7 @@ from fastapi import APIRouter, Depends, HTTPException, status
 from fastapi.responses import JSONResponse
 
 from litoral_trace.api.auth import UserTenantContext
+from litoral_trace.api.traceability_dossier import router as dossier_router
 from litoral_trace.auth.rbac import Permission, require_permission
 from litoral_trace.db.tenant import get_tenant_scoped_db_session
 from litoral_trace.services.traceability_lineage import (
@@ -81,10 +82,11 @@ async def obtener_origen_despacho_endpoint(
         session.close()
 
 
-# ``main.py`` includes one traceability-domain router. Keeping both the API
-# contract and the P1D browser workspace beneath this composition avoids a
-# second registration path while leaving the P1C service as the single source
-# of lineage truth.
+# ``main.py`` includes one traceability-domain router. Keeping the origin API,
+# P1E dossier downloads, and the P1D browser workspace beneath this composition
+# avoids duplicate registration paths while leaving P1C as the single source of
+# lineage truth.
 router = APIRouter()
 router.include_router(api_router)
+router.include_router(dossier_router)
 router.include_router(traceability_web_router)

--- a/src/litoral_trace/api/traceability_dossier.py
+++ b/src/litoral_trace/api/traceability_dossier.py
@@ -1,0 +1,169 @@
+"""Authenticated P1E origin-dossier download endpoints."""
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, HTTPException, Response, status
+
+from litoral_trace.api.auth import UserTenantContext
+from litoral_trace.auth.rbac import Permission, require_permission
+from litoral_trace.db.tenant import get_tenant_scoped_db_session
+from litoral_trace.services.traceability_dossier import (
+    OriginDossierGenerationError,
+    OriginDossierValidationError,
+    build_origin_dossier_bundle,
+    safe_artifact_stem,
+)
+from litoral_trace.services.traceability_lineage import (
+    TraceabilityLineageNotFoundError,
+    TraceabilityLineageService,
+    TraceabilityLineageValidationError,
+)
+
+
+router = APIRouter(
+    prefix="/api/v1/traceability",
+    tags=["Trazabilidad Industrial"],
+)
+
+
+def _detail(*, code: str, message: str) -> dict[str, str]:
+    return {"code": code, "message": message}
+
+
+def _load_bundle(*, shipment_code: str, user: UserTenantContext):
+    session = get_tenant_scoped_db_session(user.organization_id)
+    if session is None:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail=_detail(
+                code="TRACEABILITY_SERVICE_UNAVAILABLE",
+                message="El servicio de trazabilidad no está disponible temporalmente.",
+            ),
+        )
+
+    try:
+        payload = TraceabilityLineageService(
+            session=session,
+            organization_id=user.organization_id,
+        ).trace_shipment(shipment_code)
+        return build_origin_dossier_bundle(payload)
+    except TraceabilityLineageValidationError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
+            detail=_detail(code=exc.code, message=str(exc)),
+        ) from None
+    except TraceabilityLineageNotFoundError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=_detail(code=exc.code, message=str(exc)),
+        ) from None
+    except OriginDossierValidationError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
+            detail=_detail(code=exc.code, message=str(exc)),
+        ) from None
+    except OriginDossierGenerationError:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail=_detail(
+                code="ORIGIN_DOSSIER_GENERATION_FAILED",
+                message="No fue posible generar el dossier de origen en este momento.",
+            ),
+        ) from None
+    finally:
+        session.close()
+
+
+def _headers(*, bundle, filename: str) -> dict[str, str]:
+    return {
+        "Content-Disposition": f'attachment; filename="{filename}"',
+        "Cache-Control": "private, no-store",
+        "X-Litoral-Trace-Manifest-SHA256": bundle.manifest_sha256,
+    }
+
+
+@router.get(
+    "/shipments/{shipment_code}/dossier/manifest",
+    response_class=Response,
+)
+async def descargar_manifest_dossier_endpoint(
+    shipment_code: str,
+    user: UserTenantContext = Depends(
+        require_permission(Permission.LOTE_READ)
+    ),
+) -> Response:
+    bundle = _load_bundle(shipment_code=shipment_code, user=user)
+    stem = safe_artifact_stem(bundle.shipment_code)
+    return Response(
+        content=bundle.manifest_json_bytes,
+        media_type="application/json",
+        headers=_headers(
+            bundle=bundle,
+            filename=f"litoral-trace-{stem}-manifest.json",
+        ),
+    )
+
+
+@router.get(
+    "/shipments/{shipment_code}/dossier/geojson",
+    response_class=Response,
+)
+async def descargar_geojson_dossier_endpoint(
+    shipment_code: str,
+    user: UserTenantContext = Depends(
+        require_permission(Permission.LOTE_READ)
+    ),
+) -> Response:
+    bundle = _load_bundle(shipment_code=shipment_code, user=user)
+    stem = safe_artifact_stem(bundle.shipment_code)
+    return Response(
+        content=bundle.geojson_bytes,
+        media_type="application/geo+json",
+        headers=_headers(
+            bundle=bundle,
+            filename=f"litoral-trace-{stem}-origins.geojson",
+        ),
+    )
+
+
+@router.get(
+    "/shipments/{shipment_code}/dossier/pdf",
+    response_class=Response,
+)
+async def descargar_pdf_dossier_endpoint(
+    shipment_code: str,
+    user: UserTenantContext = Depends(
+        require_permission(Permission.LOTE_READ)
+    ),
+) -> Response:
+    bundle = _load_bundle(shipment_code=shipment_code, user=user)
+    stem = safe_artifact_stem(bundle.shipment_code)
+    return Response(
+        content=bundle.pdf_bytes,
+        media_type="application/pdf",
+        headers=_headers(
+            bundle=bundle,
+            filename=f"litoral-trace-{stem}-dossier.pdf",
+        ),
+    )
+
+
+@router.get(
+    "/shipments/{shipment_code}/dossier/bundle",
+    response_class=Response,
+)
+async def descargar_bundle_dossier_endpoint(
+    shipment_code: str,
+    user: UserTenantContext = Depends(
+        require_permission(Permission.LOTE_READ)
+    ),
+) -> Response:
+    bundle = _load_bundle(shipment_code=shipment_code, user=user)
+    stem = safe_artifact_stem(bundle.shipment_code)
+    return Response(
+        content=bundle.zip_bytes,
+        media_type="application/zip",
+        headers=_headers(
+            bundle=bundle,
+            filename=f"litoral-trace-{stem}-dossier.zip",
+        ),
+    )

--- a/src/litoral_trace/api/traceability_dossier.py
+++ b/src/litoral_trace/api/traceability_dossier.py
@@ -1,7 +1,7 @@
 """Authenticated P1E origin-dossier download endpoints."""
 from __future__ import annotations
 
-from fastapi import APIRouter, Depends, HTTPException, Response, status
+from fastapi import APIRouter, Depends, HTTPException, Query, Response, status
 
 from litoral_trace.api.auth import UserTenantContext
 from litoral_trace.auth.rbac import Permission, require_permission
@@ -81,12 +81,20 @@ def _headers(*, bundle, filename: str) -> dict[str, str]:
     }
 
 
+ShipmentCodeQuery = Query(
+    ...,
+    min_length=1,
+    max_length=120,
+    description="Código comercial del despacho dentro de la organización autenticada.",
+)
+
+
 @router.get(
-    "/shipments/{shipment_code}/dossier/manifest",
+    "/shipments/dossier/manifest",
     response_class=Response,
 )
 async def descargar_manifest_dossier_endpoint(
-    shipment_code: str,
+    shipment_code: str = ShipmentCodeQuery,
     user: UserTenantContext = Depends(
         require_permission(Permission.LOTE_READ)
     ),
@@ -104,11 +112,11 @@ async def descargar_manifest_dossier_endpoint(
 
 
 @router.get(
-    "/shipments/{shipment_code}/dossier/geojson",
+    "/shipments/dossier/geojson",
     response_class=Response,
 )
 async def descargar_geojson_dossier_endpoint(
-    shipment_code: str,
+    shipment_code: str = ShipmentCodeQuery,
     user: UserTenantContext = Depends(
         require_permission(Permission.LOTE_READ)
     ),
@@ -126,11 +134,11 @@ async def descargar_geojson_dossier_endpoint(
 
 
 @router.get(
-    "/shipments/{shipment_code}/dossier/pdf",
+    "/shipments/dossier/pdf",
     response_class=Response,
 )
 async def descargar_pdf_dossier_endpoint(
-    shipment_code: str,
+    shipment_code: str = ShipmentCodeQuery,
     user: UserTenantContext = Depends(
         require_permission(Permission.LOTE_READ)
     ),
@@ -148,11 +156,11 @@ async def descargar_pdf_dossier_endpoint(
 
 
 @router.get(
-    "/shipments/{shipment_code}/dossier/bundle",
+    "/shipments/dossier/bundle",
     response_class=Response,
 )
 async def descargar_bundle_dossier_endpoint(
-    shipment_code: str,
+    shipment_code: str = ShipmentCodeQuery,
     user: UserTenantContext = Depends(
         require_permission(Permission.LOTE_READ)
     ),

--- a/src/litoral_trace/services/traceability_dossier.py
+++ b/src/litoral_trace/services/traceability_dossier.py
@@ -1,0 +1,669 @@
+"""Buyer-facing origin dossier artifacts built from one P1C lineage payload.
+
+P1E is intentionally a pure projection over the P1C reverse-lineage result.
+It does not mutate genealogy, inventory, shipments, or source lots.
+
+Integrity is anchored to a canonical JSON manifest. The SHA-256 digest is
+computed from stable traceability content only; generation time and PDF byte
+metadata are deliberately excluded so the same business evidence yields the
+same manifest hash.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+import hashlib
+import io
+import json
+import re
+from typing import Any
+import zipfile
+
+
+SCHEMA_VERSION = "litoral-trace.origin-dossier.v1"
+DOSSIER_TYPE = "ORIGIN_CHAIN_OF_CUSTODY"
+INTEGRITY_ALGORITHM = "SHA-256"
+DISCLAIMER = (
+    "Este dossier documenta origen y cadena de custodia según los registros "
+    "disponibles en Litoral Trace. No constituye por sí solo una declaración "
+    "regulatoria ni reemplaza la debida diligencia exigible al operador."
+)
+
+
+class OriginDossierError(RuntimeError):
+    """Base dossier generation failure."""
+
+
+class OriginDossierValidationError(OriginDossierError):
+    """Invalid or incomplete P1C payload for dossier generation."""
+
+    def __init__(self, code: str, detail: str) -> None:
+        super().__init__(detail)
+        self.code = code
+
+
+class OriginDossierGenerationError(OriginDossierError):
+    """Artifact rendering failed after a valid manifest was built."""
+
+    def __init__(self, code: str, detail: str) -> None:
+        super().__init__(detail)
+        self.code = code
+
+
+@dataclass(frozen=True)
+class OriginDossierBundle:
+    shipment_code: str
+    canonical_manifest: dict[str, Any]
+    manifest_document: dict[str, Any]
+    manifest_sha256: str
+    manifest_json_bytes: bytes
+    geojson: dict[str, Any]
+    geojson_bytes: bytes
+    pdf_bytes: bytes
+    zip_bytes: bytes
+
+
+def _text(value: Any) -> str | None:
+    if value is None:
+        return None
+    normalized = str(value).strip()
+    return normalized or None
+
+
+def _number(value: Any) -> float | None:
+    if value is None:
+        return None
+    try:
+        number = float(value)
+    except (TypeError, ValueError):
+        return None
+    if number != number or number in {float("inf"), float("-inf")}:
+        return None
+    return number
+
+
+def _canonical_json_bytes(value: Any) -> bytes:
+    try:
+        rendered = json.dumps(
+            value,
+            ensure_ascii=False,
+            sort_keys=True,
+            separators=(",", ":"),
+            allow_nan=False,
+        )
+    except (TypeError, ValueError) as exc:
+        raise OriginDossierValidationError(
+            "DOSSIER_CANONICALIZATION_FAILED",
+            "El contenido de trazabilidad no puede canonicalizarse de forma segura.",
+        ) from exc
+    return rendered.encode("utf-8")
+
+
+def _pretty_json_bytes(value: Any) -> bytes:
+    return (
+        json.dumps(
+            value,
+            ensure_ascii=False,
+            sort_keys=True,
+            indent=2,
+            allow_nan=False,
+        )
+        + "\n"
+    ).encode("utf-8")
+
+
+def _geometry_from_lote(lote: dict[str, Any]) -> tuple[dict[str, Any] | None, str | None]:
+    polygon_wkt = _text(lote.get("polygon_wkt"))
+    if polygon_wkt:
+        try:
+            from shapely.geometry import mapping
+            from shapely import wkt
+
+            geometry = mapping(wkt.loads(polygon_wkt))
+            geometry_type = str(geometry.get("type") or "")
+            if geometry_type in {"Polygon", "MultiPolygon"}:
+                return dict(geometry), None
+            return dict(geometry), "SOURCE_GEOMETRY_NON_POLYGON"
+        except Exception:
+            # A valid point fallback is still useful, but the warning remains
+            # visible in the dossier so polygon evidence is never fabricated.
+            pass
+
+    latitude = _number(lote.get("latitud"))
+    longitude = _number(lote.get("longitud"))
+    if latitude is not None and longitude is not None:
+        warning = "SOURCE_GEOMETRY_POINT_FALLBACK" if polygon_wkt else "SOURCE_POLYGON_MISSING"
+        return {
+            "type": "Point",
+            "coordinates": [longitude, latitude],
+        }, warning
+
+    return None, "SOURCE_GEOMETRY_UNAVAILABLE"
+
+
+def _clean_issue(issue: dict[str, Any]) -> dict[str, str | None]:
+    return {
+        "code": _text(issue.get("code")),
+        "message": _text(issue.get("message")),
+    }
+
+
+def _clean_edge(edge: dict[str, Any]) -> dict[str, str | None]:
+    return {
+        "batch_code": _text(edge.get("batch_code")),
+        "quantity": _text(edge.get("quantity")),
+        "unit": _text(edge.get("unit")),
+    }
+
+
+def _clean_source_contribution(source: dict[str, Any]) -> dict[str, Any]:
+    lote = source.get("lote") or {}
+    return {
+        "origin_identifier": _text(lote.get("identificador")),
+        "producer_reference": _text(lote.get("productor_id")),
+        "attributed_quantity": _text(source.get("attributed_shipment_quantity")),
+        "unit": _text(source.get("unit")),
+        "share": _text(source.get("share_of_shipment_item")),
+    }
+
+
+def build_canonical_manifest(payload: dict[str, Any]) -> dict[str, Any]:
+    """Return stable buyer-facing traceability content with no internal DB ids."""
+
+    if not isinstance(payload, dict):
+        raise OriginDossierValidationError(
+            "DOSSIER_PAYLOAD_INVALID",
+            "Se requiere un resultado de genealogía válido.",
+        )
+
+    shipment = payload.get("shipment") or {}
+    shipment_code = _text(shipment.get("shipment_code"))
+    if not shipment_code:
+        raise OriginDossierValidationError(
+            "DOSSIER_SHIPMENT_CODE_REQUIRED",
+            "El resultado de genealogía no contiene un código de despacho.",
+        )
+
+    artifact_warnings: list[dict[str, str | None]] = []
+    origins: list[dict[str, Any]] = []
+    for source in payload.get("source_lotes") or []:
+        lote = source.get("lote") or {}
+        geometry, geometry_warning = _geometry_from_lote(lote)
+        origin = {
+            "identifier": _text(lote.get("identificador")),
+            "producer_reference": _text(lote.get("productor_id")),
+            "product": _text(lote.get("producto_forestal")),
+            "hectares": _number(lote.get("hectareas")),
+            "source_status": _text(lote.get("estatus")),
+            "attributed_shipment_quantity": _text(
+                source.get("attributed_shipment_quantity")
+            ),
+            "unit": _text(source.get("unit")),
+            "share_of_shipped_unit": _text(source.get("share_of_shipped_unit")),
+            "geometry": geometry,
+        }
+        origins.append(origin)
+        if geometry_warning:
+            artifact_warnings.append(
+                {
+                    "code": geometry_warning,
+                    "message": (
+                        "El origen no aporta un polígono utilizable; el dossier conserva "
+                        "la mejor georreferencia disponible sin inventar geometría."
+                    ),
+                    "origin_identifier": origin["identifier"],
+                }
+            )
+
+    items: list[dict[str, Any]] = []
+    for item in payload.get("items") or []:
+        batch = item.get("batch") or {}
+        contributions = [
+            _clean_source_contribution(source)
+            for source in item.get("source_contributions") or []
+        ]
+        contributions.sort(
+            key=lambda value: (
+                value.get("origin_identifier") or "",
+                value.get("producer_reference") or "",
+                value.get("unit") or "",
+            )
+        )
+        items.append(
+            {
+                "batch_public_id": _text(batch.get("public_id")),
+                "batch_code": _text(batch.get("code")),
+                "product": _text(batch.get("product_name")),
+                "stage": _text(batch.get("stage")),
+                "batch_status": _text(batch.get("status")),
+                "shipped_quantity": _text(item.get("shipped_quantity")),
+                "attributed_quantity": _text(item.get("attributed_quantity")),
+                "unresolved_quantity": _text(item.get("unresolved_quantity")),
+                "unit": _text(item.get("unit")),
+                "complete": bool(item.get("complete")),
+                "issues": sorted(
+                    [_clean_issue(issue) for issue in item.get("issues") or []],
+                    key=lambda value: (
+                        value.get("code") or "",
+                        value.get("message") or "",
+                    ),
+                ),
+                "source_contributions": contributions,
+            }
+        )
+
+    events: list[dict[str, Any]] = []
+    for event in payload.get("events") or []:
+        reconciliation = event.get("reconciliation") or {}
+        inputs = [_clean_edge(edge) for edge in event.get("inputs") or []]
+        outputs = [_clean_edge(edge) for edge in event.get("outputs") or []]
+        inputs.sort(key=lambda value: (value.get("batch_code") or "", value.get("unit") or ""))
+        outputs.sort(key=lambda value: (value.get("batch_code") or "", value.get("unit") or ""))
+        events.append(
+            {
+                "event_public_id": _text(event.get("public_id")),
+                "event_code": _text(event.get("event_code")),
+                "event_type": _text(event.get("event_type")),
+                "status": _text(event.get("status")),
+                "occurred_at": _text(event.get("occurred_at")),
+                "facility_reference": _text(event.get("facility_reference")),
+                "inputs": inputs,
+                "outputs": outputs,
+                "reconciliation": {
+                    "unit": _text(reconciliation.get("unit")),
+                    "input_quantity": _text(reconciliation.get("input_quantity")),
+                    "output_quantity": _text(reconciliation.get("output_quantity")),
+                    "loss_quantity": _text(reconciliation.get("loss_quantity")),
+                    "yield_ratio": _text(reconciliation.get("yield_ratio")),
+                },
+            }
+        )
+
+    unit_totals = [
+        {
+            "unit": _text(total.get("unit")),
+            "shipped_quantity": _text(total.get("shipped_quantity")),
+            "attributed_quantity": _text(total.get("attributed_quantity")),
+            "unresolved_quantity": _text(total.get("unresolved_quantity")),
+        }
+        for total in payload.get("unit_totals") or []
+    ]
+
+    origins.sort(
+        key=lambda value: (
+            value.get("identifier") or "",
+            value.get("producer_reference") or "",
+            value.get("unit") or "",
+        )
+    )
+    items.sort(key=lambda value: (value.get("batch_code") or "", value.get("unit") or ""))
+    events.sort(
+        key=lambda value: (
+            value.get("occurred_at") or "",
+            value.get("event_code") or "",
+            value.get("event_public_id") or "",
+        )
+    )
+    unit_totals.sort(key=lambda value: value.get("unit") or "")
+    artifact_warnings.sort(
+        key=lambda value: (
+            value.get("code") or "",
+            value.get("origin_identifier") or "",
+        )
+    )
+
+    lineage_issues = sorted(
+        [_clean_issue(issue) for issue in payload.get("issues") or []],
+        key=lambda value: (
+            value.get("code") or "",
+            value.get("message") or "",
+        ),
+    )
+
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "dossier_type": DOSSIER_TYPE,
+        "shipment": {
+            "public_id": _text(shipment.get("public_id")),
+            "shipment_code": shipment_code,
+            "sale_reference": _text(shipment.get("sale_reference")),
+            "buyer_reference": _text(shipment.get("buyer_reference")),
+            "destination_country": _text(shipment.get("destination_country")),
+            "shipped_at": _text(shipment.get("shipped_at")),
+            "status": _text(shipment.get("status")),
+            "lineage_state": _text(shipment.get("lineage_state")),
+        },
+        "lineage": {
+            "allocation_method": _text(payload.get("allocation_method")),
+            "complete": bool(payload.get("complete")),
+            "issues": lineage_issues,
+        },
+        "unit_totals": unit_totals,
+        "items": items,
+        "events": events,
+        "origins": origins,
+        "artifact_warnings": artifact_warnings,
+        "disclaimer": DISCLAIMER,
+    }
+
+
+def manifest_sha256(manifest: dict[str, Any]) -> str:
+    return hashlib.sha256(_canonical_json_bytes(manifest)).hexdigest()
+
+
+def build_manifest_document(manifest: dict[str, Any]) -> dict[str, Any]:
+    digest = manifest_sha256(manifest)
+    return {
+        "integrity": {
+            "algorithm": INTEGRITY_ALGORITHM,
+            "canonical_manifest_sha256": digest,
+        },
+        "manifest": manifest,
+    }
+
+
+def build_geojson(manifest: dict[str, Any], digest: str) -> dict[str, Any]:
+    features: list[dict[str, Any]] = []
+    for origin in manifest.get("origins") or []:
+        features.append(
+            {
+                "type": "Feature",
+                "id": origin.get("identifier"),
+                "geometry": origin.get("geometry"),
+                "properties": {
+                    "identifier": origin.get("identifier"),
+                    "producer_reference": origin.get("producer_reference"),
+                    "product": origin.get("product"),
+                    "hectares": origin.get("hectares"),
+                    "source_status": origin.get("source_status"),
+                    "attributed_shipment_quantity": origin.get(
+                        "attributed_shipment_quantity"
+                    ),
+                    "unit": origin.get("unit"),
+                    "share_of_shipped_unit": origin.get("share_of_shipped_unit"),
+                },
+            }
+        )
+    return {
+        "type": "FeatureCollection",
+        "name": f"Litoral Trace origins - {manifest['shipment']['shipment_code']}",
+        "litoral_trace_integrity": {
+            "algorithm": INTEGRITY_ALGORITHM,
+            "canonical_manifest_sha256": digest,
+            "schema_version": SCHEMA_VERSION,
+        },
+        "features": features,
+    }
+
+
+def _pdf_safe(value: Any) -> str:
+    text = "—" if value is None else str(value)
+    return text.encode("latin-1", errors="replace").decode("latin-1")
+
+
+def _unit_label(unit: Any) -> str:
+    return {
+        "M3": "m3",
+        "TON": "t",
+        "KG": "kg",
+    }.get(str(unit or "").upper(), _pdf_safe(unit))
+
+
+def build_pdf(manifest: dict[str, Any], digest: str) -> bytes:
+    try:
+        from fpdf import FPDF
+
+        class OriginDossierPDF(FPDF):
+            def footer(self) -> None:
+                self.set_y(-14)
+                self.set_font("Helvetica", "", 7)
+                self.set_text_color(90, 90, 90)
+                self.cell(
+                    0,
+                    4,
+                    _pdf_safe(
+                        f"Litoral Trace | SHA-256 manifest: {digest[:24]}... | Página {self.page_no()}"
+                    ),
+                    align="C",
+                )
+
+        pdf = OriginDossierPDF()
+        pdf.set_auto_page_break(auto=True, margin=18)
+        if hasattr(pdf, "set_creation_date"):
+            pdf.set_creation_date(datetime(2000, 1, 1, tzinfo=timezone.utc))
+        if hasattr(pdf, "set_title"):
+            pdf.set_title(_pdf_safe(f"Dossier de origen - {manifest['shipment']['shipment_code']}"))
+        if hasattr(pdf, "set_author"):
+            pdf.set_author("Litoral Trace")
+        if hasattr(pdf, "set_producer"):
+            pdf.set_producer("Litoral Trace")
+
+        pdf.add_page()
+        pdf.set_font("Helvetica", "B", 15)
+        pdf.set_text_color(15, 23, 42)
+        pdf.cell(0, 9, "LITORAL TRACE - DOSSIER DE ORIGEN Y TRAZABILIDAD", align="C")
+        pdf.ln(12)
+
+        shipment = manifest["shipment"]
+        lineage = manifest["lineage"]
+        pdf.set_font("Helvetica", "B", 11)
+        pdf.cell(0, 7, _pdf_safe(f"Despacho: {shipment.get('shipment_code')}"))
+        pdf.ln(7)
+        pdf.set_font("Helvetica", "", 9)
+        for label, value in (
+            ("Venta / referencia", shipment.get("sale_reference")),
+            ("Comprador", shipment.get("buyer_reference")),
+            ("País destino", shipment.get("destination_country")),
+            ("Fecha despacho", shipment.get("shipped_at")),
+            ("Estado despacho", shipment.get("status")),
+            ("Estado genealogía", "CERRADA" if lineage.get("complete") else "INCOMPLETA"),
+            ("Método atribución", lineage.get("allocation_method")),
+        ):
+            pdf.set_font("Helvetica", "B", 9)
+            pdf.cell(43, 5, _pdf_safe(f"{label}:"))
+            pdf.set_font("Helvetica", "", 9)
+            pdf.multi_cell(0, 5, _pdf_safe(value))
+
+        pdf.ln(2)
+        pdf.set_font("Helvetica", "B", 10)
+        pdf.cell(0, 7, "1. RECONCILIACIÓN DE VOLUMEN", border=1)
+        pdf.ln(8)
+        for total in manifest.get("unit_totals") or []:
+            pdf.set_font("Helvetica", "", 9)
+            unit = _unit_label(total.get("unit"))
+            pdf.multi_cell(
+                0,
+                5,
+                _pdf_safe(
+                    "Unidad {unit} | Despachado {shipped} | Atribuido {attributed} | "
+                    "Sin resolver {unresolved}".format(
+                        unit=unit,
+                        shipped=total.get("shipped_quantity"),
+                        attributed=total.get("attributed_quantity"),
+                        unresolved=total.get("unresolved_quantity"),
+                    )
+                ),
+            )
+
+        pdf.ln(2)
+        pdf.set_font("Helvetica", "B", 10)
+        pdf.cell(0, 7, "2. ORÍGENES ATRIBUIDOS", border=1)
+        pdf.ln(8)
+        origins = manifest.get("origins") or []
+        if origins:
+            for index, origin in enumerate(origins, start=1):
+                pdf.set_font("Helvetica", "B", 9)
+                pdf.multi_cell(
+                    0,
+                    5,
+                    _pdf_safe(
+                        f"{index}. {origin.get('identifier')} | Proveedor: "
+                        f"{origin.get('producer_reference')}"
+                    ),
+                )
+                pdf.set_font("Helvetica", "", 8)
+                geometry = origin.get("geometry") or {}
+                pdf.multi_cell(
+                    0,
+                    4,
+                    _pdf_safe(
+                        "Producto: {product} | Superficie: {ha} ha | Atribución: {qty} {unit} | "
+                        "Participación: {share} | Geometría: {geometry_type}".format(
+                            product=origin.get("product"),
+                            ha=origin.get("hectares"),
+                            qty=origin.get("attributed_shipment_quantity"),
+                            unit=_unit_label(origin.get("unit")),
+                            share=origin.get("share_of_shipped_unit"),
+                            geometry_type=geometry.get("type") or "no disponible",
+                        )
+                    ),
+                )
+                pdf.ln(1)
+        else:
+            pdf.set_font("Helvetica", "", 9)
+            pdf.multi_cell(0, 5, "No se pudieron atribuir orígenes a este despacho.")
+
+        pdf.ln(2)
+        pdf.set_font("Helvetica", "B", 10)
+        pdf.cell(0, 7, "3. CAMINO INDUSTRIAL", border=1)
+        pdf.ln(8)
+        events = manifest.get("events") or []
+        if events:
+            for event in events:
+                pdf.set_font("Helvetica", "B", 8)
+                pdf.multi_cell(
+                    0,
+                    4,
+                    _pdf_safe(
+                        f"{event.get('event_code')} | {event.get('event_type')} | "
+                        f"{event.get('occurred_at')} | {event.get('facility_reference')}"
+                    ),
+                )
+                reconciliation = event.get("reconciliation") or {}
+                pdf.set_font("Helvetica", "", 8)
+                pdf.multi_cell(
+                    0,
+                    4,
+                    _pdf_safe(
+                        "Input {input_q} {unit} | Output {output_q} {unit} | Merma/diferencia "
+                        "{loss_q} {unit} | Rendimiento {yield_ratio}".format(
+                            input_q=reconciliation.get("input_quantity"),
+                            output_q=reconciliation.get("output_quantity"),
+                            loss_q=reconciliation.get("loss_quantity"),
+                            unit=_unit_label(reconciliation.get("unit")),
+                            yield_ratio=reconciliation.get("yield_ratio"),
+                        )
+                    ),
+                )
+                pdf.ln(1)
+        else:
+            pdf.set_font("Helvetica", "", 9)
+            pdf.multi_cell(0, 5, "No hay eventos industriales recorribles.")
+
+        issues = lineage.get("issues") or []
+        warnings = manifest.get("artifact_warnings") or []
+        if issues or warnings:
+            pdf.ln(2)
+            pdf.set_font("Helvetica", "B", 10)
+            pdf.cell(0, 7, "4. INCIDENCIAS Y ADVERTENCIAS", border=1)
+            pdf.ln(8)
+            pdf.set_font("Helvetica", "", 8)
+            for issue in [*issues, *warnings]:
+                pdf.multi_cell(
+                    0,
+                    4,
+                    _pdf_safe(f"[{issue.get('code')}] {issue.get('message')}"),
+                )
+
+        pdf.ln(4)
+        pdf.set_font("Helvetica", "B", 9)
+        pdf.multi_cell(0, 5, _pdf_safe(f"SHA-256 del manifest canónico: {digest}"))
+        pdf.set_font("Helvetica", "", 8)
+        pdf.multi_cell(0, 4, _pdf_safe(manifest.get("disclaimer")))
+
+        return bytes(pdf.output())
+    except OriginDossierError:
+        raise
+    except Exception as exc:
+        raise OriginDossierGenerationError(
+            "DOSSIER_PDF_GENERATION_FAILED",
+            "No fue posible generar el PDF del dossier.",
+        ) from exc
+
+
+def _zip_entry(name: str, content: bytes) -> tuple[zipfile.ZipInfo, bytes]:
+    info = zipfile.ZipInfo(filename=name, date_time=(1980, 1, 1, 0, 0, 0))
+    info.compress_type = zipfile.ZIP_DEFLATED
+    info.external_attr = 0o644 << 16
+    return info, content
+
+
+def build_zip(
+    *,
+    shipment_code: str,
+    digest: str,
+    manifest_json_bytes: bytes,
+    geojson_bytes: bytes,
+    pdf_bytes: bytes,
+) -> bytes:
+    readme = (
+        "LITORAL TRACE - ORIGIN DOSSIER\n"
+        f"Shipment: {shipment_code}\n"
+        f"Integrity: {INTEGRITY_ALGORITHM} {digest}\n\n"
+        "The SHA-256 value anchors the canonical traceability manifest contained "
+        "in manifest.json. PDF and GeoJSON are projections of that manifest.\n\n"
+        f"{DISCLAIMER}\n"
+    ).encode("utf-8")
+
+    buffer = io.BytesIO()
+    with zipfile.ZipFile(buffer, mode="w", compression=zipfile.ZIP_DEFLATED, compresslevel=9) as archive:
+        for name, content in (
+            ("manifest.json", manifest_json_bytes),
+            ("origins.geojson", geojson_bytes),
+            ("dossier.pdf", pdf_bytes),
+            ("README.txt", readme),
+        ):
+            info, payload = _zip_entry(name, content)
+            archive.writestr(info, payload)
+    return buffer.getvalue()
+
+
+def safe_artifact_stem(shipment_code: str) -> str:
+    normalized = re.sub(r"[^A-Za-z0-9._-]+", "-", shipment_code.strip())
+    normalized = normalized.strip("-._")
+    return normalized[:80] or "shipment"
+
+
+def build_origin_dossier_bundle(payload: dict[str, Any]) -> OriginDossierBundle:
+    manifest = build_canonical_manifest(payload)
+    digest = manifest_sha256(manifest)
+    manifest_document = {
+        "integrity": {
+            "algorithm": INTEGRITY_ALGORITHM,
+            "canonical_manifest_sha256": digest,
+        },
+        "manifest": manifest,
+    }
+    manifest_bytes = _pretty_json_bytes(manifest_document)
+    geojson = build_geojson(manifest, digest)
+    geojson_bytes = _pretty_json_bytes(geojson)
+    pdf_bytes = build_pdf(manifest, digest)
+    shipment_code = str(manifest["shipment"]["shipment_code"])
+    zip_bytes = build_zip(
+        shipment_code=shipment_code,
+        digest=digest,
+        manifest_json_bytes=manifest_bytes,
+        geojson_bytes=geojson_bytes,
+        pdf_bytes=pdf_bytes,
+    )
+    return OriginDossierBundle(
+        shipment_code=shipment_code,
+        canonical_manifest=manifest,
+        manifest_document=manifest_document,
+        manifest_sha256=digest,
+        manifest_json_bytes=manifest_bytes,
+        geojson=geojson,
+        geojson_bytes=geojson_bytes,
+        pdf_bytes=pdf_bytes,
+        zip_bytes=zip_bytes,
+    )

--- a/src/litoral_trace/services/traceability_dossier.py
+++ b/src/litoral_trace/services/traceability_dossier.py
@@ -112,12 +112,14 @@ def _pretty_json_bytes(value: Any) -> bytes:
     ).encode("utf-8")
 
 
-def _geometry_from_lote(lote: dict[str, Any]) -> tuple[dict[str, Any] | None, str | None]:
+def _geometry_from_lote(
+    lote: dict[str, Any],
+) -> tuple[dict[str, Any] | None, str | None]:
     polygon_wkt = _text(lote.get("polygon_wkt"))
     if polygon_wkt:
         try:
-            from shapely.geometry import mapping
             from shapely import wkt
+            from shapely.geometry import mapping
 
             geometry = mapping(wkt.loads(polygon_wkt))
             geometry_type = str(geometry.get("type") or "")
@@ -125,14 +127,18 @@ def _geometry_from_lote(lote: dict[str, Any]) -> tuple[dict[str, Any] | None, st
                 return dict(geometry), None
             return dict(geometry), "SOURCE_GEOMETRY_NON_POLYGON"
         except Exception:
-            # A valid point fallback is still useful, but the warning remains
-            # visible in the dossier so polygon evidence is never fabricated.
+            # Keep a visible warning and use only a real point if coordinates
+            # exist. Never synthesize a polygon from invalid source evidence.
             pass
 
     latitude = _number(lote.get("latitud"))
     longitude = _number(lote.get("longitud"))
     if latitude is not None and longitude is not None:
-        warning = "SOURCE_GEOMETRY_POINT_FALLBACK" if polygon_wkt else "SOURCE_POLYGON_MISSING"
+        warning = (
+            "SOURCE_GEOMETRY_POINT_FALLBACK"
+            if polygon_wkt
+            else "SOURCE_POLYGON_MISSING"
+        )
         return {
             "type": "Point",
             "coordinates": [longitude, latitude],
@@ -257,8 +263,18 @@ def build_canonical_manifest(payload: dict[str, Any]) -> dict[str, Any]:
         reconciliation = event.get("reconciliation") or {}
         inputs = [_clean_edge(edge) for edge in event.get("inputs") or []]
         outputs = [_clean_edge(edge) for edge in event.get("outputs") or []]
-        inputs.sort(key=lambda value: (value.get("batch_code") or "", value.get("unit") or ""))
-        outputs.sort(key=lambda value: (value.get("batch_code") or "", value.get("unit") or ""))
+        inputs.sort(
+            key=lambda value: (
+                value.get("batch_code") or "",
+                value.get("unit") or "",
+            )
+        )
+        outputs.sort(
+            key=lambda value: (
+                value.get("batch_code") or "",
+                value.get("unit") or "",
+            )
+        )
         events.append(
             {
                 "event_public_id": _text(event.get("public_id")),
@@ -296,7 +312,12 @@ def build_canonical_manifest(payload: dict[str, Any]) -> dict[str, Any]:
             value.get("unit") or "",
         )
     )
-    items.sort(key=lambda value: (value.get("batch_code") or "", value.get("unit") or ""))
+    items.sort(
+        key=lambda value: (
+            value.get("batch_code") or "",
+            value.get("unit") or "",
+        )
+    )
     events.sort(
         key=lambda value: (
             value.get("occurred_at") or "",
@@ -311,7 +332,6 @@ def build_canonical_manifest(payload: dict[str, Any]) -> dict[str, Any]:
             value.get("origin_identifier") or "",
         )
     )
-
     lineage_issues = sorted(
         [_clean_issue(issue) for issue in payload.get("issues") or []],
         key=lambda value: (
@@ -410,16 +430,18 @@ def _unit_label(unit: Any) -> str:
 
 
 def build_pdf(manifest: dict[str, Any], digest: str) -> bytes:
+    """Render a readable projection without relying on fpdf cursor defaults."""
     try:
         from fpdf import FPDF
 
         class OriginDossierPDF(FPDF):
             def footer(self) -> None:
                 self.set_y(-14)
+                self.set_x(self.l_margin)
                 self.set_font("Helvetica", "", 7)
                 self.set_text_color(90, 90, 90)
                 self.cell(
-                    0,
+                    self.epw,
                     4,
                     _pdf_safe(
                         f"Litoral Trace | SHA-256 manifest: {digest[:24]}... | Página {self.page_no()}"
@@ -432,23 +454,55 @@ def build_pdf(manifest: dict[str, Any], digest: str) -> bytes:
         if hasattr(pdf, "set_creation_date"):
             pdf.set_creation_date(datetime(2000, 1, 1, tzinfo=timezone.utc))
         if hasattr(pdf, "set_title"):
-            pdf.set_title(_pdf_safe(f"Dossier de origen - {manifest['shipment']['shipment_code']}"))
+            pdf.set_title(
+                _pdf_safe(
+                    f"Dossier de origen - {manifest['shipment']['shipment_code']}"
+                )
+            )
         if hasattr(pdf, "set_author"):
             pdf.set_author("Litoral Trace")
         if hasattr(pdf, "set_producer"):
             pdf.set_producer("Litoral Trace")
 
+        def full_width_cell(
+            height: float,
+            text: Any,
+            *,
+            border: int = 0,
+            align: str = "L",
+        ) -> None:
+            pdf.set_x(pdf.l_margin)
+            pdf.cell(
+                pdf.epw,
+                height,
+                _pdf_safe(text),
+                border=border,
+                align=align,
+            )
+            pdf.ln(height)
+            pdf.set_x(pdf.l_margin)
+
+        def full_width_multicell(height: float, text: Any) -> None:
+            # fpdf2 2.8 defaults multi_cell new_x to RIGHT. Resetting before
+            # and after every block makes the dossier stable across versions.
+            pdf.set_x(pdf.l_margin)
+            pdf.multi_cell(pdf.epw, height, _pdf_safe(text))
+            pdf.set_x(pdf.l_margin)
+
         pdf.add_page()
         pdf.set_font("Helvetica", "B", 15)
         pdf.set_text_color(15, 23, 42)
-        pdf.cell(0, 9, "LITORAL TRACE - DOSSIER DE ORIGEN Y TRAZABILIDAD", align="C")
-        pdf.ln(12)
+        full_width_cell(
+            9,
+            "LITORAL TRACE - DOSSIER DE ORIGEN Y TRAZABILIDAD",
+            align="C",
+        )
+        pdf.ln(3)
 
         shipment = manifest["shipment"]
         lineage = manifest["lineage"]
         pdf.set_font("Helvetica", "B", 11)
-        pdf.cell(0, 7, _pdf_safe(f"Despacho: {shipment.get('shipment_code')}"))
-        pdf.ln(7)
+        full_width_cell(7, f"Despacho: {shipment.get('shipment_code')}")
         pdf.set_font("Helvetica", "", 9)
         for label, value in (
             ("Venta / referencia", shipment.get("sale_reference")),
@@ -456,130 +510,116 @@ def build_pdf(manifest: dict[str, Any], digest: str) -> bytes:
             ("País destino", shipment.get("destination_country")),
             ("Fecha despacho", shipment.get("shipped_at")),
             ("Estado despacho", shipment.get("status")),
-            ("Estado genealogía", "CERRADA" if lineage.get("complete") else "INCOMPLETA"),
+            (
+                "Estado genealogía",
+                "CERRADA" if lineage.get("complete") else "INCOMPLETA",
+            ),
             ("Método atribución", lineage.get("allocation_method")),
         ):
-            pdf.set_font("Helvetica", "B", 9)
-            pdf.cell(43, 5, _pdf_safe(f"{label}:"))
-            pdf.set_font("Helvetica", "", 9)
-            pdf.multi_cell(0, 5, _pdf_safe(value))
+            full_width_multicell(5, f"{label}: {_pdf_safe(value)}")
 
         pdf.ln(2)
         pdf.set_font("Helvetica", "B", 10)
-        pdf.cell(0, 7, "1. RECONCILIACIÓN DE VOLUMEN", border=1)
-        pdf.ln(8)
+        full_width_cell(7, "1. RECONCILIACIÓN DE VOLUMEN", border=1)
         for total in manifest.get("unit_totals") or []:
             pdf.set_font("Helvetica", "", 9)
             unit = _unit_label(total.get("unit"))
-            pdf.multi_cell(
-                0,
+            full_width_multicell(
                 5,
-                _pdf_safe(
-                    "Unidad {unit} | Despachado {shipped} | Atribuido {attributed} | "
-                    "Sin resolver {unresolved}".format(
-                        unit=unit,
-                        shipped=total.get("shipped_quantity"),
-                        attributed=total.get("attributed_quantity"),
-                        unresolved=total.get("unresolved_quantity"),
-                    )
+                "Unidad {unit} | Despachado {shipped} | Atribuido {attributed} | "
+                "Sin resolver {unresolved}".format(
+                    unit=unit,
+                    shipped=total.get("shipped_quantity"),
+                    attributed=total.get("attributed_quantity"),
+                    unresolved=total.get("unresolved_quantity"),
                 ),
             )
 
         pdf.ln(2)
         pdf.set_font("Helvetica", "B", 10)
-        pdf.cell(0, 7, "2. ORÍGENES ATRIBUIDOS", border=1)
-        pdf.ln(8)
+        full_width_cell(7, "2. ORÍGENES ATRIBUIDOS", border=1)
         origins = manifest.get("origins") or []
         if origins:
             for index, origin in enumerate(origins, start=1):
                 pdf.set_font("Helvetica", "B", 9)
-                pdf.multi_cell(
-                    0,
+                full_width_multicell(
                     5,
-                    _pdf_safe(
-                        f"{index}. {origin.get('identifier')} | Proveedor: "
-                        f"{origin.get('producer_reference')}"
-                    ),
+                    f"{index}. {origin.get('identifier')} | Proveedor: "
+                    f"{origin.get('producer_reference')}",
                 )
                 pdf.set_font("Helvetica", "", 8)
                 geometry = origin.get("geometry") or {}
-                pdf.multi_cell(
-                    0,
+                full_width_multicell(
                     4,
-                    _pdf_safe(
-                        "Producto: {product} | Superficie: {ha} ha | Atribución: {qty} {unit} | "
-                        "Participación: {share} | Geometría: {geometry_type}".format(
-                            product=origin.get("product"),
-                            ha=origin.get("hectares"),
-                            qty=origin.get("attributed_shipment_quantity"),
-                            unit=_unit_label(origin.get("unit")),
-                            share=origin.get("share_of_shipped_unit"),
-                            geometry_type=geometry.get("type") or "no disponible",
-                        )
+                    "Producto: {product} | Superficie: {ha} ha | Atribución: {qty} {unit} | "
+                    "Participación: {share} | Geometría: {geometry_type}".format(
+                        product=origin.get("product"),
+                        ha=origin.get("hectares"),
+                        qty=origin.get("attributed_shipment_quantity"),
+                        unit=_unit_label(origin.get("unit")),
+                        share=origin.get("share_of_shipped_unit"),
+                        geometry_type=geometry.get("type") or "no disponible",
                     ),
                 )
                 pdf.ln(1)
         else:
             pdf.set_font("Helvetica", "", 9)
-            pdf.multi_cell(0, 5, "No se pudieron atribuir orígenes a este despacho.")
+            full_width_multicell(
+                5,
+                "No se pudieron atribuir orígenes a este despacho.",
+            )
 
         pdf.ln(2)
         pdf.set_font("Helvetica", "B", 10)
-        pdf.cell(0, 7, "3. CAMINO INDUSTRIAL", border=1)
-        pdf.ln(8)
+        full_width_cell(7, "3. CAMINO INDUSTRIAL", border=1)
         events = manifest.get("events") or []
         if events:
             for event in events:
                 pdf.set_font("Helvetica", "B", 8)
-                pdf.multi_cell(
-                    0,
+                full_width_multicell(
                     4,
-                    _pdf_safe(
-                        f"{event.get('event_code')} | {event.get('event_type')} | "
-                        f"{event.get('occurred_at')} | {event.get('facility_reference')}"
-                    ),
+                    f"{event.get('event_code')} | {event.get('event_type')} | "
+                    f"{event.get('occurred_at')} | {event.get('facility_reference')}",
                 )
                 reconciliation = event.get("reconciliation") or {}
                 pdf.set_font("Helvetica", "", 8)
-                pdf.multi_cell(
-                    0,
+                full_width_multicell(
                     4,
-                    _pdf_safe(
-                        "Input {input_q} {unit} | Output {output_q} {unit} | Merma/diferencia "
-                        "{loss_q} {unit} | Rendimiento {yield_ratio}".format(
-                            input_q=reconciliation.get("input_quantity"),
-                            output_q=reconciliation.get("output_quantity"),
-                            loss_q=reconciliation.get("loss_quantity"),
-                            unit=_unit_label(reconciliation.get("unit")),
-                            yield_ratio=reconciliation.get("yield_ratio"),
-                        )
+                    "Input {input_q} {unit} | Output {output_q} {unit} | Merma/diferencia "
+                    "{loss_q} {unit} | Rendimiento {yield_ratio}".format(
+                        input_q=reconciliation.get("input_quantity"),
+                        output_q=reconciliation.get("output_quantity"),
+                        loss_q=reconciliation.get("loss_quantity"),
+                        unit=_unit_label(reconciliation.get("unit")),
+                        yield_ratio=reconciliation.get("yield_ratio"),
                     ),
                 )
                 pdf.ln(1)
         else:
             pdf.set_font("Helvetica", "", 9)
-            pdf.multi_cell(0, 5, "No hay eventos industriales recorribles.")
+            full_width_multicell(5, "No hay eventos industriales recorribles.")
 
         issues = lineage.get("issues") or []
         warnings = manifest.get("artifact_warnings") or []
         if issues or warnings:
             pdf.ln(2)
             pdf.set_font("Helvetica", "B", 10)
-            pdf.cell(0, 7, "4. INCIDENCIAS Y ADVERTENCIAS", border=1)
-            pdf.ln(8)
+            full_width_cell(7, "4. INCIDENCIAS Y ADVERTENCIAS", border=1)
             pdf.set_font("Helvetica", "", 8)
             for issue in [*issues, *warnings]:
-                pdf.multi_cell(
-                    0,
+                full_width_multicell(
                     4,
-                    _pdf_safe(f"[{issue.get('code')}] {issue.get('message')}"),
+                    f"[{issue.get('code')}] {issue.get('message')}",
                 )
 
         pdf.ln(4)
         pdf.set_font("Helvetica", "B", 9)
-        pdf.multi_cell(0, 5, _pdf_safe(f"SHA-256 del manifest canónico: {digest}"))
+        full_width_multicell(
+            5,
+            f"SHA-256 del manifest canónico: {digest}",
+        )
         pdf.set_font("Helvetica", "", 8)
-        pdf.multi_cell(0, 4, _pdf_safe(manifest.get("disclaimer")))
+        full_width_multicell(4, manifest.get("disclaimer"))
 
         return bytes(pdf.output())
     except OriginDossierError:
@@ -592,7 +632,10 @@ def build_pdf(manifest: dict[str, Any], digest: str) -> bytes:
 
 
 def _zip_entry(name: str, content: bytes) -> tuple[zipfile.ZipInfo, bytes]:
-    info = zipfile.ZipInfo(filename=name, date_time=(1980, 1, 1, 0, 0, 0))
+    info = zipfile.ZipInfo(
+        filename=name,
+        date_time=(1980, 1, 1, 0, 0, 0),
+    )
     info.compress_type = zipfile.ZIP_DEFLATED
     info.external_attr = 0o644 << 16
     return info, content
@@ -616,25 +659,36 @@ def build_zip(
     ).encode("utf-8")
 
     buffer = io.BytesIO()
-    with zipfile.ZipFile(buffer, mode="w", compression=zipfile.ZIP_DEFLATED, compresslevel=9) as archive:
+    with zipfile.ZipFile(
+        buffer,
+        mode="w",
+        compression=zipfile.ZIP_DEFLATED,
+        compresslevel=9,
+    ) as archive:
         for name, content in (
             ("manifest.json", manifest_json_bytes),
             ("origins.geojson", geojson_bytes),
             ("dossier.pdf", pdf_bytes),
             ("README.txt", readme),
         ):
-            info, payload = _zip_entry(name, content)
-            archive.writestr(info, payload)
+            info, entry_payload = _zip_entry(name, content)
+            archive.writestr(info, entry_payload)
     return buffer.getvalue()
 
 
 def safe_artifact_stem(shipment_code: str) -> str:
-    normalized = re.sub(r"[^A-Za-z0-9._-]+", "-", shipment_code.strip())
+    normalized = re.sub(
+        r"[^A-Za-z0-9._-]+",
+        "-",
+        shipment_code.strip(),
+    )
     normalized = normalized.strip("-._")
     return normalized[:80] or "shipment"
 
 
-def build_origin_dossier_bundle(payload: dict[str, Any]) -> OriginDossierBundle:
+def build_origin_dossier_bundle(
+    payload: dict[str, Any],
+) -> OriginDossierBundle:
     manifest = build_canonical_manifest(payload)
     digest = manifest_sha256(manifest)
     manifest_document = {

--- a/src/litoral_trace/templates/traceability.html
+++ b/src/litoral_trace/templates/traceability.html
@@ -93,6 +93,38 @@
     </div>
 </section>
 
+{% if result.dossier %}
+<section class="mb-6 rounded-2xl border border-slate-200 bg-white p-5 shadow-sm">
+    <div class="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
+        <div class="max-w-3xl">
+            <p class="text-[11px] font-bold uppercase tracking-wider text-emerald-700">Dossier de origen</p>
+            <h2 class="mt-1 text-base font-bold text-slate-950">Paquete buyer-facing del despacho</h2>
+            <p class="mt-1 text-xs leading-5 text-slate-500">
+                Descargá el expediente consolidado con manifest canónico, GeoJSON de orígenes y PDF. El dossier documenta origen y cadena de custodia; no reemplaza por sí solo una declaración regulatoria.
+            </p>
+        </div>
+        <div class="flex flex-wrap items-center gap-2 text-xs font-semibold">
+            <a href="{{ result.dossier.bundle_href }}" class="inline-flex items-center justify-center gap-2 rounded-lg bg-forest-800 px-5 py-2.5 text-sm font-semibold text-white shadow-sm transition hover:bg-forest-900">
+                <i class="fa-solid fa-file-zipper" aria-hidden="true"></i>
+                Descargar paquete
+            </a>
+            <a href="{{ result.dossier.pdf_href }}" class="inline-flex items-center gap-2 rounded-lg border border-slate-300 bg-white px-3 py-2 text-slate-700">
+                <i class="fa-solid fa-file-pdf" aria-hidden="true"></i>
+                PDF
+            </a>
+            <a href="{{ result.dossier.geojson_href }}" class="inline-flex items-center gap-2 rounded-lg border border-slate-300 bg-white px-3 py-2 text-slate-700">
+                <i class="fa-solid fa-map" aria-hidden="true"></i>
+                GeoJSON
+            </a>
+            <a href="{{ result.dossier.manifest_href }}" class="inline-flex items-center gap-2 rounded-lg border border-slate-300 bg-white px-3 py-2 text-slate-700">
+                <i class="fa-solid fa-code" aria-hidden="true"></i>
+                Manifest
+            </a>
+        </div>
+    </div>
+</section>
+{% endif %}
+
 <div class="mb-6 grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4">
     <section class="rounded-xl border border-slate-200 bg-white p-5 shadow-sm">
         <p class="text-[11px] font-bold uppercase tracking-wider text-slate-500">Despacho</p>

--- a/src/litoral_trace/web/traceability.py
+++ b/src/litoral_trace/web/traceability.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 from datetime import datetime
 from decimal import Decimal, InvalidOperation
 from typing import Any
-from urllib.parse import quote
+from urllib.parse import urlencode
 
 from fastapi import APIRouter, Request, status
 from fastapi.responses import HTMLResponse
@@ -226,12 +226,12 @@ def build_traceability_view(
 
     shipment = payload.get("shipment") or {}
     shipment_code = str(shipment.get("shipment_code") or "").strip()
-    encoded_shipment_code = quote(shipment_code, safe="")
-    dossier_base = (
-        f"/api/v1/traceability/shipments/{encoded_shipment_code}/dossier"
-        if encoded_shipment_code
+    dossier_query = (
+        urlencode({"shipment_code": shipment_code})
+        if shipment_code
         else None
     )
+    dossier_base = "/api/v1/traceability/shipments/dossier"
     totals = payload.get("unit_totals") or []
     sources = [_present_source(source) for source in payload.get("source_lotes") or []]
     events = [_present_event(event) for event in payload.get("events") or []]
@@ -275,12 +275,12 @@ def build_traceability_view(
         },
         "dossier": (
             {
-                "bundle_href": f"{dossier_base}/bundle",
-                "pdf_href": f"{dossier_base}/pdf",
-                "geojson_href": f"{dossier_base}/geojson",
-                "manifest_href": f"{dossier_base}/manifest",
+                "bundle_href": f"{dossier_base}/bundle?{dossier_query}",
+                "pdf_href": f"{dossier_base}/pdf?{dossier_query}",
+                "geojson_href": f"{dossier_base}/geojson?{dossier_query}",
+                "manifest_href": f"{dossier_base}/manifest?{dossier_query}",
             }
-            if dossier_base is not None
+            if dossier_query is not None
             else None
         ),
         "allocation_method": _text(payload.get("allocation_method")),

--- a/src/litoral_trace/web/traceability.py
+++ b/src/litoral_trace/web/traceability.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 from datetime import datetime
 from decimal import Decimal, InvalidOperation
 from typing import Any
+from urllib.parse import quote
 
 from fastapi import APIRouter, Request, status
 from fastapi.responses import HTMLResponse
@@ -224,6 +225,13 @@ def build_traceability_view(
         return view
 
     shipment = payload.get("shipment") or {}
+    shipment_code = str(shipment.get("shipment_code") or "").strip()
+    encoded_shipment_code = quote(shipment_code, safe="")
+    dossier_base = (
+        f"/api/v1/traceability/shipments/{encoded_shipment_code}/dossier"
+        if encoded_shipment_code
+        else None
+    )
     totals = payload.get("unit_totals") or []
     sources = [_present_source(source) for source in payload.get("source_lotes") or []]
     events = [_present_event(event) for event in payload.get("events") or []]
@@ -265,6 +273,16 @@ def build_traceability_view(
                 else "Previsualización"
             ),
         },
+        "dossier": (
+            {
+                "bundle_href": f"{dossier_base}/bundle",
+                "pdf_href": f"{dossier_base}/pdf",
+                "geojson_href": f"{dossier_base}/geojson",
+                "manifest_href": f"{dossier_base}/manifest",
+            }
+            if dossier_base is not None
+            else None
+        ),
         "allocation_method": _text(payload.get("allocation_method")),
         "totals": [
             {

--- a/tests/test_traceability_p1e_api_unittest.py
+++ b/tests/test_traceability_p1e_api_unittest.py
@@ -1,0 +1,139 @@
+"""P1E authenticated dossier endpoint contracts."""
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+import subprocess
+import sys
+from types import SimpleNamespace
+
+import litoral_trace.api.traceability_dossier as dossier_api
+from litoral_trace.services.traceability_dossier import OriginDossierBundle
+
+
+EXPECTED_PATHS = {
+    "/api/v1/traceability/shipments/{shipment_code}/dossier/manifest",
+    "/api/v1/traceability/shipments/{shipment_code}/dossier/geojson",
+    "/api/v1/traceability/shipments/{shipment_code}/dossier/pdf",
+    "/api/v1/traceability/shipments/{shipment_code}/dossier/bundle",
+}
+
+
+def _bundle() -> OriginDossierBundle:
+    digest = "a" * 64
+    manifest = {
+        "shipment": {"shipment_code": "EXP-UE-2026-001"},
+    }
+    document = {
+        "integrity": {
+            "algorithm": "SHA-256",
+            "canonical_manifest_sha256": digest,
+        },
+        "manifest": manifest,
+    }
+    geojson = {
+        "type": "FeatureCollection",
+        "features": [],
+    }
+    return OriginDossierBundle(
+        shipment_code="EXP-UE-2026-001",
+        canonical_manifest=manifest,
+        manifest_document=document,
+        manifest_sha256=digest,
+        manifest_json_bytes=b'{"manifest":{}}\n',
+        geojson=geojson,
+        geojson_bytes=b'{"type":"FeatureCollection"}\n',
+        pdf_bytes=b"%PDF-1.7 dossier",
+        zip_bytes=b"PK dossier",
+    )
+
+
+def _user():
+    return SimpleNamespace(
+        organization_id=7,
+        role="auditor",
+    )
+
+
+def test_p1e_download_endpoints_are_registered_on_cold_start() -> None:
+    root_dir = Path(__file__).resolve().parents[1]
+    probe = f"""
+import main
+expected = {sorted(EXPECTED_PATHS)!r}
+schema = main.app.openapi()
+for path in expected:
+    assert path in schema['paths'], (path, sorted(schema['paths']))
+    assert 'get' in schema['paths'][path], schema['paths'][path]
+"""
+    completed = subprocess.run(
+        [sys.executable, "-c", probe],
+        cwd=root_dir,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert completed.returncode == 0, (
+        "P1E dossier endpoints were not exposed on isolated ASGI cold start.\n"
+        f"STDOUT:\n{completed.stdout}\nSTDERR:\n{completed.stderr}"
+    )
+
+
+def test_manifest_download_has_integrity_header_and_safe_attachment(monkeypatch) -> None:
+    bundle = _bundle()
+    monkeypatch.setattr(dossier_api, "_load_bundle", lambda **kwargs: bundle)
+
+    response = asyncio.run(
+        dossier_api.descargar_manifest_dossier_endpoint(
+            'EXP 2026/001\r\n"evil"',
+            user=_user(),
+        )
+    )
+
+    assert response.status_code == 200
+    assert response.media_type == "application/json"
+    assert response.headers["x-litoral-trace-manifest-sha256"] == bundle.manifest_sha256
+    assert response.headers["cache-control"] == "private, no-store"
+    assert response.headers["content-disposition"] == (
+        'attachment; filename="litoral-trace-EXP-UE-2026-001-manifest.json"'
+    )
+    assert response.body == bundle.manifest_json_bytes
+
+
+def test_geojson_pdf_and_bundle_downloads_use_expected_media_types(monkeypatch) -> None:
+    bundle = _bundle()
+    monkeypatch.setattr(dossier_api, "_load_bundle", lambda **kwargs: bundle)
+
+    geojson = asyncio.run(
+        dossier_api.descargar_geojson_dossier_endpoint(
+            bundle.shipment_code,
+            user=_user(),
+        )
+    )
+    pdf = asyncio.run(
+        dossier_api.descargar_pdf_dossier_endpoint(
+            bundle.shipment_code,
+            user=_user(),
+        )
+    )
+    archive = asyncio.run(
+        dossier_api.descargar_bundle_dossier_endpoint(
+            bundle.shipment_code,
+            user=_user(),
+        )
+    )
+
+    assert geojson.media_type == "application/geo+json"
+    assert geojson.body == bundle.geojson_bytes
+    assert geojson.headers["content-disposition"].endswith('-origins.geojson"')
+
+    assert pdf.media_type == "application/pdf"
+    assert pdf.body.startswith(b"%PDF")
+    assert pdf.headers["content-disposition"].endswith('-dossier.pdf"')
+
+    assert archive.media_type == "application/zip"
+    assert archive.body.startswith(b"PK")
+    assert archive.headers["content-disposition"].endswith('-dossier.zip"')
+
+    for response in (geojson, pdf, archive):
+        assert response.headers["x-litoral-trace-manifest-sha256"] == bundle.manifest_sha256
+        assert response.headers["cache-control"] == "private, no-store"

--- a/tests/test_traceability_p1e_api_unittest.py
+++ b/tests/test_traceability_p1e_api_unittest.py
@@ -12,10 +12,10 @@ from litoral_trace.services.traceability_dossier import OriginDossierBundle
 
 
 EXPECTED_PATHS = {
-    "/api/v1/traceability/shipments/{shipment_code}/dossier/manifest",
-    "/api/v1/traceability/shipments/{shipment_code}/dossier/geojson",
-    "/api/v1/traceability/shipments/{shipment_code}/dossier/pdf",
-    "/api/v1/traceability/shipments/{shipment_code}/dossier/bundle",
+    "/api/v1/traceability/shipments/dossier/manifest",
+    "/api/v1/traceability/shipments/dossier/geojson",
+    "/api/v1/traceability/shipments/dossier/pdf",
+    "/api/v1/traceability/shipments/dossier/bundle",
 }
 
 
@@ -63,7 +63,12 @@ expected = {sorted(EXPECTED_PATHS)!r}
 schema = main.app.openapi()
 for path in expected:
     assert path in schema['paths'], (path, sorted(schema['paths']))
-    assert 'get' in schema['paths'][path], schema['paths'][path]
+    operation = schema['paths'][path]['get']
+    parameters = operation.get('parameters', [])
+    shipment = [item for item in parameters if item.get('name') == 'shipment_code']
+    assert len(shipment) == 1, (path, parameters)
+    assert shipment[0].get('in') == 'query', shipment[0]
+    assert shipment[0].get('required') is True, shipment[0]
 """
     completed = subprocess.run(
         [sys.executable, "-c", probe],
@@ -80,15 +85,23 @@ for path in expected:
 
 def test_manifest_download_has_integrity_header_and_safe_attachment(monkeypatch) -> None:
     bundle = _bundle()
-    monkeypatch.setattr(dossier_api, "_load_bundle", lambda **kwargs: bundle)
+    captured = {}
 
+    def _fake_load_bundle(**kwargs):
+        captured.update(kwargs)
+        return bundle
+
+    monkeypatch.setattr(dossier_api, "_load_bundle", _fake_load_bundle)
+
+    requested_code = 'EXP 2026/001\r\n"evil"'
     response = asyncio.run(
         dossier_api.descargar_manifest_dossier_endpoint(
-            'EXP 2026/001\r\n"evil"',
+            requested_code,
             user=_user(),
         )
     )
 
+    assert captured["shipment_code"] == requested_code
     assert response.status_code == 200
     assert response.media_type == "application/json"
     assert response.headers["x-litoral-trace-manifest-sha256"] == bundle.manifest_sha256

--- a/tests/test_traceability_p1e_dossier_unittest.py
+++ b/tests/test_traceability_p1e_dossier_unittest.py
@@ -1,0 +1,307 @@
+"""P1E deterministic buyer-facing origin dossier acceptance."""
+from __future__ import annotations
+
+from copy import deepcopy
+import hashlib
+import io
+import json
+import zipfile
+
+from litoral_trace.services.traceability_dossier import (
+    DISCLAIMER,
+    SCHEMA_VERSION,
+    build_canonical_manifest,
+    build_origin_dossier_bundle,
+    manifest_sha256,
+    safe_artifact_stem,
+)
+
+
+def _payload(*, complete: bool = True) -> dict:
+    issues = [] if complete else [
+        {
+            "code": "MISSING_PROVENANCE",
+            "message": "Un lote no tiene origen resoluble.",
+            "batch_id": 999,
+        }
+    ]
+    unresolved = "0.000000" if complete else "5.000000"
+    attributed = "60.000000" if complete else "55.000000"
+
+    return {
+        "organization_id": 77,
+        "shipment": {
+            "id": 910,
+            "public_id": "8d4de42a-2283-48e4-996d-e47b19ae1001",
+            "shipment_code": "EXP-UE-2026-001",
+            "sale_reference": "FACTURA-E-001",
+            "buyer_reference": "BUYER-EU-001",
+            "destination_country": "DE",
+            "shipped_at": "2026-08-20T20:00:00+00:00",
+            "status": "DISPATCHED",
+            "lineage_state": "FINAL",
+        },
+        "allocation_method": "PROPORTIONAL_INPUT_ALLOCATION",
+        "complete": complete,
+        "issues": issues,
+        "unit_totals": [
+            {
+                "unit": "M3",
+                "shipped_quantity": "60.000000",
+                "attributed_quantity": attributed,
+                "unresolved_quantity": unresolved,
+            }
+        ],
+        "items": [
+            {
+                "shipment_item_id": 1,
+                "batch": {
+                    "id": 301,
+                    "public_id": "8d4de42a-2283-48e4-996d-e47b19ae2001",
+                    "code": "ASERRADO-001",
+                    "product_name": "Madera aserrada de pino",
+                    "stage": "FINISHED_GOOD",
+                    "unit": "M3",
+                    "status": "ACTIVE",
+                    "source_lote_id": None,
+                },
+                "shipped_quantity": "60.000000",
+                "unit": "M3",
+                "attributed_quantity": attributed,
+                "unresolved_quantity": unresolved,
+                "complete": complete,
+                "issues": issues,
+                "source_contributions": [
+                    {
+                        "lote": {
+                            "id": 10,
+                            "identificador": "RODAL-PINO-A",
+                            "productor_id": "PROVEEDOR-A",
+                            "producto_forestal": "Pino resinoso",
+                            "hectareas": 50.0,
+                            "latitud": -28.05,
+                            "longitud": -56.03,
+                            "polygon_wkt": "POLYGON((-56.04 -28.06,-56.02 -28.06,-56.02 -28.04,-56.04 -28.04,-56.04 -28.06))",
+                            "estatus": "Verde",
+                        },
+                        "attributed_shipment_quantity": "42.000000",
+                        "unit": "M3",
+                        "share_of_shipment_item": "0.700000",
+                    },
+                    {
+                        "lote": {
+                            "id": 11,
+                            "identificador": "RODAL-PINO-B",
+                            "productor_id": "PROVEEDOR-B",
+                            "producto_forestal": "Pino resinoso",
+                            "hectareas": 60.0,
+                            "latitud": -28.06,
+                            "longitud": -56.04,
+                            "polygon_wkt": "POLYGON((-56.05 -28.07,-56.03 -28.07,-56.03 -28.05,-56.05 -28.05,-56.05 -28.07))",
+                            "estatus": "Verde",
+                        },
+                        "attributed_shipment_quantity": "18.000000",
+                        "unit": "M3",
+                        "share_of_shipment_item": "0.300000",
+                    },
+                ],
+            }
+        ],
+        "events": [
+            {
+                "id": 100,
+                "public_id": "8d4de42a-2283-48e4-996d-e47b19ae3001",
+                "event_code": "SAW-001",
+                "event_type": "TRANSFORMATION",
+                "status": "POSTED",
+                "occurred_at": "2026-08-19T13:00:00+00:00",
+                "facility_reference": "Planta Virasoro",
+                "inputs": [
+                    {
+                        "batch_id": 201,
+                        "batch_code": "REC-A-001",
+                        "quantity": "70.000000",
+                        "unit": "M3",
+                    },
+                    {
+                        "batch_id": 202,
+                        "batch_code": "REC-B-001",
+                        "quantity": "30.000000",
+                        "unit": "M3",
+                    },
+                ],
+                "outputs": [
+                    {
+                        "batch_id": 301,
+                        "batch_code": "ASERRADO-001",
+                        "quantity": "65.000000",
+                        "unit": "M3",
+                    }
+                ],
+                "reconciliation": {
+                    "unit": "M3",
+                    "input_quantity": "100.000000",
+                    "output_quantity": "65.000000",
+                    "loss_quantity": "35.000000",
+                    "yield_ratio": "0.650000",
+                },
+            }
+        ],
+        "source_lotes": [
+            {
+                "lote": {
+                    "id": 10,
+                    "identificador": "RODAL-PINO-A",
+                    "productor_id": "PROVEEDOR-A",
+                    "producto_forestal": "Pino resinoso",
+                    "hectareas": 50.0,
+                    "latitud": -28.05,
+                    "longitud": -56.03,
+                    "polygon_wkt": "POLYGON((-56.04 -28.06,-56.02 -28.06,-56.02 -28.04,-56.04 -28.04,-56.04 -28.06))",
+                    "estatus": "Verde",
+                },
+                "attributed_shipment_quantity": "42.000000",
+                "unit": "M3",
+                "share_of_shipped_unit": "0.700000",
+            },
+            {
+                "lote": {
+                    "id": 11,
+                    "identificador": "RODAL-PINO-B",
+                    "productor_id": "PROVEEDOR-B",
+                    "producto_forestal": "Pino resinoso",
+                    "hectareas": 60.0,
+                    "latitud": -28.06,
+                    "longitud": -56.04,
+                    "polygon_wkt": "POLYGON((-56.05 -28.07,-56.03 -28.07,-56.03 -28.05,-56.05 -28.05,-56.05 -28.07))",
+                    "estatus": "Verde",
+                },
+                "attributed_shipment_quantity": "18.000000",
+                "unit": "M3",
+                "share_of_shipped_unit": "0.300000",
+            },
+        ],
+    }
+
+
+def test_manifest_is_buyer_facing_and_excludes_internal_database_ids() -> None:
+    manifest = build_canonical_manifest(_payload())
+    encoded = json.dumps(manifest, ensure_ascii=False)
+
+    assert manifest["schema_version"] == SCHEMA_VERSION
+    assert manifest["shipment"]["shipment_code"] == "EXP-UE-2026-001"
+    assert manifest["lineage"]["complete"] is True
+    assert manifest["origins"][0]["identifier"] == "RODAL-PINO-A"
+    assert manifest["origins"][0]["attributed_shipment_quantity"] == "42.000000"
+    assert manifest["origins"][1]["attributed_shipment_quantity"] == "18.000000"
+    assert manifest["disclaimer"] == DISCLAIMER
+    assert '"organization_id"' not in encoded
+    assert '"shipment_item_id"' not in encoded
+    assert '"source_lote_id"' not in encoded
+    assert '"batch_id"' not in encoded
+    assert '"event_id"' not in encoded
+
+
+def test_manifest_hash_is_deterministic_for_same_traceability_content() -> None:
+    first = build_canonical_manifest(_payload())
+    second_payload = deepcopy(_payload())
+    second_payload["source_lotes"] = list(reversed(second_payload["source_lotes"]))
+    second_payload["items"][0]["source_contributions"] = list(
+        reversed(second_payload["items"][0]["source_contributions"])
+    )
+    second_payload["events"][0]["inputs"] = list(
+        reversed(second_payload["events"][0]["inputs"])
+    )
+    second = build_canonical_manifest(second_payload)
+
+    assert first == second
+    assert manifest_sha256(first) == manifest_sha256(second)
+    assert manifest_sha256(first) == hashlib.sha256(
+        json.dumps(
+            first,
+            ensure_ascii=False,
+            sort_keys=True,
+            separators=(",", ":"),
+            allow_nan=False,
+        ).encode("utf-8")
+    ).hexdigest()
+
+
+def test_manifest_hash_changes_when_business_evidence_changes() -> None:
+    first = build_canonical_manifest(_payload())
+    changed_payload = deepcopy(_payload())
+    changed_payload["source_lotes"][0]["attributed_shipment_quantity"] = "41.000000"
+    changed = build_canonical_manifest(changed_payload)
+
+    assert manifest_sha256(first) != manifest_sha256(changed)
+
+
+def test_bundle_contains_pdf_geojson_manifest_and_zip_with_same_digest() -> None:
+    bundle = build_origin_dossier_bundle(_payload())
+
+    assert bundle.pdf_bytes.startswith(b"%PDF")
+    assert bundle.geojson["type"] == "FeatureCollection"
+    assert len(bundle.geojson["features"]) == 2
+    assert all(
+        feature["geometry"]["type"] == "Polygon"
+        for feature in bundle.geojson["features"]
+    )
+    assert (
+        bundle.geojson["litoral_trace_integrity"]["canonical_manifest_sha256"]
+        == bundle.manifest_sha256
+    )
+    assert (
+        bundle.manifest_document["integrity"]["canonical_manifest_sha256"]
+        == bundle.manifest_sha256
+    )
+
+    with zipfile.ZipFile(io.BytesIO(bundle.zip_bytes)) as archive:
+        assert sorted(archive.namelist()) == [
+            "README.txt",
+            "dossier.pdf",
+            "manifest.json",
+            "origins.geojson",
+        ]
+        manifest_document = json.loads(archive.read("manifest.json"))
+        geojson = json.loads(archive.read("origins.geojson"))
+        assert archive.read("dossier.pdf").startswith(b"%PDF")
+        assert (
+            manifest_document["integrity"]["canonical_manifest_sha256"]
+            == bundle.manifest_sha256
+        )
+        assert (
+            geojson["litoral_trace_integrity"]["canonical_manifest_sha256"]
+            == bundle.manifest_sha256
+        )
+
+
+def test_geometry_falls_back_to_point_and_never_fabricates_polygon() -> None:
+    payload = _payload()
+    payload["source_lotes"][0]["lote"]["polygon_wkt"] = "BROKEN POLYGON"
+    manifest = build_canonical_manifest(payload)
+    first_origin = next(
+        origin for origin in manifest["origins"]
+        if origin["identifier"] == "RODAL-PINO-A"
+    )
+
+    assert first_origin["geometry"] == {
+        "type": "Point",
+        "coordinates": [-56.03, -28.05],
+    }
+    assert any(
+        warning["code"] == "SOURCE_GEOMETRY_POINT_FALLBACK"
+        for warning in manifest["artifact_warnings"]
+    )
+
+
+def test_incomplete_lineage_stays_incomplete_in_dossier() -> None:
+    bundle = build_origin_dossier_bundle(_payload(complete=False))
+
+    assert bundle.canonical_manifest["lineage"]["complete"] is False
+    assert bundle.canonical_manifest["lineage"]["issues"][0]["code"] == "MISSING_PROVENANCE"
+    assert bundle.canonical_manifest["unit_totals"][0]["unresolved_quantity"] == "5.000000"
+    assert DISCLAIMER in bundle.canonical_manifest["disclaimer"]
+
+
+def test_safe_artifact_stem_prevents_content_disposition_injection() -> None:
+    assert safe_artifact_stem('EXP 2026/001\r\n"evil"') == "EXP-2026-001-evil"

--- a/tests/test_traceability_p1e_ui_unittest.py
+++ b/tests/test_traceability_p1e_ui_unittest.py
@@ -1,0 +1,74 @@
+"""P1E browser presentation contracts for origin dossier downloads."""
+from __future__ import annotations
+
+from pathlib import Path
+
+from litoral_trace.web.traceability import build_traceability_view
+
+
+ROOT = Path(__file__).resolve().parents[1]
+TEMPLATE = (
+    ROOT
+    / "src"
+    / "litoral_trace"
+    / "templates"
+    / "traceability.html"
+)
+
+
+def _payload() -> dict:
+    return {
+        "shipment": {
+            "public_id": "8d4de42a-2283-48e4-996d-e47b19ae1001",
+            "shipment_code": "EXP UE/2026 001",
+            "sale_reference": "FACTURA-E-001",
+            "buyer_reference": "BUYER-EU-001",
+            "destination_country": "DE",
+            "shipped_at": "2026-08-20T20:00:00+00:00",
+            "status": "DISPATCHED",
+            "lineage_state": "FINAL",
+        },
+        "allocation_method": "PROPORTIONAL_INPUT_ALLOCATION",
+        "complete": True,
+        "issues": [],
+        "unit_totals": [
+            {
+                "unit": "M3",
+                "shipped_quantity": "60.000000",
+                "attributed_quantity": "60.000000",
+                "unresolved_quantity": "0.000000",
+            }
+        ],
+        "items": [],
+        "events": [],
+        "source_lotes": [],
+    }
+
+
+def test_traceability_view_exposes_url_encoded_dossier_downloads() -> None:
+    view = build_traceability_view(
+        query="EXP UE/2026 001",
+        payload=_payload(),
+    )
+    dossier = view["result"]["dossier"]
+    base = "/api/v1/traceability/shipments/EXP%20UE%2F2026%20001/dossier"
+
+    assert dossier == {
+        "bundle_href": f"{base}/bundle",
+        "pdf_href": f"{base}/pdf",
+        "geojson_href": f"{base}/geojson",
+        "manifest_href": f"{base}/manifest",
+    }
+
+
+def test_traceability_template_surfaces_buyer_facing_bundle_without_compliance_claim() -> None:
+    template = TEMPLATE.read_text(encoding="utf-8")
+
+    assert "Dossier de origen" in template
+    assert "Paquete buyer-facing del despacho" in template
+    assert "{{ result.dossier.bundle_href }}" in template
+    assert "{{ result.dossier.pdf_href }}" in template
+    assert "{{ result.dossier.geojson_href }}" in template
+    assert "{{ result.dossier.manifest_href }}" in template
+    assert "Descargar paquete" in template
+    assert "no reemplaza por sí solo una declaración regulatoria" in template

--- a/tests/test_traceability_p1e_ui_unittest.py
+++ b/tests/test_traceability_p1e_ui_unittest.py
@@ -45,19 +45,20 @@ def _payload() -> dict:
     }
 
 
-def test_traceability_view_exposes_url_encoded_dossier_downloads() -> None:
+def test_traceability_view_exposes_query_safe_dossier_downloads() -> None:
     view = build_traceability_view(
         query="EXP UE/2026 001",
         payload=_payload(),
     )
     dossier = view["result"]["dossier"]
-    base = "/api/v1/traceability/shipments/EXP%20UE%2F2026%20001/dossier"
+    base = "/api/v1/traceability/shipments/dossier"
+    query = "shipment_code=EXP+UE%2F2026+001"
 
     assert dossier == {
-        "bundle_href": f"{base}/bundle",
-        "pdf_href": f"{base}/pdf",
-        "geojson_href": f"{base}/geojson",
-        "manifest_href": f"{base}/manifest",
+        "bundle_href": f"{base}/bundle?{query}",
+        "pdf_href": f"{base}/pdf?{query}",
+        "geojson_href": f"{base}/geojson?{query}",
+        "manifest_href": f"{base}/manifest?{query}",
     }
 
 


### PR DESCRIPTION
## Goal
Build a buyer-facing origin dossier as a pure projection of the P1C reverse-lineage result, without mutating genealogy or inventory and without making automatic regulatory-compliance claims.

## Completed scope
- deterministic canonical traceability manifest
- SHA-256 integrity anchored to stable business evidence, excluding generation time
- buyer-facing manifest excludes internal database ids
- deterministic ordering of origins, event edges, events, items and issues
- multi-origin GeoJSON derived from source parcels
- invalid/missing polygons fail visibly to point/no-geometry fallback instead of fabricating shapes
- PDF origin and chain-of-custody dossier using explicit fpdf2 cursor/width semantics
- ZIP bundle containing `manifest.json`, `origins.geojson`, `dossier.pdf`, and `README.txt`
- authenticated tenant-safe download endpoints for manifest / GeoJSON / PDF / ZIP
- download routes use `shipment_code` as a required query parameter so commercial codes containing `/` remain robust across proxies/routers
- every artifact response returns `Cache-Control: private, no-store` and `X-Litoral-Trace-Manifest-SHA256`
- P1D traceability workspace exposes direct ZIP / PDF / GeoJSON / manifest downloads
- dedicated fail-closed Gate 17

## Integrity semantics
The SHA-256 value covers the canonical manifest, not PDF bytes or generation timestamps. Re-generating the same underlying traceability evidence yields the same manifest digest; changing business evidence changes the digest.

## Regulatory semantics
The dossier documents origin and chain of custody. It does **not** by itself assert EUDR or other regulatory compliance. Incomplete P1C genealogy stays explicitly incomplete in all P1E artifacts.

## Corrientes acceptance scenario
The existing 70/30 industrial attribution remains preserved in the buyer-facing dossier: a 60 M3 shipment resolves to 42 M3 from `RODAL-PINO-A` and 18 M3 from `RODAL-PINO-B` when the underlying P1C genealogy is complete.

## Acceptance — current head
Candidate head: `aeaa28e412a6feed2fc768176e37e7a32ad33d34`

- P1E Origin Dossier Gate / Gate 17: **green**
  - deterministic manifest/hash contract: green
  - hash changes when business evidence changes: green
  - GeoJSON geometry/fallback contract: green
  - current fpdf2 PDF generation: green
  - deterministic ZIP contents: green
  - authenticated API/OpenAPI contract: green
  - slash-safe query shipment-code contract: green
  - P1D dossier download presentation contract: green
  - fail-closed: no skipped/failing/error tests accepted
- CI: **green**
  - Python syntax gate: green
  - Alembic canonical head gate: green
  - full pytest suite: green
  - frontend build + dependency audit + reproducible tracked assets: green
  - production Docker / Compose / Nginx / Prometheus / Alertmanager validation: green

## Dependency / merge status
This PR is stacked on top of draft PR #38 (`p1-traceability-genealogy`). It intentionally remains **draft** and must not be merged before #38 is reviewed/merged or the branch is rebased appropriately. `p2-enterprise-production` remains untouched by P1E.