### PR TITLE
ops: trigger fresh P1-A recovery gate

### DIFF
--- a/.github/workflows/postgres-logical-backup.yml
+++ b/.github/workflows/postgres-logical-backup.yml
@@ -1,3 +1,4 @@
+# Audit trigger: fresh P1-A pre-cutover recovery point (2026-08-23 UTC)
 name: PostgreSQL Logical Backup
 
 on:


### PR DESCRIPTION
Comment-only audit trigger for the current PostgreSQL Logical Backup workflow. No workflow semantics, application code, database schema, secrets, or production data are changed. Merge to `main` intentionally triggers the existing fail-closed backup → S3 publication → exact complete.json retrieval → P2.7A5 recovery gate and sanitized issue #48 report.