### PR TITLE
ops: trigger registered P1-A production smoke

### DIFF
--- a/.github/workflows/p1a-production-public-smoke-once.yml
+++ b/.github/workflows/p1a-production-public-smoke-once.yml
@@ -1,3 +1,4 @@
+# One-shot trigger after workflow registration on main.
 name: P1-A Production Public Smoke Once
 
 on:


### PR DESCRIPTION
No-op workflow comment change to trigger the already registered P1-A production public smoke on `main`. No product/runtime/database changes.