### PR TITLE
ops: trigger UX12 clear-selection workflow

### DIFF
--- a/.github/workflows/dispatch-ux12-clear-selection-fix.yml
+++ b/.github/workflows/dispatch-ux12-clear-selection-fix.yml
@@ -1,5 +1,6 @@
 name: Dispatch UX12 Clear Selection Fix
 
+# Explicit one-shot trigger after workflow registration on main.
 on:
   push:
     branches:


### PR DESCRIPTION
Explicit no-op trigger now that the clear-selection workflow is registered on `main`. This should push only the tested PR #85 follow-up to the isolated UX12 branch.