### PR TITLE
ops: trigger registered P1-A authenticated smoke

### DIFF
--- a/.github/workflows/p1a-production-authenticated-smoke-once.yml
+++ b/.github/workflows/p1a-production-authenticated-smoke-once.yml
@@ -1,3 +1,4 @@
+# One-shot trigger after workflow registration on main.
 name: P1-A Production Authenticated Smoke Once
 
 on:
@@ -202,9 +203,6 @@ jobs:
                   expect_json_list(auditor_session, path, 200)
               results["api_auditor"] = "200"
 
-              # Auditor has READ but not MANAGE. Use the HTML manage endpoint because
-              # authorization is evaluated before the mutation/CSRF path, guaranteeing
-              # that this denial cannot create an integration connection.
               denied = auditor_session.post(
                   BASE + "/integrations/connections",
                   data={"name": f"must-not-exist-{RUN}"},


### PR DESCRIPTION
No-op comment-only workflow change to trigger the already registered authenticated P1-A production acceptance gate on `main`. No product/runtime/database logic changes.