### PR TITLE
ops: use default GEE project in GitHub worker MVP

### DIFF
--- a/.github/workflows/production-satellite-worker-mvp.yml
+++ b/.github/workflows/production-satellite-worker-mvp.yml
@@ -28,7 +28,9 @@ jobs:
       WORKERS_ENABLED: "1"
       DATABASE_URL: ${{ secrets.LT_PROD_DATABASE_URL }}
       WORKER_DATABASE_URL: ${{ secrets.LT_PROD_WORKER_DATABASE_URL }}
-      GCP_PROJECT_ID: ${{ secrets.LT_GCP_PROJECT_ID }}
+      # Code-level production default; add LT_GCP_PROJECT_ID only if the GEE
+      # project is intentionally moved away from litoral-trace-engine.
+      GCP_PROJECT_ID: ${{ secrets.LT_GCP_PROJECT_ID || 'litoral-trace-engine' }}
       GCP_SERVICE_ACCOUNT: ${{ secrets.LT_GCP_SERVICE_ACCOUNT }}
       SATELLITE_WORKER_ID: gha-${{ github.run_id }}-${{ github.run_attempt }}
       SATELLITE_WORKER_HEARTBEAT_SECONDS: "15"
@@ -46,7 +48,7 @@ jobs:
         run: |
           set -euo pipefail
           missing=0
-          for name in DATABASE_URL WORKER_DATABASE_URL GCP_PROJECT_ID GCP_SERVICE_ACCOUNT; do
+          for name in DATABASE_URL WORKER_DATABASE_URL GCP_SERVICE_ACCOUNT; do
             if [ -z "${!name:-}" ]; then
               missing=1
             fi


### PR DESCRIPTION
Reduces the one-time GitHub secret setup from four values to three. The worker now uses the application code's existing production default GEE project `litoral-trace-engine`, while still allowing an optional `LT_GCP_PROJECT_ID` override later. Required secrets become only the runtime DB URL, dedicated worker DB URL, and GEE service-account JSON.