### PR TITLE
ops: self-trigger GitHub satellite worker workflow changes

### DIFF
--- a/.github/workflows/production-satellite-worker-mvp.yml
+++ b/.github/workflows/production-satellite-worker-mvp.yml
@@ -8,6 +8,11 @@ on:
     # Every 15 minutes, deliberately offset from :00 to reduce scheduler peaks.
     - cron: "7,22,37,52 * * * *"
   workflow_dispatch:
+  push:
+    branches:
+      - main
+    paths:
+      - ".github/workflows/production-satellite-worker-mvp.yml"
 
 permissions:
   contents: read


### PR DESCRIPTION
Adds a narrow push trigger only when the production satellite worker workflow file itself changes on `main`. This lets us validate workflow registration now and, after the three private secrets are added once, trigger the first real worker run automatically with a harmless workflow metadata change. Ordinary application pushes do not run the worker.