### PR TITLE
fix: expose src package to GitHub satellite worker

### DIFF
--- a/.github/workflows/production-satellite-worker-mvp.yml
+++ b/.github/workflows/production-satellite-worker-mvp.yml
@@ -32,6 +32,7 @@ jobs:
       ENVIRONMENT: production
       LOG_LEVEL: INFO
       WORKERS_ENABLED: "1"
+      PYTHONPATH: src
       DATABASE_URL: ${{ secrets.LT_PROD_DATABASE_URL }}
       WORKER_DATABASE_URL: ${{ secrets.LT_PROD_WORKER_DATABASE_URL }}
       # Code-level production default; add LT_GCP_PROJECT_ID only if the GEE


### PR DESCRIPTION
Fixes the first production worker run failure (`ModuleNotFoundError: litoral_trace`) by exporting `PYTHONPATH=src` in the GitHub Actions worker job. The first run already verified all three secrets and the queue capability, and failed before claiming the job. No application code, schema, or queue mutation changes.