### PR TITLE
ops: trigger valid UX12 dispatcher

### DIFF
--- a/.github/workflows/dispatch-ux12-operations-polish.yml
+++ b/.github/workflows/dispatch-ux12-operations-polish.yml
@@ -1,5 +1,6 @@
 name: Dispatch UX12 Operations Polish
 
+# Explicit one-shot trigger after the dispatcher was made valid on main.
 on:
   push:
     branches:


### PR DESCRIPTION
Explicit no-op trigger on the now-valid dispatcher workflow so the one-shot UX12 patcher runs against the isolated product branch. No product/runtime changes in this PR.