### PR TITLE
ops: trigger post-migration readiness probe

### DIFF
--- a/.github/workflows/production-readiness-probe.yml
+++ b/.github/workflows/production-readiness-probe.yml
@@ -1,4 +1,5 @@
 name: Production Readiness Probe
+# Operational trigger marker: post-migration verification 2026-08-22.
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
Operational one-line marker only, used to trigger the existing protected production readiness workflow after the 018→020 Neon migration. No product or database changes.