### PR TITLE
P1-B: Corrientes + ARCA shipment export case

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,7 @@ jobs:
             echo "Expected exactly one Alembic head."
             exit 1
           fi
-          grep -Fx "022_add_integration_history (head)" alembic-heads.txt
+          grep -Fx "023_add_shipment_export_cases (head)" alembic-heads.txt
 
       - name: Run pytest suite
         run: python -m pytest -q -rs

--- a/.github/workflows/p1a-integration-core-postgres-gate.yml
+++ b/.github/workflows/p1a-integration-core-postgres-gate.yml
@@ -108,8 +108,11 @@ jobs:
           engine.dispose()
           PY
 
-      - name: Migrate database to P1-A canonical head
-        run: python -m alembic upgrade head
+      # Keep the P1-A regression pinned to the schema it owns. Later feature
+      # gates validate newer Alembic heads independently, avoiding a false red
+      # when an additive downstream migration is introduced.
+      - name: Migrate database to P1-A canonical revision
+        run: python -m alembic upgrade 022_add_integration_history
 
       - name: Provision existing-domain read contract and worker capability
         shell: bash

--- a/.github/workflows/p1b-export-case-postgres-gate.yml
+++ b/.github/workflows/p1b-export-case-postgres-gate.yml
@@ -1,0 +1,142 @@
+name: P1-B Corrientes ARCA PostgreSQL Gate
+
+on:
+  pull_request:
+    branches:
+      - p2-enterprise-production
+  push:
+    branches:
+      - p2-enterprise-production
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: p1b-export-case-postgres-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  p1b-export-case-postgres:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    services:
+      postgres:
+        image: postgis/postgis:17-3.5
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: p1b_owner_password_2026
+          POSTGRES_DB: litoral_trace_p1b_ci
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U postgres -d litoral_trace_p1b_ci"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 20
+
+    env:
+      ENVIRONMENT: development
+      ENABLE_POSTGRES_TESTS: "1"
+      JWT_SECRET_KEY: p1b-ci-only-jwt-secret-key-2026
+      LITORAL_TRACE_BOOTSTRAP_SUPERADMIN_PASSWORD: P1bCiBootstrapPassword2026
+      TEST_POSTGRES_MIGRATION_DATABASE_URL: postgresql+psycopg://postgres:p1b_owner_password_2026@127.0.0.1:5432/litoral_trace_p1b_ci
+      MIGRATION_DATABASE_URL: postgresql+psycopg://postgres:p1b_owner_password_2026@127.0.0.1:5432/litoral_trace_p1b_ci
+      TEST_POSTGRES_DATABASE_URL: postgresql+psycopg://litoral_trace_app:p1b_runtime_password_2026@127.0.0.1:5432/litoral_trace_p1b_ci
+      DATABASE_URL: postgresql+psycopg://litoral_trace_app:p1b_runtime_password_2026@127.0.0.1:5432/litoral_trace_p1b_ci
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: pip
+          cache-dependency-path: requirements.txt
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -r requirements.txt pytest alembic
+
+      - name: Provision runtime principal
+        shell: bash
+        run: |
+          python - <<'PY'
+          import os
+          from sqlalchemy import create_engine
+
+          engine = create_engine(
+              os.environ["TEST_POSTGRES_MIGRATION_DATABASE_URL"],
+              isolation_level="AUTOCOMMIT",
+              pool_pre_ping=True,
+              hide_parameters=True,
+          )
+          statements = [
+              """
+              CREATE ROLE litoral_trace_app
+                LOGIN
+                PASSWORD 'p1b_runtime_password_2026'
+                NOSUPERUSER
+                NOCREATEDB
+                NOCREATEROLE
+                NOINHERIT
+                NOBYPASSRLS
+              """,
+              "GRANT CONNECT ON DATABASE litoral_trace_p1b_ci TO litoral_trace_app",
+              "GRANT USAGE ON SCHEMA public TO litoral_trace_app",
+          ]
+          with engine.connect() as connection:
+              for statement in statements:
+                  connection.exec_driver_sql(statement)
+          engine.dispose()
+          PY
+
+      - name: Migrate database to P1-B canonical head
+        run: python -m alembic upgrade head
+
+      - name: Verify canonical revision
+        shell: bash
+        run: |
+          set -euo pipefail
+          python -m alembic current | tee p1b-alembic-current.txt
+          grep -F "023_add_shipment_export_cases" p1b-alembic-current.txt
+
+      - name: Write isolated runtime contract
+        shell: bash
+        run: |
+          cat > .env.integration <<'EOF'
+          ENABLE_POSTGRES_TESTS=1
+          TEST_POSTGRES_DATABASE_URL=postgresql+psycopg://litoral_trace_app:p1b_runtime_password_2026@127.0.0.1:5432/litoral_trace_p1b_ci
+          TEST_POSTGRES_MIGRATION_DATABASE_URL=postgresql+psycopg://postgres:p1b_owner_password_2026@127.0.0.1:5432/litoral_trace_p1b_ci
+          EOF
+
+      - name: Gate P1-B - readiness, tenant isolation and least privilege
+        shell: bash
+        run: |
+          set -euo pipefail
+          python -m pytest -q -rs \
+            tests/test_shipment_export_case_p1b_postgres_integration.py \
+            --junitxml=p1b-export-case-postgres.xml
+          python - <<'PY'
+          import xml.etree.ElementTree as ET
+
+          root = ET.parse("p1b-export-case-postgres.xml").getroot()
+          suites = [root] if root.tag == "testsuite" else list(root.iter("testsuite"))
+          tests = sum(int(s.attrib.get("tests", "0")) for s in suites)
+          skipped = sum(int(s.attrib.get("skipped", "0")) for s in suites)
+          failures = sum(int(s.attrib.get("failures", "0")) for s in suites)
+          errors = sum(int(s.attrib.get("errors", "0")) for s in suites)
+          if tests != 1 or skipped or failures or errors:
+              raise SystemExit(
+                  "P1-B PostgreSQL gate fails closed: "
+                  f"tests={tests}, skipped={skipped}, failures={failures}, errors={errors}"
+              )
+          PY
+
+      - name: Cleanup isolated contract
+        if: always()
+        run: rm -f .env.integration

--- a/.github/workflows/release-integration-gates.yml
+++ b/.github/workflows/release-integration-gates.yml
@@ -374,7 +374,7 @@ jobs:
         run: |
           set -euo pipefail
           python -m alembic current | tee alembic-current.txt
-          grep -F "022_add_integration_history" alembic-current.txt
+          grep -F "023_add_shipment_export_cases" alembic-current.txt
 
       - name: Cleanup ephemeral integration files and MinIO
         if: always()

--- a/.github/workflows/ux10g-postgres-web-stabilization-gate.yml
+++ b/.github/workflows/ux10g-postgres-web-stabilization-gate.yml
@@ -143,7 +143,7 @@ jobs:
         run: |
           set -euo pipefail
           python -m alembic current | tee alembic-current.txt
-          grep -F "022_add_integration_history" alembic-current.txt
+          grep -F "023_add_shipment_export_cases" alembic-current.txt
 
       - name: Auth RLS login preflight
         shell: bash

--- a/.github/workflows/v1-final-release-acceptance.yml
+++ b/.github/workflows/v1-final-release-acceptance.yml
@@ -153,7 +153,7 @@ jobs:
         run: |
           set -euo pipefail
           python -m alembic current | tee v1-final-alembic-current.txt
-          grep -F "022_add_integration_history" v1-final-alembic-current.txt
+          grep -F "023_add_shipment_export_cases" v1-final-alembic-current.txt
 
       - name: Gate 39 - final browser staging sign-off
         shell: bash

--- a/alembic/versions/023_add_shipment_export_cases.py
+++ b/alembic/versions/023_add_shipment_export_cases.py
@@ -1,0 +1,169 @@
+"""Add shipment export cases and Corrientes fruit-guide evidence type.
+
+Revision ID: 023_add_shipment_export_cases
+Revises: 022_add_integration_history
+Create Date: 2026-08-22 22:30:00.000000
+"""
+from __future__ import annotations
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+revision: str = "023_add_shipment_export_cases"
+down_revision: Union[str, Sequence[str], None] = "022_add_integration_history"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+RUNTIME_ROLE = "litoral_trace_app"
+WORKER_EXECUTOR_ROLE = "litoral_trace_worker_executor"
+TENANT_CONTEXT_SQL = "NULLIF(current_setting('app.current_organization_id', true), '')::integer"
+TABLE = "shipment_export_cases"
+EVIDENCE_TABLE = "traceability_evidence_links"
+EVIDENCE_CHECK = "ck_traceability_evidence_links_type"
+
+
+def _evidence_constraint(types: str) -> str:
+    return f"evidence_type IN ({types})"
+
+
+def upgrade() -> None:
+    op.create_table(
+        TABLE,
+        sa.Column("id", sa.Integer(), autoincrement=True, nullable=False),
+        sa.Column(
+            "public_id",
+            sa.Uuid(),
+            nullable=False,
+            server_default=sa.text("gen_random_uuid()"),
+        ),
+        sa.Column("organization_id", sa.Integer(), nullable=False),
+        sa.Column("shipment_id", sa.Integer(), nullable=False),
+        sa.Column("origin_profile", sa.String(length=24), nullable=False),
+        sa.Column("export_invoice_number", sa.String(length=80), nullable=True),
+        sa.Column("export_invoice_cae", sa.String(length=32), nullable=True),
+        sa.Column("customs_destination_id", sa.String(length=64), nullable=True),
+        sa.Column("customs_subregime", sa.String(length=16), nullable=True),
+        sa.Column("customs_officialized_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("notes", sa.Text(), nullable=True),
+        sa.Column("created_by_user_id", sa.Integer(), nullable=True),
+        sa.Column("updated_by_user_id", sa.Integer(), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("CURRENT_TIMESTAMP"),
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("CURRENT_TIMESTAMP"),
+        ),
+        sa.PrimaryKeyConstraint("id", name="pk_shipment_export_cases"),
+        sa.UniqueConstraint("id", "organization_id", name="uq_shipment_export_cases_id_org"),
+        sa.UniqueConstraint("public_id", name="uq_shipment_export_cases_public_id"),
+        sa.UniqueConstraint("shipment_id", name="uq_shipment_export_cases_shipment_id"),
+        sa.ForeignKeyConstraint(
+            ["organization_id"],
+            ["organizations.id"],
+            name="fk_shipment_export_cases_organization_id",
+            ondelete="RESTRICT",
+        ),
+        sa.ForeignKeyConstraint(
+            ["shipment_id", "organization_id"],
+            ["shipments.id", "shipments.organization_id"],
+            name="fk_shipment_export_cases_shipment_tenant",
+            ondelete="RESTRICT",
+        ),
+        sa.ForeignKeyConstraint(
+            ["created_by_user_id"],
+            ["users.id"],
+            name="fk_shipment_export_cases_created_by_user_id",
+            ondelete="SET NULL",
+        ),
+        sa.ForeignKeyConstraint(
+            ["updated_by_user_id"],
+            ["users.id"],
+            name="fk_shipment_export_cases_updated_by_user_id",
+            ondelete="SET NULL",
+        ),
+        sa.CheckConstraint(
+            "origin_profile IN ('CULTIVATED','NATIVE')",
+            name="ck_shipment_export_cases_origin_profile",
+        ),
+    )
+    op.create_index(
+        "ix_shipment_export_cases_tenant_shipment",
+        TABLE,
+        ["organization_id", "shipment_id"],
+    )
+    op.create_index(
+        "ix_shipment_export_cases_tenant_customs_destination",
+        TABLE,
+        ["organization_id", "customs_destination_id"],
+    )
+
+    tenant_match = f"organization_id = {TENANT_CONTEXT_SQL}"
+    op.execute(f"ALTER TABLE public.{TABLE} ENABLE ROW LEVEL SECURITY")
+    op.execute(f"ALTER TABLE public.{TABLE} FORCE ROW LEVEL SECURITY")
+    op.execute(
+        f"CREATE POLICY {TABLE}_tenant_select ON public.{TABLE} "
+        f"FOR SELECT USING ({tenant_match})"
+    )
+    op.execute(
+        f"CREATE POLICY {TABLE}_tenant_insert ON public.{TABLE} "
+        f"FOR INSERT WITH CHECK ({tenant_match})"
+    )
+    op.execute(
+        f"CREATE POLICY {TABLE}_tenant_update ON public.{TABLE} "
+        f"FOR UPDATE USING ({tenant_match}) WITH CHECK ({tenant_match})"
+    )
+
+    op.execute(f"REVOKE ALL PRIVILEGES ON TABLE public.{TABLE} FROM PUBLIC")
+    op.execute(f"REVOKE ALL PRIVILEGES ON SEQUENCE public.{TABLE}_id_seq FROM PUBLIC")
+    op.execute(f"GRANT SELECT, INSERT, UPDATE ON TABLE public.{TABLE} TO {RUNTIME_ROLE}")
+    op.execute(f"GRANT USAGE, SELECT ON SEQUENCE public.{TABLE}_id_seq TO {RUNTIME_ROLE}")
+    op.execute(f"REVOKE ALL PRIVILEGES ON TABLE public.{TABLE} FROM {WORKER_EXECUTOR_ROLE}")
+    op.execute(f"REVOKE ALL PRIVILEGES ON SEQUENCE public.{TABLE}_id_seq FROM {WORKER_EXECUTOR_ROLE}")
+
+    # Corrientes distinguishes Guía de Frutos (cultivated forest products) from
+    # Guía Forestal/Vale used for native-forest transport, so evidence needs a
+    # separate semantic type instead of overloading FOREST_GUIDE.
+    op.drop_constraint(EVIDENCE_CHECK, EVIDENCE_TABLE, type_="check")
+    op.create_check_constraint(
+        EVIDENCE_CHECK,
+        EVIDENCE_TABLE,
+        _evidence_constraint(
+            "'ORIGIN_AUTHORIZATION','FOREST_GUIDE','FRUIT_GUIDE','REMITO','INVOICE',"
+            "'CERTIFICATE','TRANSPORT','GEOSPATIAL','SUPPLIER_DECLARATION','OTHER'"
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.execute(
+        "UPDATE public.traceability_evidence_links "
+        "SET evidence_type = 'OTHER' WHERE evidence_type = 'FRUIT_GUIDE'"
+    )
+    op.drop_constraint(EVIDENCE_CHECK, EVIDENCE_TABLE, type_="check")
+    op.create_check_constraint(
+        EVIDENCE_CHECK,
+        EVIDENCE_TABLE,
+        _evidence_constraint(
+            "'ORIGIN_AUTHORIZATION','FOREST_GUIDE','REMITO','INVOICE','CERTIFICATE',"
+            "'TRANSPORT','GEOSPATIAL','SUPPLIER_DECLARATION','OTHER'"
+        ),
+    )
+
+    op.execute(f"REVOKE USAGE, SELECT ON SEQUENCE public.{TABLE}_id_seq FROM {RUNTIME_ROLE}")
+    op.execute(f"REVOKE SELECT, INSERT, UPDATE ON TABLE public.{TABLE} FROM {RUNTIME_ROLE}")
+    op.execute(f"DROP POLICY IF EXISTS {TABLE}_tenant_update ON public.{TABLE}")
+    op.execute(f"DROP POLICY IF EXISTS {TABLE}_tenant_insert ON public.{TABLE}")
+    op.execute(f"DROP POLICY IF EXISTS {TABLE}_tenant_select ON public.{TABLE}")
+    op.execute(f"ALTER TABLE public.{TABLE} NO FORCE ROW LEVEL SECURITY")
+    op.execute(f"ALTER TABLE public.{TABLE} DISABLE ROW LEVEL SECURITY")
+    op.drop_index("ix_shipment_export_cases_tenant_customs_destination", table_name=TABLE)
+    op.drop_index("ix_shipment_export_cases_tenant_shipment", table_name=TABLE)
+    op.drop_table(TABLE)

--- a/src/litoral_trace/api/shipment_export_case.py
+++ b/src/litoral_trace/api/shipment_export_case.py
@@ -1,0 +1,166 @@
+"""Tenant-scoped Corrientes + ARCA shipment export-case API."""
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from pydantic import BaseModel, Field
+
+from litoral_trace.api.auth import UserTenantContext
+from litoral_trace.auth.rbac import Permission, require_permission
+from litoral_trace.db.tenant import get_tenant_scoped_db_session
+from litoral_trace.services.shipment_export_case import (
+    ShipmentExportCaseNotFoundError,
+    ShipmentExportCasePersistenceError,
+    ShipmentExportCaseService,
+    ShipmentExportCaseValidationError,
+)
+
+
+router = APIRouter(prefix="/api/v1/export-cases", tags=["Expediente Exportador"])
+
+
+class ShipmentExportCaseRequest(BaseModel):
+    origin_profile: str
+    export_invoice_number: str | None = Field(default=None, max_length=80)
+    export_invoice_cae: str | None = Field(default=None, max_length=32)
+    customs_destination_id: str | None = Field(default=None, max_length=64)
+    customs_subregime: str | None = Field(default=None, max_length=16)
+    customs_officialized_at: datetime | None = None
+    notes: str | None = Field(default=None, max_length=2000)
+
+
+def _service(user: UserTenantContext):
+    session = get_tenant_scoped_db_session(user.organization_id)
+    if session is None:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail={
+                "code": "EXPORT_CASE_UNAVAILABLE",
+                "message": "La base de datos no está disponible temporalmente.",
+            },
+        )
+    return session, ShipmentExportCaseService(
+        session=session,
+        organization_id=user.organization_id,
+    )
+
+
+def _raise_service_error(exc: Exception) -> None:
+    if isinstance(exc, ShipmentExportCaseValidationError):
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
+            detail={"code": exc.code, "message": exc.detail},
+        ) from None
+    if isinstance(exc, ShipmentExportCaseNotFoundError):
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail={"code": "SHIPMENT_NOT_FOUND", "message": str(exc)},
+        ) from None
+    if isinstance(exc, ShipmentExportCasePersistenceError):
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail={"code": "EXPORT_CASE_UNAVAILABLE", "message": str(exc)},
+        ) from None
+    raise exc
+
+
+def _case_payload(row) -> dict[str, Any]:
+    return {
+        "public_id": str(row.public_id),
+        "shipment_public_id": str(row.shipment_public_id),
+        "shipment_code": row.shipment_code,
+        "origin_profile": row.origin_profile,
+        "export_invoice_number": row.export_invoice_number,
+        "export_invoice_cae": row.export_invoice_cae,
+        "customs_destination_id": row.customs_destination_id,
+        "customs_subregime": row.customs_subregime,
+        "customs_officialized_at": (
+            row.customs_officialized_at.isoformat()
+            if row.customs_officialized_at
+            else None
+        ),
+        "notes": row.notes,
+        "created_at": row.created_at.isoformat(),
+        "updated_at": row.updated_at.isoformat(),
+    }
+
+
+def _readiness_payload(row) -> dict[str, Any]:
+    return {
+        "shipment_public_id": str(row.shipment_public_id),
+        "shipment_code": row.shipment_code,
+        "state": row.state,
+        "ready": row.ready,
+        "origin_profile": row.origin_profile,
+        "missing": list(row.missing),
+        "evidence_types": list(row.evidence_types),
+        "requirements": [
+            {
+                "key": item.key,
+                "label": item.label,
+                "satisfied": item.satisfied,
+                "source": item.source,
+            }
+            for item in row.requirements
+        ],
+        "export_case": _case_payload(row.export_case) if row.export_case else None,
+        "ledger_mutated": False,
+    }
+
+
+@router.get("/{shipment_code}")
+def get_export_case_readiness(
+    shipment_code: str,
+    user: UserTenantContext = Depends(require_permission(Permission.LOTE_READ)),
+) -> dict[str, Any]:
+    session, service = _service(user)
+    try:
+        try:
+            return _readiness_payload(service.readiness(shipment_code))
+        except Exception as exc:
+            _raise_service_error(exc)
+            raise
+    finally:
+        session.close()
+
+
+@router.put("/{shipment_code}")
+def upsert_export_case(
+    shipment_code: str,
+    body: ShipmentExportCaseRequest,
+    user: UserTenantContext = Depends(
+        require_permission(Permission.TRACEABILITY_EVIDENCE)
+    ),
+) -> dict[str, Any]:
+    session, service = _service(user)
+    try:
+        try:
+            row = service.upsert_case(
+                shipment_code=shipment_code,
+                origin_profile=body.origin_profile,
+                export_invoice_number=body.export_invoice_number,
+                export_invoice_cae=body.export_invoice_cae,
+                customs_destination_id=body.customs_destination_id,
+                customs_subregime=body.customs_subregime,
+                customs_officialized_at=body.customs_officialized_at,
+                notes=body.notes,
+                actor_user_id=user.user_id,
+            )
+            # Re-apply tenant context because commit closes the transaction-local
+            # GUC used by FORCE RLS before the readiness query starts.
+            from litoral_trace.db.tenant import set_tenant_db_context
+
+            set_tenant_db_context(session, user.organization_id)
+            readiness = service.readiness(shipment_code)
+            return {
+                "export_case": _case_payload(row),
+                "readiness": _readiness_payload(readiness),
+                "ledger_mutated": False,
+            }
+        except Exception as exc:
+            _raise_service_error(exc)
+            raise
+    finally:
+        session.close()

--- a/src/litoral_trace/api/traceability.py
+++ b/src/litoral_trace/api/traceability.py
@@ -1,9 +1,4 @@
-"""Industrial traceability API and read-only browser composition.
-
-Operational UX10-D writes are registered directly by the application bootstrap
-from the web layer, so this API module never imports the write workspace back
-through the HTML runtime layer.
-"""
+"""Industrial traceability API and browser-domain composition."""
 from __future__ import annotations
 
 from typing import Any
@@ -13,6 +8,7 @@ from fastapi.responses import JSONResponse
 
 from litoral_trace.api.auth import UserTenantContext
 from litoral_trace.api.integrations import router as integrations_api_router
+from litoral_trace.api.shipment_export_case import router as export_case_api_router
 from litoral_trace.api.traceability_dossier import router as dossier_router
 from litoral_trace.auth.rbac import Permission, require_permission
 from litoral_trace.db.tenant import get_tenant_scoped_db_session
@@ -22,6 +18,7 @@ from litoral_trace.services.traceability_lineage import (
     TraceabilityLineageValidationError,
 )
 from litoral_trace.web.integrations import router as integrations_web_router
+from litoral_trace.web.shipment_export_case import router as export_case_web_router
 from litoral_trace.web.traceability import router as traceability_web_router
 from litoral_trace.web.traceability_release_control import (
     router as release_control_web_router,
@@ -92,14 +89,15 @@ async def obtener_origen_despacho_endpoint(
         session.close()
 
 
-# ``main.py`` includes one traceability-domain router for the origin API,
-# P1E dossier downloads and browser workspaces. P1-A is composed here to avoid
-# changing the legacy application bootstrap while keeping a separate
-# `/api/v1/integrations` and `/integrations` namespace.
+# ``main.py`` includes one traceability-domain router. P1-A and P1-B are
+# composed here so the production bootstrap remains stable while each feature
+# keeps an independent API/browser namespace.
 router = APIRouter()
 router.include_router(api_router)
 router.include_router(dossier_router)
 router.include_router(integrations_api_router)
+router.include_router(export_case_api_router)
 router.include_router(traceability_web_router)
 router.include_router(release_control_web_router)
 router.include_router(integrations_web_router)
+router.include_router(export_case_web_router)

--- a/src/litoral_trace/db/models/__init__.py
+++ b/src/litoral_trace/db/models/__init__.py
@@ -13,6 +13,7 @@ from litoral_trace.db.models.vault_document import VaultDocument
 from litoral_trace.db.models.batch_import import BatchImport
 from litoral_trace.db.models.batch_evidence_link import BatchEvidenceLink
 from litoral_trace.db.models.traceability_evidence_link import TraceabilityEvidenceLink
+from litoral_trace.db.models.shipment_export_case import ShipmentExportCase
 from litoral_trace.db.models.integration import (
     ExternalEntity,
     ExternalEntityVersion,
@@ -46,6 +47,7 @@ __all__ = [
     "BatchImport",
     "BatchEvidenceLink",
     "TraceabilityEvidenceLink",
+    "ShipmentExportCase",
     "TraceabilityBatch",
     "TraceabilityEvent",
     "TraceabilityEventInput",

--- a/src/litoral_trace/db/models/shipment_export_case.py
+++ b/src/litoral_trace/db/models/shipment_export_case.py
@@ -1,0 +1,102 @@
+"""Structured export dossier metadata attached to one traced shipment.
+
+Binary documents remain in Vault and are linked through TraceabilityEvidenceLink.
+This model stores only shipment-level Corrientes/ARCA/SIM references needed to
+calculate a deterministic export-readiness result.
+"""
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Final
+from uuid import UUID, uuid4
+
+from sqlalchemy import (
+    CheckConstraint,
+    DateTime,
+    ForeignKey,
+    ForeignKeyConstraint,
+    Index,
+    Integer,
+    String,
+    Text,
+    UniqueConstraint,
+    Uuid,
+)
+from sqlalchemy.orm import Mapped, mapped_column
+
+from litoral_trace.db.base import Base, TimestampMixin
+
+
+EXPORT_ORIGIN_PROFILES: Final[frozenset[str]] = frozenset({"CULTIVATED", "NATIVE"})
+
+
+class ShipmentExportCase(Base, TimestampMixin):
+    """One structured Corrientes/ARCA export case for a tenant shipment."""
+
+    __tablename__ = "shipment_export_cases"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    public_id: Mapped[UUID] = mapped_column(Uuid(as_uuid=True), default=uuid4, nullable=False)
+    organization_id: Mapped[int] = mapped_column(Integer, nullable=False)
+    shipment_id: Mapped[int] = mapped_column(Integer, nullable=False)
+
+    origin_profile: Mapped[str] = mapped_column(String(24), nullable=False)
+    export_invoice_number: Mapped[str | None] = mapped_column(String(80), nullable=True)
+    export_invoice_cae: Mapped[str | None] = mapped_column(String(32), nullable=True)
+    customs_destination_id: Mapped[str | None] = mapped_column(String(64), nullable=True)
+    customs_subregime: Mapped[str | None] = mapped_column(String(16), nullable=True)
+    customs_officialized_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+    notes: Mapped[str | None] = mapped_column(Text, nullable=True)
+
+    created_by_user_id: Mapped[int | None] = mapped_column(
+        Integer,
+        ForeignKey(
+            "users.id",
+            ondelete="SET NULL",
+            name="fk_shipment_export_cases_created_by_user_id",
+        ),
+        nullable=True,
+    )
+    updated_by_user_id: Mapped[int | None] = mapped_column(
+        Integer,
+        ForeignKey(
+            "users.id",
+            ondelete="SET NULL",
+            name="fk_shipment_export_cases_updated_by_user_id",
+        ),
+        nullable=True,
+    )
+
+    __table_args__ = (
+        UniqueConstraint("id", "organization_id", name="uq_shipment_export_cases_id_org"),
+        UniqueConstraint("public_id", name="uq_shipment_export_cases_public_id"),
+        UniqueConstraint("shipment_id", name="uq_shipment_export_cases_shipment_id"),
+        ForeignKeyConstraint(
+            ["organization_id"],
+            ["organizations.id"],
+            name="fk_shipment_export_cases_organization_id",
+            ondelete="RESTRICT",
+        ),
+        ForeignKeyConstraint(
+            ["shipment_id", "organization_id"],
+            ["shipments.id", "shipments.organization_id"],
+            name="fk_shipment_export_cases_shipment_tenant",
+            ondelete="RESTRICT",
+        ),
+        CheckConstraint(
+            "origin_profile IN ('CULTIVATED','NATIVE')",
+            name="ck_shipment_export_cases_origin_profile",
+        ),
+        Index(
+            "ix_shipment_export_cases_tenant_shipment",
+            "organization_id",
+            "shipment_id",
+        ),
+        Index(
+            "ix_shipment_export_cases_tenant_customs_destination",
+            "organization_id",
+            "customs_destination_id",
+        ),
+    )

--- a/src/litoral_trace/db/models/traceability_evidence_link.py
+++ b/src/litoral_trace/db/models/traceability_evidence_link.py
@@ -29,6 +29,7 @@ TRACEABILITY_EVIDENCE_TYPES: Final[frozenset[str]] = frozenset(
     {
         "ORIGIN_AUTHORIZATION",
         "FOREST_GUIDE",
+        "FRUIT_GUIDE",
         "REMITO",
         "INVOICE",
         "CERTIFICATE",
@@ -125,7 +126,7 @@ class TraceabilityEvidenceLink(Base):
             ondelete="RESTRICT",
         ),
         CheckConstraint(
-            "evidence_type IN ('ORIGIN_AUTHORIZATION','FOREST_GUIDE','REMITO','INVOICE','CERTIFICATE','TRANSPORT','GEOSPATIAL','SUPPLIER_DECLARATION','OTHER')",
+            "evidence_type IN ('ORIGIN_AUTHORIZATION','FOREST_GUIDE','FRUIT_GUIDE','REMITO','INVOICE','CERTIFICATE','TRANSPORT','GEOSPATIAL','SUPPLIER_DECLARATION','OTHER')",
             name="ck_traceability_evidence_links_type",
         ),
         CheckConstraint(

--- a/src/litoral_trace/services/shipment_export_case.py
+++ b/src/litoral_trace/services/shipment_export_case.py
@@ -1,0 +1,354 @@
+"""Corrientes + ARCA export-case metadata and deterministic readiness.
+
+The service never copies binary evidence out of Vault and never mutates the
+traceability ledger. It evaluates only tenant-scoped shipment metadata,
+structured external references and active/available Vault evidence links.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Any
+from uuid import UUID
+
+from sqlalchemy import and_, func, select
+from sqlalchemy.exc import IntegrityError, SQLAlchemyError
+from sqlalchemy.orm import Session
+
+from litoral_trace.db.models import (
+    Shipment,
+    ShipmentExportCase,
+    TraceabilityEvidenceLink,
+    VaultDocument,
+)
+from litoral_trace.db.models.shipment_export_case import EXPORT_ORIGIN_PROFILES
+
+
+class ShipmentExportCaseError(RuntimeError):
+    """Base safe error for export-case workflows."""
+
+
+class ShipmentExportCaseNotFoundError(ShipmentExportCaseError):
+    pass
+
+
+class ShipmentExportCaseValidationError(ShipmentExportCaseError):
+    def __init__(self, code: str, detail: str) -> None:
+        self.code = code
+        self.detail = detail
+        super().__init__(detail)
+
+
+class ShipmentExportCasePersistenceError(ShipmentExportCaseError):
+    pass
+
+
+@dataclass(frozen=True)
+class ShipmentExportCaseView:
+    public_id: UUID
+    shipment_public_id: UUID
+    shipment_code: str
+    origin_profile: str
+    export_invoice_number: str | None
+    export_invoice_cae: str | None
+    customs_destination_id: str | None
+    customs_subregime: str | None
+    customs_officialized_at: datetime | None
+    notes: str | None
+    created_at: datetime
+    updated_at: datetime
+
+
+@dataclass(frozen=True)
+class ExportRequirementView:
+    key: str
+    label: str
+    satisfied: bool
+    source: str
+
+
+@dataclass(frozen=True)
+class ShipmentExportReadinessView:
+    shipment_public_id: UUID
+    shipment_code: str
+    state: str
+    origin_profile: str | None
+    requirements: tuple[ExportRequirementView, ...]
+    missing: tuple[str, ...]
+    evidence_types: tuple[str, ...]
+    export_case: ShipmentExportCaseView | None
+
+    @property
+    def ready(self) -> bool:
+        return self.state == "READY"
+
+
+def _optional_text(value: Any, *, maximum: int, uppercase: bool = False) -> str | None:
+    normalized = str(value or "").strip()
+    if not normalized:
+        return None
+    if len(normalized) > maximum:
+        raise ShipmentExportCaseValidationError(
+            "TEXT_TOO_LONG",
+            f"El valor supera el máximo de {maximum} caracteres.",
+        )
+    return normalized.upper() if uppercase else normalized
+
+
+def _normalize_profile(value: Any) -> str:
+    normalized = str(value or "").strip().upper()
+    if normalized not in EXPORT_ORIGIN_PROFILES:
+        raise ShipmentExportCaseValidationError(
+            "INVALID_ORIGIN_PROFILE",
+            "El perfil forestal debe ser CULTIVATED o NATIVE.",
+        )
+    return normalized
+
+
+class ShipmentExportCaseService:
+    """Manage one structured export dossier per shipment without ledger writes."""
+
+    def __init__(self, *, session: Session, organization_id: int) -> None:
+        self._session = session
+        self._organization_id = int(organization_id)
+
+    def _shipment(self, shipment_code: str) -> Shipment:
+        code = str(shipment_code or "").strip()
+        if not code or len(code) > 120:
+            raise ShipmentExportCaseValidationError(
+                "INVALID_SHIPMENT_CODE",
+                "Debe informar un código de despacho válido.",
+            )
+        shipment = self._session.scalar(
+            select(Shipment).where(
+                Shipment.organization_id == self._organization_id,
+                func.lower(Shipment.shipment_code) == code.lower(),
+            )
+        )
+        if shipment is None:
+            raise ShipmentExportCaseNotFoundError(
+                "El despacho no existe en la organización activa."
+            )
+        return shipment
+
+    @staticmethod
+    def _view(case: ShipmentExportCase, shipment: Shipment) -> ShipmentExportCaseView:
+        return ShipmentExportCaseView(
+            public_id=case.public_id,
+            shipment_public_id=shipment.public_id,
+            shipment_code=shipment.shipment_code,
+            origin_profile=case.origin_profile,
+            export_invoice_number=case.export_invoice_number,
+            export_invoice_cae=case.export_invoice_cae,
+            customs_destination_id=case.customs_destination_id,
+            customs_subregime=case.customs_subregime,
+            customs_officialized_at=case.customs_officialized_at,
+            notes=case.notes,
+            created_at=case.created_at,
+            updated_at=case.updated_at,
+        )
+
+    def get_case(self, shipment_code: str) -> ShipmentExportCaseView | None:
+        shipment = self._shipment(shipment_code)
+        case = self._session.scalar(
+            select(ShipmentExportCase).where(
+                ShipmentExportCase.organization_id == self._organization_id,
+                ShipmentExportCase.shipment_id == shipment.id,
+            )
+        )
+        return self._view(case, shipment) if case is not None else None
+
+    def upsert_case(
+        self,
+        *,
+        shipment_code: str,
+        origin_profile: str,
+        export_invoice_number: Any = None,
+        export_invoice_cae: Any = None,
+        customs_destination_id: Any = None,
+        customs_subregime: Any = None,
+        customs_officialized_at: datetime | None = None,
+        notes: Any = None,
+        actor_user_id: int | None = None,
+    ) -> ShipmentExportCaseView:
+        shipment = self._shipment(shipment_code)
+        profile = _normalize_profile(origin_profile)
+        invoice_number = _optional_text(export_invoice_number, maximum=80)
+        invoice_cae = _optional_text(export_invoice_cae, maximum=32)
+        destination_id = _optional_text(customs_destination_id, maximum=64, uppercase=True)
+        subregime = _optional_text(customs_subregime, maximum=16, uppercase=True)
+        normalized_notes = _optional_text(notes, maximum=2000)
+
+        case = self._session.scalar(
+            select(ShipmentExportCase).where(
+                ShipmentExportCase.organization_id == self._organization_id,
+                ShipmentExportCase.shipment_id == shipment.id,
+            )
+        )
+        if case is None:
+            case = ShipmentExportCase(
+                organization_id=self._organization_id,
+                shipment_id=int(shipment.id),
+                origin_profile=profile,
+                created_by_user_id=actor_user_id,
+                updated_by_user_id=actor_user_id,
+            )
+            self._session.add(case)
+        else:
+            case.origin_profile = profile
+            case.updated_by_user_id = actor_user_id
+
+        case.export_invoice_number = invoice_number
+        case.export_invoice_cae = invoice_cae
+        case.customs_destination_id = destination_id
+        case.customs_subregime = subregime
+        case.customs_officialized_at = customs_officialized_at
+        case.notes = normalized_notes
+
+        try:
+            self._session.flush()
+            result = self._view(case, shipment)
+            self._session.commit()
+            return result
+        except IntegrityError as exc:
+            self._session.rollback()
+            raise ShipmentExportCaseValidationError(
+                "EXPORT_CASE_CONFLICT",
+                "No fue posible guardar el expediente porque sus referencias entran en conflicto.",
+            ) from exc
+        except SQLAlchemyError as exc:
+            self._session.rollback()
+            raise ShipmentExportCasePersistenceError(
+                "No fue posible guardar el expediente exportador."
+            ) from exc
+
+    def _active_evidence_types(self, shipment: Shipment) -> tuple[str, ...]:
+        rows = self._session.scalars(
+            select(TraceabilityEvidenceLink.evidence_type)
+            .join(
+                VaultDocument,
+                and_(
+                    VaultDocument.id == TraceabilityEvidenceLink.vault_document_id,
+                    VaultDocument.organization_id == TraceabilityEvidenceLink.organization_id,
+                ),
+            )
+            .where(
+                TraceabilityEvidenceLink.organization_id == self._organization_id,
+                TraceabilityEvidenceLink.shipment_id == shipment.id,
+                TraceabilityEvidenceLink.unlinked_at.is_(None),
+                VaultDocument.status == "available",
+            )
+            .distinct()
+        ).all()
+        return tuple(sorted(str(value) for value in rows))
+
+    @staticmethod
+    def _requirement(
+        key: str,
+        label: str,
+        satisfied: bool,
+        source: str,
+    ) -> ExportRequirementView:
+        return ExportRequirementView(
+            key=key,
+            label=label,
+            satisfied=bool(satisfied),
+            source=source,
+        )
+
+    def readiness(self, shipment_code: str) -> ShipmentExportReadinessView:
+        shipment = self._shipment(shipment_code)
+        case_row = self._session.scalar(
+            select(ShipmentExportCase).where(
+                ShipmentExportCase.organization_id == self._organization_id,
+                ShipmentExportCase.shipment_id == shipment.id,
+            )
+        )
+        evidence_types = self._active_evidence_types(shipment)
+        evidence = set(evidence_types)
+        requirements: list[ExportRequirementView] = []
+
+        if case_row is None:
+            requirements.append(
+                self._requirement(
+                    "EXPORT_CASE",
+                    "Definir perfil forestal del expediente",
+                    False,
+                    "Expediente",
+                )
+            )
+            profile = None
+            case_view = None
+        else:
+            profile = case_row.origin_profile
+            case_view = self._view(case_row, shipment)
+            if profile == "CULTIVATED":
+                requirements.extend(
+                    [
+                        self._requirement(
+                            "CULTIVATED_INVOICE_OR_REMITO",
+                            "Factura o Remito oficial del traslado",
+                            bool({"INVOICE", "REMITO"} & evidence),
+                            "Vault",
+                        ),
+                        self._requirement(
+                            "FRUIT_GUIDE",
+                            "Guía de Frutos de Corrientes",
+                            "FRUIT_GUIDE" in evidence,
+                            "Vault",
+                        ),
+                    ]
+                )
+            else:
+                requirements.extend(
+                    [
+                        self._requirement(
+                            "FOREST_GUIDE",
+                            "Guía de Productos Forestales Nativos",
+                            "FOREST_GUIDE" in evidence,
+                            "Vault",
+                        ),
+                        self._requirement(
+                            "FOREST_TRANSPORT_VOUCHER",
+                            "Vale de Transporte forestal",
+                            "TRANSPORT" in evidence,
+                            "Vault",
+                        ),
+                    ]
+                )
+
+            requirements.extend(
+                [
+                    self._requirement(
+                        "EXPORT_INVOICE_E",
+                        "Factura E de exportación",
+                        bool(case_row.export_invoice_number),
+                        "ARCA",
+                    ),
+                    self._requirement(
+                        "SIM_DESTINATION",
+                        "Identificador de destinación aduanera SIM",
+                        bool(case_row.customs_destination_id),
+                        "SIM",
+                    ),
+                    self._requirement(
+                        "SIM_SUBREGIME",
+                        "Subrégimen de la destinación SIM",
+                        bool(case_row.customs_subregime),
+                        "SIM",
+                    ),
+                ]
+            )
+
+        missing = tuple(item.key for item in requirements if not item.satisfied)
+        state = "READY" if requirements and not missing else "BLOCKED"
+        return ShipmentExportReadinessView(
+            shipment_public_id=shipment.public_id,
+            shipment_code=shipment.shipment_code,
+            state=state,
+            origin_profile=profile,
+            requirements=tuple(requirements),
+            missing=missing,
+            evidence_types=evidence_types,
+            export_case=case_view,
+        )

--- a/src/litoral_trace/services/shipment_export_release_control.py
+++ b/src/litoral_trace/services/shipment_export_release_control.py
@@ -1,0 +1,146 @@
+"""Compose P1-B export readiness into the existing release-control view."""
+from __future__ import annotations
+
+from copy import deepcopy
+from typing import Any
+from urllib.parse import urlencode
+
+from litoral_trace.services.shipment_export_case import ShipmentExportReadinessView
+
+READY = "READY"
+ATTENTION = "ATTENTION"
+BLOCKED = "BLOCKED"
+
+_STATE_LABELS = {
+    READY: "Listo",
+    ATTENTION: "Requiere atención",
+    BLOCKED: "Bloqueado",
+}
+_STATE_PRIORITY = {BLOCKED: 0, ATTENTION: 1, READY: 2}
+
+
+def is_international_shipment(lineage_payload: dict[str, Any]) -> bool:
+    shipment = lineage_payload.get("shipment") or {}
+    country = str(shipment.get("destination_country") or "").strip().upper()
+    return bool(country and country != "AR")
+
+
+def apply_export_case_release_control(
+    control: dict[str, Any],
+    *,
+    lineage_payload: dict[str, Any],
+    readiness: ShipmentExportReadinessView | None,
+) -> dict[str, Any]:
+    """Return release control with a P1-B gate for international shipments.
+
+    Domestic or destination-less shipments remain byte-for-byte equivalent at
+    the semantic level: no export check is added. International shipments fail
+    closed if readiness is missing or BLOCKED.
+    """
+    if not is_international_shipment(lineage_payload):
+        return control
+
+    result = deepcopy(control)
+    shipment = lineage_payload.get("shipment") or {}
+    shipment_code = str(shipment.get("shipment_code") or "").strip()
+    query = urlencode({"shipment_code": shipment_code}) if shipment_code else ""
+    href = f"/export-case?{query}" if query else "/export-case"
+
+    if readiness is None:
+        state = BLOCKED
+        summary = "Falta evaluar el expediente exportador Corrientes/ARCA."
+        detail = "El despacho internacional no puede cerrarse sin una evaluación documental exportadora."
+        metric = "Sin evaluar"
+    elif readiness.ready:
+        state = READY
+        summary = "El expediente Corrientes/ARCA tiene completos sus requisitos configurados."
+        detail = (
+            f"Perfil {readiness.origin_profile or '—'} · "
+            f"{len(readiness.requirements)} requisito(s) documental(es) verificados."
+        )
+        metric = "READY"
+    else:
+        state = BLOCKED
+        missing_labels = [
+            row.label for row in readiness.requirements if not row.satisfied
+        ]
+        summary = "El expediente exportador tiene requisitos pendientes."
+        detail = (
+            "Falta completar: " + ", ".join(missing_labels) + "."
+            if missing_labels
+            else "El expediente exportador no está listo."
+        )
+        metric = f"{len(readiness.missing)} pendiente(s)"
+
+    export_check = {
+        "key": "export_case",
+        "title": "Expediente Corrientes + ARCA",
+        "state": state,
+        "state_label": _STATE_LABELS[state],
+        "summary": summary,
+        "detail": detail,
+        "action_label": "Abrir expediente exportador",
+        "action_href": href,
+        "metric": metric,
+        "category": "Exportación",
+    }
+    result.setdefault("checks", []).append(export_check)
+    result.setdefault("links", {})["export_case"] = href
+
+    checks = list(result.get("checks") or [])
+    ready = sum(item.get("state") == READY for item in checks)
+    attention = sum(item.get("state") == ATTENTION for item in checks)
+    blocked = sum(item.get("state") == BLOCKED for item in checks)
+    total = len(checks)
+    progress = int(round((ready / total) * 100)) if total else 0
+
+    if blocked:
+        overall_state = BLOCKED
+        overall_title = "Bloqueado para compartir"
+        overall_message = "Hay controles operativos que impiden presentar este despacho como expediente cerrado."
+    elif attention:
+        overall_state = ATTENTION
+        overall_title = "Requiere atención antes de compartir"
+        overall_message = "La trazabilidad esencial está cerrada, pero conviene resolver las brechas visibles."
+    else:
+        overall_state = READY
+        overall_title = "Listo para compartir"
+        overall_message = "Los controles operativos de Litoral Trace están cerrados y el expediente es verificable."
+
+    result["overall"] = {
+        "state": overall_state,
+        "state_label": _STATE_LABELS[overall_state],
+        "title": overall_title,
+        "message": overall_message,
+        "ready": ready,
+        "attention": attention,
+        "blocked": blocked,
+        "total": total,
+        "progress": progress,
+    }
+
+    indexed_checks = list(enumerate(checks))
+    ordered_actions = sorted(
+        (pair for pair in indexed_checks if pair[1].get("state") != READY),
+        key=lambda pair: (_STATE_PRIORITY[pair[1].get("state", BLOCKED)], pair[0]),
+    )
+    result["next_actions"] = [
+        {
+            "title": item["title"],
+            "state": item["state"],
+            "state_label": item["state_label"],
+            "message": item["summary"],
+            "href": item["action_href"],
+            "label": item["action_label"],
+        }
+        for _, item in ordered_actions[:4]
+    ]
+
+    stages = list(result.get("stages") or [])
+    for stage in stages:
+        if stage.get("label") == "Salida" and state == BLOCKED:
+            stage["state"] = BLOCKED
+            stage["caption"] = "Expediente exportador pendiente"
+            break
+    result["stages"] = stages
+    return result

--- a/src/litoral_trace/templates/shipment_export_case.html
+++ b/src/litoral_trace/templates/shipment_export_case.html
@@ -5,7 +5,7 @@
 {% block content %}
 <section class="min-w-0 space-y-6" aria-labelledby="export-case-title">
     <header class="overflow-hidden rounded-2xl border border-slate-200 bg-slate-950 text-white shadow-sm">
-        <div class="grid gap-6 p-6 lg:grid-cols-[1.2fr_0.8fr] lg:p-8">
+        <div class="grid gap-6 p-6 lg:grid-cols-[1.25fr_0.75fr] lg:p-8">
             <div>
                 <div class="flex flex-wrap gap-2">
                     <span class="rounded-full border border-emerald-400/20 bg-emerald-400/10 px-3 py-1 text-xs font-semibold text-emerald-200">P1-B · Corrientes + ARCA</span>
@@ -15,7 +15,7 @@
                 <p class="mt-3 max-w-3xl text-sm leading-6 text-slate-300">Concentrá las referencias forestales, Factura E y destinación SIM de un despacho. Los archivos siguen en Evidence Vault; este módulo sólo estructura el expediente y muestra qué falta.</p>
             </div>
             <aside class="rounded-2xl border border-white/10 bg-white/5 p-5">
-                <p class="text-xs font-bold uppercase tracking-wider text-amber-300">Límite del control</p>
+                <p class="text-xs font-bold uppercase tracking-wider text-amber-500">Límite del control</p>
                 <ul class="mt-3 space-y-2 text-sm leading-5 text-slate-300">
                     <li>READY significa que los requisitos documentales configurados están presentes.</li>
                     <li>No equivale a certificación, oficialización aduanera ni declaración de cumplimiento EUDR.</li>
@@ -51,7 +51,7 @@
 
     {% if export_case_view %}
     {% set view = export_case_view %}
-    <div class="grid min-w-0 gap-6 xl:grid-cols-[0.9fr_1.1fr]">
+    <div class="grid min-w-0 gap-6 xl:grid-cols-[0.8fr_1.2fr]">
         <section class="rounded-2xl border {% if view.ready %}border-emerald-200 bg-emerald-50{% else %}border-amber-200 bg-amber-50{% endif %} p-6 shadow-sm" aria-labelledby="readiness-title">
             <div class="flex flex-wrap items-start justify-between gap-3">
                 <div>
@@ -64,8 +64,8 @@
 
             <div class="mt-5 space-y-2">
                 {% for requirement in view.requirements %}
-                <article class="flex items-start gap-3 rounded-xl border border-white/70 bg-white/80 p-4">
-                    <span class="mt-0.5 flex h-6 w-6 shrink-0 items-center justify-center rounded-full {% if requirement.satisfied %}bg-emerald-100 text-emerald-700{% else %}bg-rose-100 text-rose-700{% endif %}">
+                <article class="flex items-start gap-3 rounded-xl border border-slate-200 bg-white p-4">
+                    <span class="mt-0.5 flex h-7 w-7 shrink-0 items-center justify-center rounded-full {% if requirement.satisfied %}bg-emerald-100 text-emerald-700{% else %}bg-rose-100 text-rose-700{% endif %}">
                         <i class="fa-solid {% if requirement.satisfied %}fa-check{% else %}fa-xmark{% endif %} text-xs" aria-hidden="true"></i>
                     </span>
                     <div class="min-w-0 flex-1">
@@ -78,7 +78,7 @@
 
             <div class="mt-5 flex flex-wrap gap-2">
                 <a href="/evidence" class="inline-flex items-center gap-2 rounded-lg border border-slate-300 bg-white px-3.5 py-2 text-sm font-semibold text-slate-700 hover:bg-slate-50"><i class="fa-solid fa-paperclip" aria-hidden="true"></i>Completar evidencia</a>
-                <a href="/release-control?shipment_code={{ view.shipment_code|urlencode }}" class="inline-flex items-center gap-2 rounded-lg border border-slate-300 bg-white px-3.5 py-2 text-sm font-semibold text-slate-700 hover:bg-slate-50"><i class="fa-solid fa-shield-halved" aria-hidden="true"></i>Control de Salida</a>
+                <a href="/release-control?shipment_code={{ view.shipment_code }}" class="inline-flex items-center gap-2 rounded-lg border border-slate-300 bg-white px-3.5 py-2 text-sm font-semibold text-slate-700 hover:bg-slate-50"><i class="fa-solid fa-shield-halved" aria-hidden="true"></i>Control de Salida</a>
             </div>
         </section>
 

--- a/src/litoral_trace/templates/shipment_export_case.html
+++ b/src/litoral_trace/templates/shipment_export_case.html
@@ -1,0 +1,150 @@
+{% extends "app/base_app.html" %}
+
+{% block title %}Expediente exportador | Litoral Trace{% endblock %}
+
+{% block content %}
+<section class="min-w-0 space-y-6" aria-labelledby="export-case-title">
+    <header class="overflow-hidden rounded-2xl border border-slate-200 bg-slate-950 text-white shadow-sm">
+        <div class="grid gap-6 p-6 lg:grid-cols-[1.2fr_0.8fr] lg:p-8">
+            <div>
+                <div class="flex flex-wrap gap-2">
+                    <span class="rounded-full border border-emerald-400/20 bg-emerald-400/10 px-3 py-1 text-xs font-semibold text-emerald-200">P1-B · Corrientes + ARCA</span>
+                    <span class="rounded-full border border-white/10 bg-white/5 px-3 py-1 text-xs font-semibold text-slate-300">Despacho → documentos → referencias aduaneras</span>
+                </div>
+                <h1 id="export-case-title" class="mt-4 text-3xl font-bold tracking-tight">Expediente exportador</h1>
+                <p class="mt-3 max-w-3xl text-sm leading-6 text-slate-300">Concentrá las referencias forestales, Factura E y destinación SIM de un despacho. Los archivos siguen en Evidence Vault; este módulo sólo estructura el expediente y muestra qué falta.</p>
+            </div>
+            <aside class="rounded-2xl border border-white/10 bg-white/5 p-5">
+                <p class="text-xs font-bold uppercase tracking-wider text-amber-300">Límite del control</p>
+                <ul class="mt-3 space-y-2 text-sm leading-5 text-slate-300">
+                    <li>READY significa que los requisitos documentales configurados están presentes.</li>
+                    <li>No equivale a certificación, oficialización aduanera ni declaración de cumplimiento EUDR.</li>
+                    <li>Guardar referencias nunca modifica stock, lotes ni el ledger de cadena de custodia.</li>
+                </ul>
+            </aside>
+        </div>
+    </header>
+
+    {% if export_case_message %}
+    <section class="rounded-2xl border border-emerald-200 bg-emerald-50 p-5" role="status">
+        <p class="text-sm font-bold text-emerald-950">{{ export_case_message.title }}</p>
+        <p class="mt-1 text-sm text-emerald-800">{{ export_case_message.message }}</p>
+    </section>
+    {% endif %}
+
+    {% if export_case_error %}
+    <section class="rounded-2xl border border-rose-200 bg-rose-50 p-5" role="alert">
+        <p class="text-sm font-bold text-rose-950">{{ export_case_error.title }}</p>
+        <p class="mt-1 text-sm text-rose-800">{{ export_case_error.message }}</p>
+    </section>
+    {% endif %}
+
+    <section class="rounded-2xl border border-slate-200 bg-white p-5 shadow-sm">
+        <form method="get" action="/export-case" class="flex flex-col gap-3 sm:flex-row sm:items-end">
+            <div class="min-w-0 flex-1">
+                <label for="shipment_code" class="text-xs font-semibold text-slate-700">Código de despacho</label>
+                <input id="shipment_code" name="shipment_code" value="{{ export_case_query }}" maxlength="120" required placeholder="EXP-2026-001" class="mt-1.5 w-full rounded-lg border border-slate-300 px-3 py-2.5 text-sm">
+            </div>
+            <button class="inline-flex items-center justify-center gap-2 rounded-lg bg-slate-950 px-4 py-2.5 text-sm font-semibold text-white hover:bg-slate-800"><i class="fa-solid fa-magnifying-glass" aria-hidden="true"></i>Consultar expediente</button>
+        </form>
+    </section>
+
+    {% if export_case_view %}
+    {% set view = export_case_view %}
+    <div class="grid min-w-0 gap-6 xl:grid-cols-[0.9fr_1.1fr]">
+        <section class="rounded-2xl border {% if view.ready %}border-emerald-200 bg-emerald-50{% else %}border-amber-200 bg-amber-50{% endif %} p-6 shadow-sm" aria-labelledby="readiness-title">
+            <div class="flex flex-wrap items-start justify-between gap-3">
+                <div>
+                    <p class="text-[11px] font-bold uppercase tracking-wider {% if view.ready %}text-emerald-700{% else %}text-amber-700{% endif %}">Readiness documental</p>
+                    <h2 id="readiness-title" class="mt-1 text-xl font-bold text-slate-950">Despacho {{ view.shipment_code }}</h2>
+                </div>
+                <span class="rounded-full px-3 py-1.5 text-xs font-bold {% if view.ready %}bg-emerald-700 text-white{% else %}bg-amber-600 text-white{% endif %}">{{ view.state }}</span>
+            </div>
+            <p class="mt-3 text-sm leading-6 text-slate-700">{% if view.ready %}El expediente contiene todas las referencias exigidas por el perfil seleccionado.{% else %}El expediente permanece bloqueado hasta completar los elementos marcados como pendientes.{% endif %}</p>
+
+            <div class="mt-5 space-y-2">
+                {% for requirement in view.requirements %}
+                <article class="flex items-start gap-3 rounded-xl border border-white/70 bg-white/80 p-4">
+                    <span class="mt-0.5 flex h-6 w-6 shrink-0 items-center justify-center rounded-full {% if requirement.satisfied %}bg-emerald-100 text-emerald-700{% else %}bg-rose-100 text-rose-700{% endif %}">
+                        <i class="fa-solid {% if requirement.satisfied %}fa-check{% else %}fa-xmark{% endif %} text-xs" aria-hidden="true"></i>
+                    </span>
+                    <div class="min-w-0 flex-1">
+                        <p class="text-sm font-semibold text-slate-900">{{ requirement.label }}</p>
+                        <p class="mt-1 text-xs text-slate-500">Fuente: {{ requirement.source }} · {{ requirement.key }}</p>
+                    </div>
+                </article>
+                {% endfor %}
+            </div>
+
+            <div class="mt-5 flex flex-wrap gap-2">
+                <a href="/evidence" class="inline-flex items-center gap-2 rounded-lg border border-slate-300 bg-white px-3.5 py-2 text-sm font-semibold text-slate-700 hover:bg-slate-50"><i class="fa-solid fa-paperclip" aria-hidden="true"></i>Completar evidencia</a>
+                <a href="/release-control?shipment_code={{ view.shipment_code|urlencode }}" class="inline-flex items-center gap-2 rounded-lg border border-slate-300 bg-white px-3.5 py-2 text-sm font-semibold text-slate-700 hover:bg-slate-50"><i class="fa-solid fa-shield-halved" aria-hidden="true"></i>Control de Salida</a>
+            </div>
+        </section>
+
+        <section class="rounded-2xl border border-slate-200 bg-white p-6 shadow-sm" aria-labelledby="profile-title">
+            <div>
+                <p class="text-[11px] font-bold uppercase tracking-wider text-emerald-700">Perfil documental</p>
+                <h2 id="profile-title" class="mt-1 text-lg font-bold text-slate-950">Corrientes forestal</h2>
+                <p class="mt-2 text-sm leading-6 text-slate-600">Bosque cultivado exige Factura/Remito + Guía de Frutos. Bosque nativo exige Guía Forestal + Vale de Transporte. Factura E y referencias SIM se controlan en ambos perfiles.</p>
+            </div>
+
+            {% if export_case_can_manage %}
+            {% set case = view.case or {} %}
+            <form method="post" action="/export-case" class="mt-5 grid gap-4 sm:grid-cols-2">
+                <input type="hidden" name="{{ csrf_form_field }}" value="{{ csrf_token }}">
+                <input type="hidden" name="shipment_code" value="{{ view.shipment_code }}">
+                <div class="sm:col-span-2">
+                    <label class="text-xs font-semibold text-slate-700">Origen forestal</label>
+                    <select name="origin_profile" required class="mt-1.5 w-full rounded-lg border border-slate-300 bg-white px-3 py-2.5 text-sm">
+                        <option value="CULTIVATED" {% if case.origin_profile == 'CULTIVATED' %}selected{% endif %}>Bosque cultivado</option>
+                        <option value="NATIVE" {% if case.origin_profile == 'NATIVE' %}selected{% endif %}>Bosque nativo</option>
+                    </select>
+                </div>
+                <div>
+                    <label class="text-xs font-semibold text-slate-700">Factura E</label>
+                    <input name="export_invoice_number" maxlength="80" value="{{ case.export_invoice_number or '' }}" placeholder="0001-00000001" class="mt-1.5 w-full rounded-lg border border-slate-300 px-3 py-2.5 text-sm">
+                </div>
+                <div>
+                    <label class="text-xs font-semibold text-slate-700">CAE <span class="font-normal text-slate-400">(opcional)</span></label>
+                    <input name="export_invoice_cae" maxlength="32" value="{{ case.export_invoice_cae or '' }}" class="mt-1.5 w-full rounded-lg border border-slate-300 px-3 py-2.5 text-sm">
+                </div>
+                <div>
+                    <label class="text-xs font-semibold text-slate-700">Destinación SIM</label>
+                    <input name="customs_destination_id" maxlength="64" value="{{ case.customs_destination_id or '' }}" placeholder="Identificador aduanero" class="mt-1.5 w-full rounded-lg border border-slate-300 px-3 py-2.5 font-mono text-sm">
+                </div>
+                <div>
+                    <label class="text-xs font-semibold text-slate-700">Subrégimen SIM</label>
+                    <input name="customs_subregime" maxlength="16" value="{{ case.customs_subregime or '' }}" placeholder="EC01" class="mt-1.5 w-full rounded-lg border border-slate-300 px-3 py-2.5 font-mono text-sm uppercase">
+                </div>
+                <div class="sm:col-span-2">
+                    <label class="text-xs font-semibold text-slate-700">Oficialización aduanera <span class="font-normal text-slate-400">(opcional)</span></label>
+                    <input type="datetime-local" name="customs_officialized_at" value="{{ case.customs_officialized_at or '' }}" class="mt-1.5 w-full rounded-lg border border-slate-300 px-3 py-2.5 text-sm">
+                </div>
+                <div class="sm:col-span-2">
+                    <label class="text-xs font-semibold text-slate-700">Notas internas</label>
+                    <textarea name="notes" maxlength="2000" rows="3" class="mt-1.5 w-full rounded-lg border border-slate-300 px-3 py-2.5 text-sm">{{ case.notes or '' }}</textarea>
+                </div>
+                <div class="sm:col-span-2">
+                    <button class="inline-flex items-center gap-2 rounded-lg bg-emerald-700 px-4 py-2.5 text-sm font-semibold text-white hover:bg-emerald-800"><i class="fa-solid fa-floppy-disk" aria-hidden="true"></i>Guardar expediente</button>
+                </div>
+            </form>
+            {% else %}
+            <div class="mt-5 rounded-xl border border-slate-200 bg-slate-50 p-4 text-sm text-slate-600">Tu rol puede consultar el readiness y las referencias, pero no modificar el expediente.</div>
+            {% endif %}
+        </section>
+    </div>
+
+    <section class="rounded-2xl border border-slate-200 bg-white p-5 shadow-sm">
+        <p class="text-xs font-bold uppercase tracking-wider text-slate-500">Evidencia detectada en Vault</p>
+        <div class="mt-3 flex flex-wrap gap-2">
+            {% for evidence_type in view.evidence_types %}
+            <span class="rounded-full bg-slate-100 px-3 py-1 text-xs font-semibold text-slate-700">{{ evidence_type }}</span>
+            {% else %}
+            <span class="text-sm text-slate-500">No hay evidencia disponible vinculada directamente a este despacho.</span>
+            {% endfor %}
+        </div>
+    </section>
+    {% endif %}
+</section>
+{% endblock %}

--- a/src/litoral_trace/web/shipment_export_case.py
+++ b/src/litoral_trace/web/shipment_export_case.py
@@ -1,0 +1,283 @@
+"""Server-rendered Corrientes + ARCA export-case workspace."""
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any
+from urllib.parse import urlencode
+
+from fastapi import APIRouter, HTTPException, Request, status
+from fastapi.responses import HTMLResponse, RedirectResponse
+
+from litoral_trace.auth.rbac import Permission, has_permission
+from litoral_trace.db.tenant import get_tenant_scoped_db_session, set_tenant_db_context
+from litoral_trace.services.shipment_export_case import (
+    ShipmentExportCaseError,
+    ShipmentExportCaseNotFoundError,
+    ShipmentExportCasePersistenceError,
+    ShipmentExportCaseService,
+    ShipmentExportCaseValidationError,
+)
+from litoral_trace.web.csrf import enforce_csrf, get_csrf_browser_nonce
+from litoral_trace.web.runtime import (
+    get_html_route_user,
+    render_csrf_failure,
+    render_web_template,
+)
+
+
+router = APIRouter(tags=["Frontend B2B"])
+
+_RESULT_MESSAGES = {
+    "saved": {
+        "title": "Expediente actualizado",
+        "message": "Las referencias Corrientes/ARCA/SIM quedaron asociadas al despacho. El ledger de trazabilidad no fue modificado.",
+    }
+}
+
+
+def _safe_error(exc: Exception) -> dict[str, str]:
+    if isinstance(exc, ShipmentExportCaseValidationError):
+        return {"title": "Datos no válidos", "message": exc.detail}
+    if isinstance(exc, ShipmentExportCaseNotFoundError):
+        return {"title": "Despacho no encontrado", "message": str(exc)}
+    if isinstance(exc, ShipmentExportCasePersistenceError):
+        return {
+            "title": "Servicio no disponible",
+            "message": "No fue posible guardar o consultar el expediente exportador en este momento.",
+        }
+    return {
+        "title": "No se pudo completar la operación",
+        "message": "La solicitud fue rechazada de forma segura.",
+    }
+
+
+def _status_for_error(exc: Exception) -> int:
+    if isinstance(exc, ShipmentExportCaseValidationError):
+        return status.HTTP_422_UNPROCESSABLE_CONTENT
+    if isinstance(exc, ShipmentExportCaseNotFoundError):
+        return status.HTTP_404_NOT_FOUND
+    if isinstance(exc, ShipmentExportCasePersistenceError):
+        return status.HTTP_503_SERVICE_UNAVAILABLE
+    return status.HTTP_400_BAD_REQUEST
+
+
+def _parse_datetime(value: Any) -> datetime | None:
+    raw = str(value or "").strip()
+    if not raw:
+        return None
+    try:
+        return datetime.fromisoformat(raw.replace("Z", "+00:00"))
+    except ValueError as exc:
+        raise ShipmentExportCaseValidationError(
+            "INVALID_CUSTOMS_OFFICIALIZED_AT",
+            "La fecha de oficialización aduanera no tiene un formato válido.",
+        ) from exc
+
+
+def _view_payload(readiness) -> dict[str, Any]:
+    case = readiness.export_case
+    return {
+        "shipment_code": readiness.shipment_code,
+        "shipment_public_id": str(readiness.shipment_public_id),
+        "state": readiness.state,
+        "ready": readiness.ready,
+        "origin_profile": readiness.origin_profile,
+        "requirements": tuple(
+            {
+                "key": row.key,
+                "label": row.label,
+                "satisfied": row.satisfied,
+                "source": row.source,
+            }
+            for row in readiness.requirements
+        ),
+        "missing": readiness.missing,
+        "evidence_types": readiness.evidence_types,
+        "case": (
+            {
+                "origin_profile": case.origin_profile,
+                "export_invoice_number": case.export_invoice_number or "",
+                "export_invoice_cae": case.export_invoice_cae or "",
+                "customs_destination_id": case.customs_destination_id or "",
+                "customs_subregime": case.customs_subregime or "",
+                "customs_officialized_at": (
+                    case.customs_officialized_at.isoformat(timespec="minutes")
+                    if case.customs_officialized_at
+                    else ""
+                ),
+                "notes": case.notes or "",
+            }
+            if case is not None
+            else None
+        ),
+    }
+
+
+def _render(
+    request: Request,
+    *,
+    user,
+    query: str = "",
+    readiness=None,
+    error: dict[str, str] | None = None,
+    result_code: str | None = None,
+    status_code: int = status.HTTP_200_OK,
+) -> HTMLResponse:
+    return render_web_template(
+        request,
+        "shipment_export_case.html",
+        user=user,
+        context={
+            "export_case_query": query,
+            "export_case_view": _view_payload(readiness) if readiness is not None else None,
+            "export_case_error": error,
+            "export_case_message": _RESULT_MESSAGES.get(result_code or ""),
+            "export_case_can_manage": has_permission(
+                user, Permission.TRACEABILITY_EVIDENCE
+            ),
+        },
+        status_code=status_code,
+    )
+
+
+async def _csrf_or_response(request: Request, user):
+    try:
+        await enforce_csrf(
+            request,
+            user=user,
+            browser_nonce=get_csrf_browser_nonce(request),
+            require_browser_binding=True,
+        )
+    except HTTPException:
+        return render_csrf_failure()
+    return None
+
+
+@router.get(
+    "/export-case",
+    response_class=HTMLResponse,
+    include_in_schema=False,
+    name="render_shipment_export_case",
+)
+async def render_shipment_export_case(
+    request: Request,
+    shipment_code: str | None = None,
+) -> HTMLResponse:
+    user, denied = get_html_route_user(
+        request,
+        required_permission=Permission.LOTE_READ,
+    )
+    if denied is not None:
+        return denied
+
+    code = str(shipment_code or "").strip()
+    if not code:
+        return _render(request, user=user)
+
+    session = get_tenant_scoped_db_session(user.organization_id)
+    if session is None:
+        return _render(
+            request,
+            user=user,
+            query=code,
+            error=_safe_error(ShipmentExportCasePersistenceError("db")),
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+        )
+    try:
+        readiness = ShipmentExportCaseService(
+            session=session,
+            organization_id=user.organization_id,
+        ).readiness(code)
+        return _render(
+            request,
+            user=user,
+            query=code,
+            readiness=readiness,
+            result_code=request.query_params.get("result"),
+        )
+    except ShipmentExportCaseError as exc:
+        return _render(
+            request,
+            user=user,
+            query=code,
+            error=_safe_error(exc),
+            status_code=_status_for_error(exc),
+        )
+    finally:
+        session.close()
+
+
+@router.post(
+    "/export-case",
+    include_in_schema=False,
+    name="update_shipment_export_case",
+)
+async def update_shipment_export_case(request: Request):
+    user, denied = get_html_route_user(
+        request,
+        required_permission=Permission.TRACEABILITY_EVIDENCE,
+    )
+    if denied is not None:
+        return denied
+    csrf_response = await _csrf_or_response(request, user)
+    if csrf_response is not None:
+        return csrf_response
+
+    form = await request.form()
+    code = str(form.get("shipment_code", "")).strip()
+    session = get_tenant_scoped_db_session(user.organization_id)
+    if session is None:
+        return _render(
+            request,
+            user=user,
+            query=code,
+            error=_safe_error(ShipmentExportCasePersistenceError("db")),
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+        )
+
+    try:
+        service = ShipmentExportCaseService(
+            session=session,
+            organization_id=user.organization_id,
+        )
+        service.upsert_case(
+            shipment_code=code,
+            origin_profile=str(form.get("origin_profile", "")),
+            export_invoice_number=form.get("export_invoice_number"),
+            export_invoice_cae=form.get("export_invoice_cae"),
+            customs_destination_id=form.get("customs_destination_id"),
+            customs_subregime=form.get("customs_subregime"),
+            customs_officialized_at=_parse_datetime(
+                form.get("customs_officialized_at")
+            ),
+            notes=form.get("notes"),
+            actor_user_id=user.user_id,
+        )
+        set_tenant_db_context(session, user.organization_id)
+        # Evaluate immediately after the write so validation errors remain visible
+        # before redirecting. This query never changes ledger/stock.
+        service.readiness(code)
+        return RedirectResponse(
+            url=f"/export-case?{urlencode({'shipment_code': code, 'result': 'saved'})}",
+            status_code=status.HTTP_303_SEE_OTHER,
+        )
+    except ShipmentExportCaseError as exc:
+        try:
+            session.rollback()
+        except Exception:
+            pass
+        try:
+            set_tenant_db_context(session, user.organization_id)
+            readiness = service.readiness(code)
+        except Exception:
+            readiness = None
+        return _render(
+            request,
+            user=user,
+            query=code,
+            readiness=readiness,
+            error=_safe_error(exc),
+            status_code=_status_for_error(exc),
+        )
+    finally:
+        session.close()

--- a/src/litoral_trace/web/traceability_evidence.py
+++ b/src/litoral_trace/web/traceability_evidence.py
@@ -45,6 +45,7 @@ _SUBJECT_LABELS = {
 _EVIDENCE_LABELS = {
     "ORIGIN_AUTHORIZATION": "Autorización de origen",
     "FOREST_GUIDE": "Guía forestal",
+    "FRUIT_GUIDE": "Guía de Frutos",
     "REMITO": "Remito",
     "INVOICE": "Factura / documento comercial",
     "CERTIFICATE": "Certificado",

--- a/src/litoral_trace/web/traceability_release_control.py
+++ b/src/litoral_trace/web/traceability_release_control.py
@@ -8,6 +8,11 @@ from fastapi.responses import HTMLResponse
 
 from litoral_trace.auth.rbac import Permission
 from litoral_trace.db.tenant import get_tenant_scoped_db_session
+from litoral_trace.services.shipment_export_case import ShipmentExportCaseService
+from litoral_trace.services.shipment_export_release_control import (
+    apply_export_case_release_control,
+    is_international_shipment,
+)
 from litoral_trace.services.traceability_documentary_dossier import (
     build_documentary_dossier_bundle,
 )
@@ -143,6 +148,19 @@ async def render_release_control(
             dossier_available=dossier_available,
             dossier_error=dossier_error,
         )
+
+        # P1-B applies only to shipments with a non-AR destination. Domestic
+        # operations retain the existing release-control contract unchanged.
+        if is_international_shipment(payload):
+            export_readiness = ShipmentExportCaseService(
+                session=session,
+                organization_id=user.organization_id,
+            ).readiness(normalized_code)
+            control = apply_export_case_release_control(
+                control,
+                lineage_payload=payload,
+                readiness=export_readiness,
+            )
     except TraceabilityLineageNotFoundError as exc:
         return _render(
             request,

--- a/tests/test_ci_p26a_unittest.py
+++ b/tests/test_ci_p26a_unittest.py
@@ -64,7 +64,7 @@ def test_p26a_ci_checks_single_canonical_alembic_head():
     workflow = _workflow_text()
 
     assert "alembic heads" in workflow
-    assert "022_add_integration_history (head)" in workflow
+    assert "023_add_shipment_export_cases (head)" in workflow
     assert "alembic upgrade head" not in workflow
 
 

--- a/tests/test_p1b_export_release_control_unittest.py
+++ b/tests/test_p1b_export_release_control_unittest.py
@@ -1,0 +1,151 @@
+from __future__ import annotations
+
+from uuid import uuid4
+
+from litoral_trace.services.shipment_export_case import (
+    ExportRequirementView,
+    ShipmentExportReadinessView,
+)
+from litoral_trace.services.shipment_export_release_control import (
+    apply_export_case_release_control,
+    is_international_shipment,
+)
+
+
+def _base_control() -> dict:
+    return {
+        "overall": {
+            "state": "READY",
+            "state_label": "Listo",
+            "title": "Listo para compartir",
+            "message": "ok",
+            "ready": 2,
+            "attention": 0,
+            "blocked": 0,
+            "total": 2,
+            "progress": 100,
+        },
+        "checks": [
+            {
+                "key": "dispatch",
+                "title": "Estado del despacho",
+                "state": "READY",
+                "state_label": "Listo",
+                "summary": "ok",
+                "detail": "ok",
+                "action_label": "Abrir",
+                "action_href": "/operations",
+                "metric": "Final",
+                "category": "Despacho",
+            },
+            {
+                "key": "dossier",
+                "title": "Expediente verificable",
+                "state": "READY",
+                "state_label": "Listo",
+                "summary": "ok",
+                "detail": "ok",
+                "action_label": "Abrir",
+                "action_href": "/traceability",
+                "metric": "ok",
+                "category": "Expediente",
+            },
+        ],
+        "next_actions": [],
+        "links": {"operations": "/operations"},
+        "stages": [
+            {"label": "Origen", "state": "READY", "caption": "ok"},
+            {"label": "Salida", "state": "READY", "caption": "Expediente verificable"},
+        ],
+    }
+
+
+def _readiness(*, ready: bool) -> ShipmentExportReadinessView:
+    requirement = ExportRequirementView(
+        key="SIM_DESTINATION",
+        label="Identificador de destinación aduanera SIM",
+        satisfied=ready,
+        source="SIM",
+    )
+    return ShipmentExportReadinessView(
+        shipment_public_id=uuid4(),
+        shipment_code="EXP-001",
+        state="READY" if ready else "BLOCKED",
+        origin_profile="CULTIVATED",
+        requirements=(requirement,),
+        missing=() if ready else ("SIM_DESTINATION",),
+        evidence_types=("REMITO", "FRUIT_GUIDE"),
+        export_case=None,
+    )
+
+
+def test_p1b_domestic_release_control_remains_unchanged() -> None:
+    control = _base_control()
+    payload = {
+        "shipment": {
+            "shipment_code": "AR-001",
+            "destination_country": "AR",
+        }
+    }
+
+    assert is_international_shipment(payload) is False
+    result = apply_export_case_release_control(
+        control,
+        lineage_payload=payload,
+        readiness=None,
+    )
+
+    assert result is control
+    assert all(row["key"] != "export_case" for row in result["checks"])
+    assert "export_case" not in result["links"]
+
+
+def test_p1b_international_blocked_case_blocks_release_control() -> None:
+    payload = {
+        "shipment": {
+            "shipment_code": "EXP-001",
+            "destination_country": "DE",
+        }
+    }
+    result = apply_export_case_release_control(
+        _base_control(),
+        lineage_payload=payload,
+        readiness=_readiness(ready=False),
+    )
+
+    export_check = next(row for row in result["checks"] if row["key"] == "export_case")
+    assert export_check["state"] == "BLOCKED"
+    assert "destinación aduanera SIM" in export_check["detail"]
+    assert export_check["action_href"] == "/export-case?shipment_code=EXP-001"
+    assert result["overall"]["state"] == "BLOCKED"
+    assert result["overall"]["blocked"] == 1
+    assert result["links"]["export_case"] == "/export-case?shipment_code=EXP-001"
+    assert next(row for row in result["stages"] if row["label"] == "Salida")["state"] == "BLOCKED"
+
+
+def test_p1b_international_ready_case_keeps_release_ready() -> None:
+    payload = {
+        "shipment": {
+            "shipment_code": "EXP-001",
+            "destination_country": "NL",
+        }
+    }
+    result = apply_export_case_release_control(
+        _base_control(),
+        lineage_payload=payload,
+        readiness=_readiness(ready=True),
+    )
+
+    export_check = next(row for row in result["checks"] if row["key"] == "export_case")
+    assert export_check["state"] == "READY"
+    assert result["overall"] == {
+        "state": "READY",
+        "state_label": "Listo",
+        "title": "Listo para compartir",
+        "message": "Los controles operativos de Litoral Trace están cerrados y el expediente es verificable.",
+        "ready": 3,
+        "attention": 0,
+        "blocked": 0,
+        "total": 3,
+        "progress": 100,
+    }

--- a/tests/test_p1b_fruit_guide_picker_unittest.py
+++ b/tests/test_p1b_fruit_guide_picker_unittest.py
@@ -1,0 +1,10 @@
+from __future__ import annotations
+
+from litoral_trace.db.models.traceability_evidence_link import TRACEABILITY_EVIDENCE_TYPES
+from litoral_trace.web.traceability_evidence import _EVIDENCE_LABELS
+
+
+def test_p1b_fruit_guide_is_selectable_evidence() -> None:
+    assert "FRUIT_GUIDE" in TRACEABILITY_EVIDENCE_TYPES
+    assert _EVIDENCE_LABELS["FRUIT_GUIDE"] == "Guía de Frutos"
+    assert set(_EVIDENCE_LABELS).issubset(TRACEABILITY_EVIDENCE_TYPES)

--- a/tests/test_shipment_export_case_p1b_postgres_integration.py
+++ b/tests/test_shipment_export_case_p1b_postgres_integration.py
@@ -1,0 +1,417 @@
+from __future__ import annotations
+
+from pathlib import Path
+from uuid import uuid4
+
+import pytest
+from sqlalchemy import create_engine, text
+from sqlalchemy.orm import sessionmaker
+
+from litoral_trace.config.settings import normalize_database_url
+from litoral_trace.db.tenant import set_tenant_db_context
+from litoral_trace.services.shipment_export_case import (
+    ShipmentExportCaseNotFoundError,
+    ShipmentExportCaseService,
+)
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+ENV_PATH = ROOT_DIR / ".env.integration"
+EXPECTED_REVISION = "023_add_shipment_export_cases"
+
+
+def _read_env() -> dict[str, str]:
+    values: dict[str, str] = {}
+    if not ENV_PATH.exists():
+        return values
+    for raw_line in ENV_PATH.read_text(encoding="utf-8-sig").splitlines():
+        line = raw_line.strip()
+        if line and not line.startswith("#") and "=" in line:
+            name, value = line.split("=", 1)
+            values[name.strip()] = value.strip()
+    return values
+
+
+ENV = _read_env()
+ENABLED = (ENV.get("ENABLE_POSTGRES_TESTS") or "").lower() in {
+    "1", "true", "yes", "on"
+}
+RUNTIME_URL = ENV.get("TEST_POSTGRES_DATABASE_URL")
+OWNER_URL = ENV.get("TEST_POSTGRES_MIGRATION_DATABASE_URL")
+
+pytestmark = pytest.mark.skipif(
+    not (ENABLED and RUNTIME_URL and OWNER_URL),
+    reason="P1-B PostgreSQL tests require the isolated integration contract.",
+)
+
+
+def _engine(url: str):
+    return create_engine(
+        normalize_database_url(url), pool_pre_ping=True, hide_parameters=True
+    )
+
+
+def _runtime_call(RuntimeSession, organization_id: int, callback):
+    session = RuntimeSession()
+    try:
+        set_tenant_db_context(session, organization_id)
+        service = ShipmentExportCaseService(
+            session=session,
+            organization_id=organization_id,
+        )
+        return callback(service)
+    finally:
+        session.close()
+
+
+def _insert_evidence(
+    owner_engine,
+    *,
+    organization_id: int,
+    shipment_id: int,
+    evidence_type: str,
+    suffix: str,
+) -> None:
+    token = uuid4().hex
+    with owner_engine.begin() as connection:
+        vault_id = int(
+            connection.execute(
+                text(
+                    """
+                    INSERT INTO public.vault_documents (
+                        organization_id, original_filename, content_type,
+                        size_bytes, sha256, object_key, storage_backend,
+                        storage_bucket, document_type, status
+                    ) VALUES (
+                        :organization_id, :filename, 'application/pdf',
+                        16, :sha256, :object_key, 's3',
+                        'p1b-ci-vault', 'OTHER_EVIDENCE', 'available'
+                    ) RETURNING id
+                    """
+                ),
+                {
+                    "organization_id": organization_id,
+                    "filename": f"{evidence_type.lower()}-{suffix}.pdf",
+                    "sha256": (token * 2)[:64],
+                    "object_key": f"p1b/{suffix}/{evidence_type.lower()}-{token}.pdf",
+                },
+            ).scalar_one()
+        )
+        connection.execute(
+            text(
+                """
+                INSERT INTO public.traceability_evidence_links (
+                    organization_id, vault_document_id, shipment_id,
+                    evidence_type, reference_number, issuer
+                ) VALUES (
+                    :organization_id, :vault_document_id, :shipment_id,
+                    :evidence_type, :reference_number, :issuer
+                )
+                """
+            ),
+            {
+                "organization_id": organization_id,
+                "vault_document_id": vault_id,
+                "shipment_id": shipment_id,
+                "evidence_type": evidence_type,
+                "reference_number": f"P1B-{evidence_type}-{suffix}",
+                "issuer": "P1-B PostgreSQL acceptance",
+            },
+        )
+
+
+@pytest.fixture()
+def pg_export_case():
+    owner_engine = _engine(OWNER_URL)
+    runtime_engine = _engine(RUNTIME_URL)
+    RuntimeSession = sessionmaker(bind=runtime_engine, autoflush=False)
+    suffix = uuid4().hex[:10]
+    org_ids: list[int] = []
+    shipment_ids: list[int] = []
+    shipment_codes: list[str] = []
+
+    with owner_engine.begin() as connection:
+        revision = connection.execute(
+            text("SELECT version_num FROM alembic_version")
+        ).scalar_one()
+        if revision != EXPECTED_REVISION:
+            raise RuntimeError(
+                f"P1-B requires {EXPECTED_REVISION}; found {revision!r}."
+            )
+
+        for label in ("A", "B"):
+            org_id = int(
+                connection.execute(
+                    text(
+                        """
+                        INSERT INTO public.organizations
+                            (name, slug, tax_id, tier, description, is_active)
+                        VALUES
+                            (:name, :slug, :tax_id, 'pro', 'P1-B export case', true)
+                        RETURNING id
+                        """
+                    ),
+                    {
+                        "name": f"P1B Export Org {label} {suffix}",
+                        "slug": f"p1b-export-{label.lower()}-{suffix}",
+                        "tax_id": f"P1B-EXPORT-{label}-{suffix}",
+                    },
+                ).scalar_one()
+            )
+            shipment_code = f"P1B-{label}-{suffix}"
+            shipment_id = int(
+                connection.execute(
+                    text(
+                        """
+                        INSERT INTO public.shipments (
+                            organization_id, shipment_code, sale_reference,
+                            buyer_reference, destination_country, status
+                        ) VALUES (
+                            :organization_id, :shipment_code, :sale_reference,
+                            'Comprador UE P1-B', 'DE', 'DISPATCHED'
+                        ) RETURNING id
+                        """
+                    ),
+                    {
+                        "organization_id": org_id,
+                        "shipment_code": shipment_code,
+                        "sale_reference": f"SALE-{label}-{suffix}",
+                    },
+                ).scalar_one()
+            )
+            org_ids.append(org_id)
+            shipment_ids.append(shipment_id)
+            shipment_codes.append(shipment_code)
+
+    try:
+        yield (
+            RuntimeSession,
+            owner_engine,
+            org_ids,
+            shipment_ids,
+            shipment_codes,
+            suffix,
+        )
+    finally:
+        with owner_engine.begin() as connection:
+            params = {"org_a": org_ids[0], "org_b": org_ids[1]}
+            connection.execute(
+                text(
+                    "DELETE FROM public.traceability_evidence_links "
+                    "WHERE organization_id IN (:org_a, :org_b)"
+                ),
+                params,
+            )
+            connection.execute(
+                text(
+                    "DELETE FROM public.vault_documents "
+                    "WHERE organization_id IN (:org_a, :org_b)"
+                ),
+                params,
+            )
+            connection.execute(
+                text(
+                    "DELETE FROM public.shipment_export_cases "
+                    "WHERE organization_id IN (:org_a, :org_b)"
+                ),
+                params,
+            )
+            connection.execute(
+                text(
+                    "DELETE FROM public.shipments "
+                    "WHERE organization_id IN (:org_a, :org_b)"
+                ),
+                params,
+            )
+            connection.execute(
+                text(
+                    "DELETE FROM public.organizations "
+                    "WHERE id IN (:org_a, :org_b)"
+                ),
+                params,
+            )
+        runtime_engine.dispose()
+        owner_engine.dispose()
+
+
+def test_p1b_corrientes_arca_readiness_rls_and_least_privilege(
+    pg_export_case,
+) -> None:
+    (
+        RuntimeSession,
+        owner_engine,
+        org_ids,
+        shipment_ids,
+        shipment_codes,
+        suffix,
+    ) = pg_export_case
+    org_a, org_b = org_ids
+    shipment_a_id = shipment_ids[0]
+    shipment_a = shipment_codes[0]
+
+    # A case with no provincial/Vault evidence and no ARCA/SIM references must
+    # fail closed and enumerate concrete missing requirements.
+    created = _runtime_call(
+        RuntimeSession,
+        org_a,
+        lambda service: service.upsert_case(
+            shipment_code=shipment_a,
+            origin_profile="CULTIVATED",
+        ),
+    )
+    assert created.origin_profile == "CULTIVATED"
+
+    cultivated_blocked = _runtime_call(
+        RuntimeSession,
+        org_a,
+        lambda service: service.readiness(shipment_a),
+    )
+    assert cultivated_blocked.state == "BLOCKED"
+    assert set(cultivated_blocked.missing) == {
+        "CULTIVATED_INVOICE_OR_REMITO",
+        "FRUIT_GUIDE",
+        "EXPORT_INVOICE_E",
+        "SIM_DESTINATION",
+        "SIM_SUBREGIME",
+    }
+
+    _insert_evidence(
+        owner_engine,
+        organization_id=org_a,
+        shipment_id=shipment_a_id,
+        evidence_type="REMITO",
+        suffix=suffix,
+    )
+    _insert_evidence(
+        owner_engine,
+        organization_id=org_a,
+        shipment_id=shipment_a_id,
+        evidence_type="FRUIT_GUIDE",
+        suffix=suffix,
+    )
+
+    _runtime_call(
+        RuntimeSession,
+        org_a,
+        lambda service: service.upsert_case(
+            shipment_code=shipment_a,
+            origin_profile="CULTIVATED",
+            export_invoice_number="E-0001-00000001",
+            export_invoice_cae="76123456789012",
+            customs_destination_id=f"SIM-{suffix}",
+            customs_subregime="EC01",
+        ),
+    )
+    cultivated_ready = _runtime_call(
+        RuntimeSession,
+        org_a,
+        lambda service: service.readiness(shipment_a),
+    )
+    assert cultivated_ready.state == "READY"
+    assert cultivated_ready.missing == ()
+    assert "FRUIT_GUIDE" in cultivated_ready.evidence_types
+    assert "REMITO" in cultivated_ready.evidence_types
+
+    # Switching the same shipment to native forest changes the documentary
+    # contract immediately and must block until Guía Forestal + Vale exist.
+    _runtime_call(
+        RuntimeSession,
+        org_a,
+        lambda service: service.upsert_case(
+            shipment_code=shipment_a,
+            origin_profile="NATIVE",
+            export_invoice_number="E-0001-00000001",
+            customs_destination_id=f"SIM-{suffix}",
+            customs_subregime="EC01",
+        ),
+    )
+    native_blocked = _runtime_call(
+        RuntimeSession,
+        org_a,
+        lambda service: service.readiness(shipment_a),
+    )
+    assert native_blocked.state == "BLOCKED"
+    assert set(native_blocked.missing) == {
+        "FOREST_GUIDE",
+        "FOREST_TRANSPORT_VOUCHER",
+    }
+
+    _insert_evidence(
+        owner_engine,
+        organization_id=org_a,
+        shipment_id=shipment_a_id,
+        evidence_type="FOREST_GUIDE",
+        suffix=suffix,
+    )
+    _insert_evidence(
+        owner_engine,
+        organization_id=org_a,
+        shipment_id=shipment_a_id,
+        evidence_type="TRANSPORT",
+        suffix=suffix,
+    )
+    native_ready = _runtime_call(
+        RuntimeSession,
+        org_a,
+        lambda service: service.readiness(shipment_a),
+    )
+    assert native_ready.state == "READY"
+    assert native_ready.missing == ()
+
+    # Tenant B cannot resolve tenant A's shipment even with the exact code.
+    with pytest.raises(ShipmentExportCaseNotFoundError):
+        _runtime_call(
+            RuntimeSession,
+            org_b,
+            lambda service: service.readiness(shipment_a),
+        )
+
+    with owner_engine.connect() as connection:
+        rls = connection.execute(
+            text(
+                """
+                SELECT relrowsecurity, relforcerowsecurity
+                FROM pg_class
+                WHERE relname = 'shipment_export_cases'
+                """
+            )
+        ).mappings().one()
+        assert rls["relrowsecurity"] is True
+        assert rls["relforcerowsecurity"] is True
+
+        policies = connection.execute(
+            text(
+                """
+                SELECT cmd
+                FROM pg_policies
+                WHERE schemaname = 'public'
+                  AND tablename = 'shipment_export_cases'
+                ORDER BY cmd
+                """
+            )
+        ).scalars().all()
+        assert set(policies) == {"SELECT", "INSERT", "UPDATE"}
+
+        for privilege in ("SELECT", "INSERT", "UPDATE"):
+            assert connection.execute(
+                text(
+                    "SELECT has_table_privilege("
+                    "'litoral_trace_app', 'public.shipment_export_cases', :privilege)"
+                ),
+                {"privilege": privilege},
+            ).scalar_one() is True
+        assert connection.execute(
+            text(
+                "SELECT has_table_privilege("
+                "'litoral_trace_app', 'public.shipment_export_cases', 'DELETE')"
+            )
+        ).scalar_one() is False
+
+        for privilege in ("SELECT", "INSERT", "UPDATE", "DELETE"):
+            assert connection.execute(
+                text(
+                    "SELECT has_table_privilege("
+                    "'litoral_trace_worker_executor', "
+                    "'public.shipment_export_cases', :privilege)"
+                ),
+                {"privilege": privilege},
+            ).scalar_one() is False

--- a/tests/test_ux10g_operations_http_postgres_e2e.py
+++ b/tests/test_ux10g_operations_http_postgres_e2e.py
@@ -129,7 +129,7 @@ def test_operations_receipt_real_http_login_csrf_rls_and_posting(
     try:
         with owner_engine.begin() as connection:
             revision = connection.execute(text("SELECT version_num FROM alembic_version")).scalar_one()
-            assert revision == "022_add_integration_history"
+            assert revision == "023_add_shipment_export_cases"
 
             organization_id = int(
                 connection.execute(

--- a/tests/test_ux10g_traceability_runtime_postgres_integration.py
+++ b/tests/test_ux10g_traceability_runtime_postgres_integration.py
@@ -64,10 +64,10 @@ def ux10g_pg():
         revision = connection.execute(
             text("SELECT version_num FROM alembic_version")
         ).scalar_one()
-        if revision != "022_add_integration_history":
+        if revision != "023_add_shipment_export_cases":
             raise RuntimeError(
                 "UX10-G requires canonical head "
-                f"022_add_integration_history; found {revision!r}."
+                f"023_add_shipment_export_cases; found {revision!r}."
             )
 
         org_id = int(


### PR DESCRIPTION
Implements issue #96 as an additive, tenant-safe export-dossier layer attached to existing `Shipment` records.

Scope:
- Alembic 023 + `shipment_export_cases` with FORCE RLS and least privilege.
- Corrientes profiles: CULTIVATED vs NATIVE.
- Cultivated readiness: Factura/Remito evidence + Guía de Frutos.
- Native readiness: Guía Forestal + Vale/Transport evidence.
- ARCA Factura E reference + SIM destination/subregime.
- Explicit fail-closed READY/BLOCKED requirements and missing-item list.
- Vault remains the only binary evidence store; P1-B stores references only.
- API `/api/v1/export-cases/{shipment_code}` and browser workspace `/export-case`.
- Existing RBAC reused: LOTE_READ for consultation, TRACEABILITY_EVIDENCE for management.
- `ledger_mutated=false`; no export-case operation posts traceability, stock or shipment ledger movements.
- PostgreSQL/PostGIS gate covers cultivated BLOCKED→READY, native BLOCKED→READY, tenant isolation, FORCE RLS and no DELETE/worker access.
- Historical P1-A PostgreSQL gate is pinned to its owned Alembic 022 revision; P1-B validates canonical head 023 independently.

Production database is not modified by this PR. Production cutover remains a separate recovery-gated step after CI and exact-production-clone validation.