### PR TITLE
ops: dispatch traceability Jinja hotfix

### DIFF
--- a/.github/workflows/dispatch-traceability-jinja-hotfix.yml
+++ b/.github/workflows/dispatch-traceability-jinja-hotfix.yml
@@ -1,0 +1,62 @@
+name: Dispatch Traceability Jinja Hotfix
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - ".github/workflows/dispatch-traceability-jinja-hotfix.yml"
+
+permissions:
+  contents: write
+  issues: write
+
+jobs:
+  patch-release-hotfix:
+    runs-on: ubuntu-latest
+    timeout-minutes: 12
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: hotfix-traceability-jinja-items
+          fetch-depth: 0
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Patch explicit items-key access and add render regression
+        shell: bash
+        run: |
+          set -euo pipefail
+          python - <<'PY'
+          from pathlib import Path
+          replacements = {
+              Path('src/litoral_trace/templates/traceability.html'): ('{% for item in result.items %}', '{% for item in result["items"] %}'),
+              Path('src/litoral_trace/templates/app/_traceability_lineage_graph.html'): ('{% for item in graph.items %}', '{% for item in graph["items"] %}'),
+          }
+          for path, (old, new) in replacements.items():
+              text = path.read_text(encoding='utf-8')
+              if text.count(old) != 1:
+                  raise SystemExit(f'{path}: expected one items collision')
+              path.write_text(text.replace(old, new), encoding='utf-8')
+
+          Path('tests/test_traceability_jinja_render_regression.py').write_text('''"""Regression for Jinja dict.items collision in traceability rendering."""\nfrom types import SimpleNamespace\nfrom litoral_trace.web.templates import templates\nfrom litoral_trace.web.traceability import build_traceability_view\n\ndef test_traceability_complete_payload_renders_items_list() -> None:\n    payload = {\n        "shipment": {"shipment_code":"SMOKE-RENDER-001","status":"DISPATCHED","lineage_state":"FINAL"},\n        "allocation_method":"PROPORTIONAL_INPUT_ALLOCATION",\n        "complete":True,"issues":[],"unit_totals":[],"items":[],"events":[],"source_lotes":[],\n    }\n    view = build_traceability_view(query="SMOKE-RENDER-001", payload=payload)\n    context = {\n        "traceability_view":view,\n        "user":SimpleNamespace(username="smoke",organization_name="Smoke Org",role="admin"),\n        "navigation":(),"csrf_form_field":"csrf_token","csrf_token":"test-token",\n        "csrf_header_name":"X-CSRF-Token",\n        "url_for":lambda name, **kwargs: f"/static{kwargs.get('path','')}",\n    }\n    rendered = templates.env.get_template("traceability.html").render(context)\n    assert "SMOKE-RENDER-001" in rendered\n    assert "Productos despachados" in rendered\n''', encoding='utf-8')
+          PY
+      - name: Install and run targeted tests
+        run: |
+          python -m pip install --quiet -r requirements.txt
+          python -m pytest -q tests/test_traceability_jinja_render_regression.py tests/test_traceability_p1d_ui_unittest.py tests/test_ux10c_lineage_graph_unittest.py
+      - name: Commit hotfix
+        shell: bash
+        run: |
+          set -euo pipefail
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add src/litoral_trace/templates/traceability.html src/litoral_trace/templates/app/_traceability_lineage_graph.html tests/test_traceability_jinja_render_regression.py
+          git commit -m "fix: render traceability items keys explicitly"
+          git push origin HEAD:hotfix-traceability-jinja-items
+      - name: Report to cutover issue
+        if: always()
+        env:
+          GH_TOKEN: ${{ github.token }}
+          OUTCOME: ${{ job.status }}
+        run: gh issue comment 48 --repo Jose34345/litoral_trace --body "### Traceability Jinja hotfix automation — ${OUTCOME}\n\nPatched and tested explicit access to the traceability \`items\` dictionary key on release hotfix branch when successful."


### PR DESCRIPTION
Operational workflow only. On merge to main it checks out the release hotfix branch, replaces the two colliding Jinja `dict.items` accesses with explicit key access, adds a full-template render regression test, runs targeted P1D/UX10C tests, and pushes the tested hotfix back to `hotfix-traceability-jinja-items`. No product code on main and no database changes.