### PR TITLE
ops: trigger first production satellite worker run

### DIFF
--- a/.github/workflows/production-satellite-worker-mvp.yml
+++ b/.github/workflows/production-satellite-worker-mvp.yml
@@ -1,5 +1,6 @@
 name: Production Satellite Worker MVP
 
+# Activation marker: production secrets loaded 2026-08-22.
 # Temporary zero-fixed-cost worker topology until the first paying customer.
 # At that commercial trigger, migrate this workload to a persistent Render
 # Background Worker and disable this schedule.


### PR DESCRIPTION
Harmless workflow-comment change used to trigger the first real production GitHub Actions satellite worker after the three required repository secrets were loaded. No application code, schema, or business logic changes.