### PR TITLE
ops: reconcile UX11 legacy contracts

### DIFF
--- a/.github/workflows/reconcile-ux11-contracts-once.yml
+++ b/.github/workflows/reconcile-ux11-contracts-once.yml
@@ -1,0 +1,107 @@
+name: Reconcile UX11 Contracts Once
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - ".github/workflows/reconcile-ux11-contracts-once.yml"
+
+permissions:
+  contents: write
+  issues: write
+
+jobs:
+  reconcile:
+    runs-on: ubuntu-latest
+    timeout-minutes: 8
+    steps:
+      - name: Checkout UX11 branch
+        uses: actions/checkout@v4
+        with:
+          ref: ux11-sidebar-navigation-polish
+          fetch-depth: 0
+
+      - name: Align legacy navigation contracts with UX11
+        shell: bash
+        run: |
+          set -euo pipefail
+          python - <<'PY'
+          from pathlib import Path
+
+          def replace_exact(path: str, old: str, new: str) -> None:
+              p = Path(path)
+              text = p.read_text(encoding="utf-8")
+              count = text.count(old)
+              if count != 1:
+                  raise SystemExit(f"{path}: expected exactly one match, found {count}")
+              p.write_text(text.replace(old, new), encoding="utf-8")
+
+          replace_exact(
+              "tests/test_batch_p24g_ui_unittest.py",
+              '''    assert [(item.key, item.href) for item in superadmin_nav] == [\n        ("dashboard", "/dashboard"),\n        ("imports", "/imports"),\n        ("traceability", "/traceability"),\n        ("release_control", "/release-control"),\n        ("vault", "/vault"),\n        ("settings", "/settings"),\n        ("platform", "/admin"),\n    ]''',
+              '''    assert [(item.key, item.href) for item in superadmin_nav] == [\n        ("dashboard", "/dashboard"),\n        ("operations", "/operations"),\n        ("imports", "/imports"),\n        ("traceability", "/traceability"),\n        ("release_control", "/release-control"),\n        ("evidence", "/evidence"),\n        ("settings", "/settings"),\n        ("platform", "/admin"),\n    ]''',
+          )
+
+          replace_exact(
+              "tests/test_frontend_p2fea_unittest.py",
+              '''    assert [item.key for item in client_nav] == [\n        "dashboard",\n        "traceability",\n        "release_control",\n        "vault",\n    ]''',
+              '''    assert [item.key for item in client_nav] == [\n        "dashboard",\n        "traceability",\n        "release_control",\n        "evidence",\n    ]''',
+          )
+          replace_exact(
+              "tests/test_frontend_p2fea_unittest.py",
+              '''    assert [item.key for item in admin_nav] == [\n        "dashboard",\n        "imports",\n        "traceability",\n        "release_control",\n        "vault",\n        "settings",\n    ]''',
+              '''    assert [item.key for item in admin_nav] == [\n        "dashboard",\n        "operations",\n        "imports",\n        "traceability",\n        "release_control",\n        "evidence",\n        "settings",\n    ]''',
+          )
+          replace_exact(
+              "tests/test_frontend_p2fea_unittest.py",
+              '''    assert [item.key for item in superadmin_nav] == [\n        "dashboard",\n        "imports",\n        "traceability",\n        "release_control",\n        "vault",\n        "settings",\n        "platform",\n    ]''',
+              '''    assert [item.key for item in superadmin_nav] == [\n        "dashboard",\n        "operations",\n        "imports",\n        "traceability",\n        "release_control",\n        "evidence",\n        "settings",\n        "platform",\n    ]''',
+          )
+
+          replace_exact(
+              "tests/test_frontend_p2feb4_unittest.py",
+              '''    ] == [\n        ("dashboard", "/dashboard"),\n        ("imports", "/imports"),\n        ("traceability", "/traceability"),\n        ("release_control", "/release-control"),\n        ("vault", "/vault"),\n        ("settings", "/settings"),\n        ("platform", "/admin"),\n    ]''',
+              '''    ] == [\n        ("dashboard", "/dashboard"),\n        ("operations", "/operations"),\n        ("imports", "/imports"),\n        ("traceability", "/traceability"),\n        ("release_control", "/release-control"),\n        ("evidence", "/evidence"),\n        ("settings", "/settings"),\n        ("platform", "/admin"),\n    ]''',
+          )
+
+          replace_exact(
+              "src/litoral_trace/templates/app/base_app.html",
+              '<div class="shrink-0 border-t border-slate-800 p-3">',
+              '<div class="shrink-0 border-t border-slate-800 p-3" aria-label="Organización y sesión">',
+          )
+          PY
+
+      - name: Run focused navigation and shell tests
+        shell: bash
+        run: |
+          set -euo pipefail
+          python -m pip install --quiet -r requirements.txt pytest
+          python -m pytest -q \
+            tests/test_batch_p24g_ui_unittest.py \
+            tests/test_frontend_p2fea_unittest.py \
+            tests/test_frontend_p2feb32_unittest.py \
+            tests/test_frontend_p2feb4_unittest.py \
+            tests/test_ux11_sidebar_navigation_unittest.py
+
+      - name: Commit reconciled contracts to UX11 branch
+        shell: bash
+        run: |
+          set -euo pipefail
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add \
+            src/litoral_trace/templates/app/base_app.html \
+            tests/test_batch_p24g_ui_unittest.py \
+            tests/test_frontend_p2fea_unittest.py \
+            tests/test_frontend_p2feb4_unittest.py
+          git commit -m "test: align legacy navigation contracts with UX11"
+          git push origin HEAD:ux11-sidebar-navigation-polish
+
+      - name: Report result
+        if: always()
+        env:
+          GH_TOKEN: ${{ github.token }}
+          STATUS: ${{ job.status }}
+        run: |
+          gh issue comment 48 --repo Jose34345/litoral_trace --body "### UX11 legacy contract reconciliation — ${STATUS}\n\nOn success, legacy navigation tests now reflect Operations + contextual Evidence and the compact footer preserves accessible Organization semantics."


### PR DESCRIPTION
Operational workflow only. It checks out PR #61, updates legacy navigation assertions to the intentional UX11 information architecture (Operations + contextual Evidence), preserves `Organización` as accessible footer semantics, runs the focused affected tests, and pushes the reconciled contracts back to the UX11 branch. No production DB/business logic changes.