### PR TITLE
fix: wire P1-A routes into Render production entrypoint

### DIFF
--- a/render_entrypoint.py
+++ b/render_entrypoint.py
@@ -4,6 +4,11 @@ The canonical production topology exposes ``/internal/metrics`` only on the
 private service network and blocks ``/internal/*`` at Nginx. Render's direct
 Web Service ingress does not have that Nginx boundary, so this wrapper applies
 the same public-ingress invariant before delegating to the FastAPI app.
+
+P1-A integration routers are registered here explicitly because Render uses
+this entrypoint as its production boundary. This keeps the cutover narrow while
+ensuring the integration API and server-rendered workspace are actually
+reachable in the deployed application.
 """
 from __future__ import annotations
 
@@ -13,6 +18,15 @@ from typing import Any
 from starlette.responses import Response
 
 from main import app as fastapi_app
+from litoral_trace.api.integrations import router as integrations_api_router
+from litoral_trace.web.integrations import router as integrations_web_router
+
+
+# FastAPI snapshots APIRouter routes when ``include_router`` is called. Register
+# P1-A before wrapping the app so both REST and browser surfaces are present on
+# the exact FastAPI instance delegated to by Render.
+fastapi_app.include_router(integrations_api_router)
+fastapi_app.include_router(integrations_web_router)
 
 
 ASGIReceive = Callable[[], Awaitable[dict[str, Any]]]

--- a/tests/test_p1a_render_route_wiring_unittest.py
+++ b/tests/test_p1a_render_route_wiring_unittest.py
@@ -1,0 +1,26 @@
+"""Regression gate for P1-A route registration on the Render entrypoint."""
+from __future__ import annotations
+
+
+def test_render_entrypoint_registers_p1a_api_and_web_routes() -> None:
+    from render_entrypoint import fastapi_app
+
+    route_methods = {
+        (route.path, method)
+        for route in fastapi_app.routes
+        if hasattr(route, "path")
+        for method in getattr(route, "methods", set())
+    }
+
+    expected = {
+        ("/integrations", "GET"),
+        ("/integrations/connections", "POST"),
+        ("/integrations/sync-json", "POST"),
+        ("/api/v1/integrations/connections", "GET"),
+        ("/api/v1/integrations/connections", "POST"),
+        ("/api/v1/integrations/entities", "GET"),
+        ("/api/v1/integrations/sync-runs", "GET"),
+    }
+
+    missing = expected - route_methods
+    assert not missing, f"P1-A Render routes are not registered: {sorted(missing)}"

--- a/tests/test_p1a_render_route_wiring_unittest.py
+++ b/tests/test_p1a_render_route_wiring_unittest.py
@@ -1,26 +1,60 @@
 """Regression gate for P1-A route registration on the Render entrypoint."""
 from __future__ import annotations
 
+import subprocess
+import sys
+from pathlib import Path
+
 
 def test_render_entrypoint_registers_p1a_api_and_web_routes() -> None:
-    from render_entrypoint import fastapi_app
+    """Validate the production import path in a clean interpreter.
 
-    route_methods = {
-        (route.path, method)
-        for route in fastapi_app.routes
-        if hasattr(route, "path")
-        for method in getattr(route, "methods", set())
-    }
+    The full unit suite intentionally imports and reconstructs application
+    modules in several tests. Inspecting a cached ``render_entrypoint`` object
+    in that shared interpreter can therefore observe a stale FastAPI instance.
+    A fresh subprocess matches how Render starts the service and keeps this
+    release gate independent from pytest module-order side effects.
+    """
 
-    expected = {
-        ("/integrations", "GET"),
-        ("/integrations/connections", "POST"),
-        ("/integrations/sync-json", "POST"),
-        ("/api/v1/integrations/connections", "GET"),
-        ("/api/v1/integrations/connections", "POST"),
-        ("/api/v1/integrations/entities", "GET"),
-        ("/api/v1/integrations/sync-runs", "GET"),
-    }
+    root = Path(__file__).resolve().parents[1]
+    probe = r'''
+from render_entrypoint import fastapi_app
 
-    missing = expected - route_methods
-    assert not missing, f"P1-A Render routes are not registered: {sorted(missing)}"
+route_methods = {
+    (route.path, method)
+    for route in fastapi_app.routes
+    if hasattr(route, "path")
+    for method in getattr(route, "methods", set())
+}
+
+expected = {
+    ("/integrations", "GET"),
+    ("/integrations/connections", "POST"),
+    ("/integrations/sync-json", "POST"),
+    ("/api/v1/integrations/connections", "GET"),
+    ("/api/v1/integrations/connections", "POST"),
+    ("/api/v1/integrations/entities", "GET"),
+    ("/api/v1/integrations/sync-runs", "GET"),
+}
+
+missing = expected - route_methods
+if missing:
+    raise SystemExit(
+        "P1-A Render routes are not registered: " + repr(sorted(missing))
+    )
+'''
+
+    result = subprocess.run(
+        [sys.executable, "-c", probe],
+        cwd=root,
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=30,
+    )
+
+    assert result.returncode == 0, (
+        result.stderr.strip()
+        or result.stdout.strip()
+        or "Render P1-A route probe failed without diagnostic output."
+    )


### PR DESCRIPTION
Closed after release-path verification. P1-A was already correctly composed through `src/litoral_trace/api/traceability.py`, whose parent router includes both `integrations_api_router` and `integrations_web_router`, and `main.py` registers that parent router. The apparent missing-route signal came from inspecting `app.routes` as a flat list; FastAPI >=0.137 represents included routers as a nested/live route tree. This proposed Render-only registration would therefore duplicate P1-A routes and produced Duplicate Operation ID warnings. No part of this PR was merged into `p2-enterprise-production`.