### PR TITLE
ops: apply tested same-day NDVI persistence hotfix

### DIFF
--- a/.github/workflows/apply-satellite-sameday-upsert-hotfix.yml
+++ b/.github/workflows/apply-satellite-sameday-upsert-hotfix.yml
@@ -1,0 +1,81 @@
+name: Apply Satellite Same-Day Upsert Hotfix
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - ".github/workflows/apply-satellite-sameday-upsert-hotfix.yml"
+
+permissions:
+  contents: write
+  issues: write
+
+jobs:
+  patch-test-push:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: hotfix-satellite-sameday-upsert
+          fetch-depth: 0
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Patch canonical NDVI in-memory upsert and add regression
+        shell: bash
+        run: |
+          set -euo pipefail
+          python - <<'PY'
+          from pathlib import Path
+
+          source = Path('src/litoral_trace/services/satellite_ndvi_processing.py')
+          text = source.read_text(encoding='utf-8')
+          old = '''    for observation in result.observations:\n        existing_row = existing_rows.get(\n            (observation.observation_date, observation.geometry_hash)\n        )\n        if existing_row is None:\n'''
+          new = '''    for observation in result.observations:\n        observation_key = (\n            observation.observation_date,\n            observation.geometry_hash,\n        )\n        existing_row = existing_rows.get(observation_key)\n        if existing_row is None:\n'''
+          if text.count(old) != 1:
+              raise SystemExit(f'expected one observation lookup block, found {text.count(old)}')
+          text = text.replace(old, new)
+
+          old_add = '''            db_session.add(existing_row)\n            continue\n'''
+          new_add = '''            db_session.add(existing_row)\n            # Keep the identity map in sync with pending ORM inserts. GEE can\n            # return multiple Sentinel-2 scenes for the same calendar day; the\n            # canonical table intentionally has one row per date+geometry.\n            # Subsequent same-day observations therefore update this pending\n            # row instead of scheduling a duplicate INSERT.\n            existing_rows[observation_key] = existing_row\n            continue\n'''
+          if text.count(old_add) != 1:
+              raise SystemExit(f'expected one pending add block, found {text.count(old_add)}')
+          source.write_text(text.replace(old_add, new_add), encoding='utf-8')
+
+          test_path = Path('tests/test_satellite_job_results_p22e1_unittest.py')
+          test_text = test_path.read_text(encoding='utf-8')
+          anchor = '''\ndef test_sqlite_metadata_create_all_supports_satellite_job_results():\n'''
+          regression = '''\ndef test_canonical_ndvi_persistence_upserts_duplicate_same_day_scene_in_memory():\n    fixture = _create_result_fixture()\n    observation_date = date(2026, 8, 1)\n    first = NdviObservationRecord(\n        observation_date=observation_date,\n        ndvi_mean=0.61,\n        ndvi_min=0.55,\n        ndvi_max=0.68,\n        ndvi_std=0.03,\n        scene_cloud_percentage=5.0,\n        valid_pixel_count=10,\n        valid_pixel_percentage=98.0,\n        satellite="Sentinel-2",\n        collection="COPERNICUS/S2_SR_HARMONIZED",\n        geometry_hash=fixture.geometry_hash,\n        algorithm_version=fixture.algorithm_version,\n        processing_date=datetime(2026, 8, 1, 12, 0, tzinfo=timezone.utc),\n    )\n    second = NdviObservationRecord(\n        observation_date=observation_date,\n        ndvi_mean=0.72,\n        ndvi_min=0.60,\n        ndvi_max=0.81,\n        ndvi_std=0.04,\n        scene_cloud_percentage=2.0,\n        valid_pixel_count=12,\n        valid_pixel_percentage=99.0,\n        satellite="Sentinel-2",\n        collection="COPERNICUS/S2_SR_HARMONIZED",\n        geometry_hash=fixture.geometry_hash,\n        algorithm_version=fixture.algorithm_version,\n        processing_date=datetime(2026, 8, 1, 12, 5, tzinfo=timezone.utc),\n    )\n    result = NormalizedNdviExecutionResult(\n        geometry_hash=fixture.geometry_hash,\n        algorithm_version=fixture.algorithm_version,\n        observations=(first, second),\n    )\n\n    session = get_db_session()\n    persisted = persist_ndvi_execution_result(\n        session,\n        organization_id=fixture.organization_id,\n        lote_id=fixture.lote_id,\n        satellite_job_id=fixture.job_id,\n        result=result,\n    )\n    session.commit()\n\n    rows = session.execute(\n        select(SatelliteNdviObservation).where(\n            SatelliteNdviObservation.satellite_job_id == fixture.job_id,\n            SatelliteNdviObservation.observation_date == observation_date,\n            SatelliteNdviObservation.geometry_hash == fixture.geometry_hash,\n        )\n    ).scalars().all()\n    session.close()\n\n    assert persisted.observation_count == 2\n    assert len(rows) == 1\n    # Existing persistence semantics are iteration-authoritative: the later\n    # scene updates the one canonical daily row instead of duplicating it.\n    assert rows[0].ndvi_mean == pytest.approx(0.72)\n    assert rows[0].cloud_percentage == pytest.approx(2.0)\n    assert rows[0].valid_pixel_percentage == pytest.approx(99.0)\n\n'''
+          if anchor not in test_text:
+              raise SystemExit('test insertion anchor not found')
+          if 'test_canonical_ndvi_persistence_upserts_duplicate_same_day_scene_in_memory' not in test_text:
+              test_path.write_text(test_text.replace(anchor, regression + anchor), encoding='utf-8')
+          PY
+      - name: Install dependencies
+        run: python -m pip install --disable-pip-version-check --quiet -r requirements.txt
+      - name: Run satellite persistence regression and worker unit gates
+        run: |
+          python -m pytest -q \
+            tests/test_satellite_job_results_p22e1_unittest.py \
+            tests/test_satellite_worker_p22c_unittest.py \
+            tests/test_satellite_worker_p22d1_unittest.py \
+            tests/test_satellite_worker_p22d2_unittest.py \
+            tests/test_satellite_worker_p22d3_unittest.py \
+            tests/test_satellite_worker_p22d4_unittest.py
+      - name: Commit tested hotfix to release branch
+        shell: bash
+        run: |
+          set -euo pipefail
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add src/litoral_trace/services/satellite_ndvi_processing.py tests/test_satellite_job_results_p22e1_unittest.py
+          git commit -m "fix: upsert duplicate same-day NDVI observations"
+          git push origin HEAD:hotfix-satellite-sameday-upsert
+      - name: Report result to cutover issue
+        if: always()
+        env:
+          GH_TOKEN: ${{ github.token }}
+          OUTCOME: ${{ job.status }}
+        run: gh issue comment 48 --repo "$GITHUB_REPOSITORY" --body "### Same-day NDVI persistence hotfix automation — ${OUTCOME}\n\nPatched and tested the canonical daily observation upsert on branch \`hotfix-satellite-sameday-upsert\` when successful. No production queue mutation is performed by this workflow."


### PR DESCRIPTION
Operational one-shot patcher. It checks out `hotfix-satellite-sameday-upsert`, fixes the pending ORM identity-map bug that schedules duplicate inserts when GEE returns multiple scenes on the same date, adds a regression, runs the satellite persistence/worker unit gates, and pushes the tested result back to the hotfix branch. It does not mutate the production satellite queue.