### PR TITLE
P1.7-B: App Shell 2.0 semantic restyle

### DIFF
--- a/src/litoral_trace/static/src/app-shell.css
+++ b/src/litoral_trace/static/src/app-shell.css
@@ -1,0 +1,271 @@
+.lt-app-shell {
+  min-height: 100vh;
+  background:
+    radial-gradient(circle at 78% -12%, rgb(16 185 129 / 0.055), transparent 28rem),
+    var(--lt-canvas);
+}
+
+.lt-app-overlay {
+  background: rgb(2 6 23 / 0.64);
+  backdrop-filter: blur(4px);
+}
+
+.lt-sidebar {
+  border-color: rgb(51 65 85 / 0.72);
+  background:
+    radial-gradient(circle at 20% 4%, rgb(16 185 129 / 0.11), transparent 12rem),
+    linear-gradient(180deg, #07111f 0%, #0b1220 48%, #0f172a 100%);
+  box-shadow: 18px 0 42px -30px rgb(2 6 23 / 0.7);
+}
+
+.lt-sidebar__brandbar {
+  border-color: rgb(51 65 85 / 0.62);
+  background: rgb(2 6 23 / 0.16);
+}
+
+.lt-brand-link {
+  border-radius: var(--lt-radius-md);
+}
+
+.lt-brand-link:focus-visible {
+  outline: 2px solid #34d399;
+  outline-offset: 3px;
+}
+
+.lt-brand-mark {
+  background: linear-gradient(145deg, #10b981, #047857);
+  box-shadow:
+    0 10px 22px -14px rgb(16 185 129 / 0.9),
+    inset 0 1px 0 rgb(255 255 255 / 0.14);
+}
+
+.lt-brand-name {
+  letter-spacing: -0.018em;
+}
+
+.lt-brand-descriptor {
+  color: #6ee7b7;
+}
+
+.lt-sidebar__nav {
+  scrollbar-width: thin;
+  scrollbar-color: rgb(71 85 105 / 0.72) transparent;
+}
+
+.lt-sidebar__nav::-webkit-scrollbar {
+  width: 8px;
+}
+
+.lt-sidebar__nav::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+.lt-sidebar__nav::-webkit-scrollbar-thumb {
+  border: 2px solid transparent;
+  border-radius: 9999px;
+  background: rgb(71 85 105 / 0.68);
+  background-clip: padding-box;
+}
+
+.lt-nav-section {
+  position: relative;
+}
+
+.lt-nav-section__label {
+  color: #64748b;
+  letter-spacing: 0.17em;
+}
+
+.lt-nav-link {
+  position: relative;
+  border: 1px solid transparent;
+  isolation: isolate;
+  color: #cbd5e1;
+}
+
+.lt-nav-link::before {
+  content: "";
+  position: absolute;
+  inset-block: 0.55rem;
+  left: -0.25rem;
+  width: 0.1875rem;
+  border-radius: 9999px;
+  background: transparent;
+  transition:
+    background-color var(--lt-transition-fast),
+    box-shadow var(--lt-transition-fast);
+}
+
+.lt-nav-link:hover {
+  border-color: rgb(71 85 105 / 0.35);
+  background: rgb(30 41 59 / 0.68);
+  color: #f8fafc;
+}
+
+.lt-nav-link[aria-current="page"] {
+  border-color: rgb(52 211 153 / 0.18);
+  background: linear-gradient(90deg, rgb(6 78 59 / 0.47), rgb(15 23 42 / 0.86));
+  color: #ffffff;
+  box-shadow:
+    inset 0 1px 0 rgb(255 255 255 / 0.035),
+    0 10px 20px -18px rgb(16 185 129 / 0.65);
+}
+
+.lt-nav-link[aria-current="page"]::before {
+  background: #34d399;
+  box-shadow: 0 0 14px rgb(52 211 153 / 0.42);
+}
+
+.lt-nav-icon {
+  border-radius: 0.5rem;
+  transition:
+    background-color var(--lt-transition-fast),
+    color var(--lt-transition-fast);
+}
+
+.lt-nav-link:hover .lt-nav-icon {
+  background: rgb(51 65 85 / 0.5);
+  color: #cbd5e1;
+}
+
+.lt-nav-link[aria-current="page"] .lt-nav-icon {
+  background: rgb(16 185 129 / 0.12);
+  color: #6ee7b7;
+}
+
+.lt-active-dot {
+  box-shadow: 0 0 10px rgb(52 211 153 / 0.72);
+}
+
+.lt-sidebar__footer {
+  border-color: rgb(51 65 85 / 0.65);
+  background: rgb(2 6 23 / 0.12);
+}
+
+.lt-org-card {
+  border-color: rgb(71 85 105 / 0.55);
+  background: rgb(15 23 42 / 0.72);
+  box-shadow: inset 0 1px 0 rgb(255 255 255 / 0.025);
+}
+
+.lt-org-card__icon {
+  background: rgb(51 65 85 / 0.58);
+  color: #94a3b8;
+}
+
+.lt-session-action {
+  border-color: rgb(71 85 105 / 0.66);
+}
+
+.lt-session-action:hover {
+  border-color: rgb(100 116 139 / 0.88);
+  background: rgb(51 65 85 / 0.66);
+}
+
+.lt-workspace {
+  min-width: 0;
+  background: transparent;
+}
+
+.lt-topbar {
+  border-color: rgb(226 232 240 / 0.92);
+  background: rgb(255 255 255 / 0.9);
+  box-shadow: 0 1px 0 rgb(15 23 42 / 0.02);
+  backdrop-filter: blur(18px) saturate(140%);
+}
+
+.lt-topbar__inner {
+  max-width: 100%;
+}
+
+.lt-page-context__title {
+  color: var(--lt-text-primary);
+  font-weight: 750;
+  letter-spacing: -0.012em;
+}
+
+.lt-page-context__subtitle {
+  color: var(--lt-text-muted);
+}
+
+.lt-drawer-trigger {
+  transition:
+    border-color var(--lt-transition-fast),
+    background-color var(--lt-transition-fast),
+    box-shadow var(--lt-transition-fast);
+}
+
+.lt-drawer-trigger:hover {
+  border-color: var(--lt-border-strong);
+  box-shadow: var(--lt-shadow-sm);
+}
+
+.lt-audit-pill {
+  border-color: var(--lt-positive-border);
+  background: linear-gradient(180deg, #f0fdf4, #ecfdf5);
+  color: #065f46;
+  box-shadow: inset 0 1px 0 rgb(255 255 255 / 0.75);
+}
+
+.lt-audit-pill__dot {
+  box-shadow: 0 0 0 3px rgb(16 185 129 / 0.11);
+}
+
+.lt-user-meta__name {
+  color: var(--lt-text-secondary);
+}
+
+.lt-user-meta__role {
+  color: var(--lt-text-muted);
+}
+
+.lt-user-avatar {
+  background: linear-gradient(145deg, #1e293b, #0f172a);
+  box-shadow:
+    inset 0 1px 0 rgb(255 255 255 / 0.08),
+    0 4px 12px -8px rgb(15 23 42 / 0.8);
+}
+
+.lt-main {
+  min-width: 0;
+}
+
+.lt-content-frame {
+  min-width: 0;
+}
+
+@media (max-width: 1023px) {
+  .lt-sidebar {
+    width: min(18rem, calc(100vw - 2rem));
+  }
+
+  .lt-topbar {
+    box-shadow: 0 6px 18px -18px rgb(15 23 42 / 0.7);
+  }
+}
+
+@media (min-width: 1024px) {
+  .lt-workspace {
+    padding-left: 18rem;
+  }
+}
+
+@media (max-width: 639px) {
+  .lt-main {
+    padding-top: 1.25rem;
+    padding-bottom: 1.5rem;
+  }
+
+  .lt-page-context__title {
+    font-size: 0.8125rem;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .lt-nav-link,
+  .lt-nav-link::before,
+  .lt-nav-icon,
+  .lt-drawer-trigger {
+    transition-duration: 0.01ms;
+  }
+}

--- a/src/litoral_trace/templates/app/base_app.html
+++ b/src/litoral_trace/templates/app/base_app.html
@@ -1,5 +1,9 @@
 {% extends "base.html" %}
 
+{% block head_extra %}
+<link rel="stylesheet" href="{{ url_for('static', path='/src/app-shell.css') }}">
+{% endblock %}
+
 {% block body_class %}min-h-screen bg-slate-50 font-sans text-slate-900 antialiased{% endblock %}
 
 {% block shell %}
@@ -7,18 +11,18 @@
     Ir al contenido principal
 </a>
 
-<div class="min-h-screen bg-slate-50">
-    <div data-app-drawer-overlay class="fixed inset-0 z-40 hidden bg-slate-950/60 backdrop-blur-sm lg:hidden" aria-hidden="true"></div>
+<div class="lt-app-shell min-h-screen bg-slate-50">
+    <div data-app-drawer-overlay class="lt-app-overlay fixed inset-0 z-40 hidden bg-slate-950/60 backdrop-blur-sm lg:hidden" aria-hidden="true"></div>
 
-    <aside id="app-navigation" data-app-drawer data-open="false" class="fixed inset-y-0 left-0 z-50 flex w-72 -translate-x-full flex-col border-r border-slate-800 bg-slate-950 text-slate-200 shadow-2xl transition-transform duration-200 ease-out lg:translate-x-0">
-        <div class="flex h-16 shrink-0 items-center gap-3 border-b border-slate-800 px-4">
-            <a href="/dashboard" class="flex min-w-0 flex-1 items-center gap-3" aria-label="Ir al inicio de Litoral Trace">
-                <span class="flex h-9 w-9 shrink-0 items-center justify-center rounded-xl bg-emerald-600 text-white shadow-sm shadow-emerald-950" aria-hidden="true">
+    <aside id="app-navigation" data-app-drawer data-open="false" class="lt-sidebar fixed inset-y-0 left-0 z-50 flex w-72 -translate-x-full flex-col border-r border-slate-800 bg-slate-950 text-slate-200 shadow-2xl transition-transform duration-200 ease-out lg:translate-x-0">
+        <div class="lt-sidebar__brandbar flex h-16 shrink-0 items-center gap-3 border-b border-slate-800 px-4">
+            <a href="/dashboard" class="lt-brand-link flex min-w-0 flex-1 items-center gap-3" aria-label="Ir al inicio de Litoral Trace">
+                <span class="lt-brand-mark flex h-9 w-9 shrink-0 items-center justify-center rounded-xl bg-emerald-600 text-white shadow-sm shadow-emerald-950" aria-hidden="true">
                     <i class="fa-solid fa-tree"></i>
                 </span>
                 <span class="min-w-0">
-                    <span class="block truncate text-base font-bold tracking-tight text-white">Litoral Trace</span>
-                    <span class="block truncate text-[10px] font-bold uppercase tracking-[0.14em] text-emerald-400">Origen · cadena de custodia</span>
+                    <span class="lt-brand-name block truncate text-base font-bold tracking-tight text-white">Litoral Trace</span>
+                    <span class="lt-brand-descriptor block truncate text-[10px] font-bold uppercase tracking-[0.14em] text-emerald-400">Origen · cadena de custodia</span>
                 </span>
             </a>
 
@@ -27,7 +31,7 @@
             </button>
         </div>
 
-        <nav class="min-h-0 flex-1 overflow-y-auto px-3 py-4" aria-label="Navegación principal">
+        <nav class="lt-sidebar__nav min-h-0 flex-1 overflow-y-auto px-3 py-4" aria-label="Navegación principal">
             {% set nav_sections = [
                 ("operacion", "Operación"),
                 ("compliance", "Trazabilidad y evidencia"),
@@ -37,12 +41,12 @@
             {% for section_key, section_label in nav_sections %}
                 {% set section_items = navigation | selectattr("section", "equalto", section_key) | list %}
                 {% if section_items %}
-                <section class="mb-5">
-                    <p class="mb-2 px-3 text-[10px] font-bold uppercase tracking-[0.18em] text-slate-500">{{ section_label }}</p>
+                <section class="lt-nav-section mb-5">
+                    <p class="lt-nav-section__label mb-2 px-3 text-[10px] font-bold uppercase tracking-[0.18em] text-slate-500">{{ section_label }}</p>
                     <div class="space-y-1">
                         {% for item in section_items %}
-                        <a href="{{ item.href }}" {% if item.active %}aria-current="page"{% endif %} class="group flex items-center gap-3 rounded-xl px-3 py-2.5 text-sm transition-colors {% if item.active %}bg-slate-900 font-semibold text-white ring-1 ring-inset ring-slate-800{% else %}font-medium text-slate-300 hover:bg-slate-900 hover:text-white{% endif %}">
-                            <span class="flex h-7 w-7 shrink-0 items-center justify-center text-sm {% if item.active %}text-emerald-400{% else %}text-slate-500 group-hover:text-slate-300{% endif %}" aria-hidden="true">
+                        <a href="{{ item.href }}" {% if item.active %}aria-current="page"{% endif %} class="lt-nav-link group flex items-center gap-3 rounded-xl px-3 py-2.5 text-sm transition-colors {% if item.active %}bg-slate-900 font-semibold text-white ring-1 ring-inset ring-slate-800{% else %}font-medium text-slate-300 hover:bg-slate-900 hover:text-white{% endif %}">
+                            <span class="lt-nav-icon flex h-7 w-7 shrink-0 items-center justify-center text-sm {% if item.active %}text-emerald-400{% else %}text-slate-500 group-hover:text-slate-300{% endif %}" aria-hidden="true">
                                 {% if item.key == "dashboard" %}
                                 <i class="fa-solid fa-chart-line"></i>
                                 {% elif item.key == "operations" %}
@@ -64,7 +68,7 @@
                                 {% endif %}
                             </span>
                             <span class="min-w-0 flex-1 truncate">{{ item.label }}</span>
-                            {% if item.active %}<span class="h-1.5 w-1.5 shrink-0 rounded-full bg-emerald-400" aria-hidden="true"></span>{% endif %}
+                            {% if item.active %}<span class="lt-active-dot h-1.5 w-1.5 shrink-0 rounded-full bg-emerald-400" aria-hidden="true"></span>{% endif %}
                         </a>
                         {% endfor %}
                     </div>
@@ -73,9 +77,9 @@
             {% endfor %}
         </nav>
 
-        <div class="shrink-0 border-t border-slate-800 p-3" aria-label="Organización y sesión">
-            <div class="flex items-center gap-2 rounded-xl border border-slate-800 bg-slate-900 p-2.5">
-                <span class="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg bg-slate-800 text-slate-300" aria-hidden="true">
+        <div class="lt-sidebar__footer shrink-0 border-t border-slate-800 p-3" aria-label="Organización y sesión">
+            <div class="lt-org-card flex items-center gap-2 rounded-xl border border-slate-800 bg-slate-900 p-2.5">
+                <span class="lt-org-card__icon flex h-8 w-8 shrink-0 items-center justify-center rounded-lg bg-slate-800 text-slate-300" aria-hidden="true">
                     <i class="fa-solid fa-building"></i>
                 </span>
                 <div class="min-w-0 flex-1">
@@ -84,7 +88,7 @@
                 </div>
                 <form method="post" action="/logout" class="shrink-0">
                     <input type="hidden" name="{{ csrf_form_field }}" value="{{ csrf_token }}">
-                    <button type="submit" class="flex h-8 w-8 items-center justify-center rounded-lg border border-slate-700 text-slate-400 transition hover:border-slate-600 hover:bg-slate-800 hover:text-white" aria-label="Cerrar sesión" title="Cerrar sesión">
+                    <button type="submit" class="lt-session-action flex h-8 w-8 items-center justify-center rounded-lg border border-slate-700 text-slate-400 transition hover:border-slate-600 hover:bg-slate-800 hover:text-white" aria-label="Cerrar sesión" title="Cerrar sesión">
                         <i class="fa-solid fa-right-from-bracket" aria-hidden="true"></i>
                     </button>
                 </form>
@@ -92,37 +96,37 @@
         </div>
     </aside>
 
-    <div class="min-h-screen lg:pl-72">
+    <div class="lt-workspace min-h-screen lg:pl-72">
         {% set current_page = namespace(label="Litoral Trace") %}
         {% for item in navigation %}{% if item.active %}{% set current_page.label = item.label %}{% endif %}{% endfor %}
 
-        <header class="sticky top-0 z-30 border-b border-slate-200 bg-white/95 backdrop-blur-xl">
-            <div class="flex h-16 items-center gap-4 px-4 sm:px-6 lg:px-8">
-                <button type="button" data-app-drawer-open class="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg border border-slate-200 bg-white text-slate-700 shadow-sm hover:bg-slate-50 lg:hidden" aria-label="Abrir navegación" aria-controls="app-navigation" aria-expanded="false">
+        <header class="lt-topbar sticky top-0 z-30 border-b border-slate-200 bg-white/95 backdrop-blur-xl">
+            <div class="lt-topbar__inner flex h-16 items-center gap-4 px-4 sm:px-6 lg:px-8">
+                <button type="button" data-app-drawer-open class="lt-drawer-trigger flex h-10 w-10 shrink-0 items-center justify-center rounded-lg border border-slate-200 bg-white text-slate-700 shadow-sm hover:bg-slate-50 lg:hidden" aria-label="Abrir navegación" aria-controls="app-navigation" aria-expanded="false">
                     <i class="fa-solid fa-bars" aria-hidden="true"></i>
                 </button>
 
-                <div class="min-w-0 flex-1">
-                    <p class="truncate text-sm font-semibold text-slate-950">{{ current_page.label }}</p>
-                    <p class="hidden truncate text-xs text-slate-500 sm:block">Origen y cadena de custodia · Litoral Trace</p>
+                <div class="lt-page-context min-w-0 flex-1">
+                    <p class="lt-page-context__title truncate text-sm font-semibold text-slate-950">{{ current_page.label }}</p>
+                    <p class="lt-page-context__subtitle hidden truncate text-xs text-slate-500 sm:block">Origen y cadena de custodia · Litoral Trace</p>
                 </div>
 
                 <div class="flex items-center gap-3">
-                    <span class="hidden items-center gap-2 rounded-full border border-emerald-200 bg-emerald-50 px-3 py-1.5 text-xs font-semibold text-emerald-800 md:inline-flex">
-                        <span class="h-2 w-2 rounded-full bg-emerald-500" aria-hidden="true"></span>
+                    <span class="lt-audit-pill hidden items-center gap-2 rounded-full border border-emerald-200 bg-emerald-50 px-3 py-1.5 text-xs font-semibold text-emerald-800 md:inline-flex">
+                        <span class="lt-audit-pill__dot h-2 w-2 rounded-full bg-emerald-500" aria-hidden="true"></span>
                         Evidencia auditable
                     </span>
-                    <div class="hidden max-w-64 text-right xl:block">
-                        <p class="truncate text-xs font-semibold text-slate-800" title="{{ user.organization_name }}">{{ user.organization_name }}</p>
-                        <p class="truncate text-[11px] text-slate-500">{{ user.username }} · {{ user.role|upper }}</p>
+                    <div class="lt-user-meta hidden max-w-64 text-right xl:block">
+                        <p class="lt-user-meta__name truncate text-xs font-semibold text-slate-800" title="{{ user.organization_name }}">{{ user.organization_name }}</p>
+                        <p class="lt-user-meta__role truncate text-[11px] text-slate-500">{{ user.username }} · {{ user.role|upper }}</p>
                     </div>
-                    <div class="flex h-9 w-9 shrink-0 items-center justify-center rounded-full bg-slate-900 text-sm font-bold text-white" aria-hidden="true">{{ user.username[:1]|upper }}</div>
+                    <div class="lt-user-avatar flex h-9 w-9 shrink-0 items-center justify-center rounded-full bg-slate-900 text-sm font-bold text-white" aria-hidden="true">{{ user.username[:1]|upper }}</div>
                 </div>
             </div>
         </header>
 
-        <main id="main-content" tabindex="-1" class="px-4 py-6 sm:px-6 lg:px-8">
-            <div class="mx-auto w-full max-w-[1536px]">{% block content %}{% endblock %}</div>
+        <main id="main-content" tabindex="-1" class="lt-main px-4 py-6 sm:px-6 lg:px-8">
+            <div class="lt-content-frame mx-auto w-full max-w-[1536px]">{% block content %}{% endblock %}</div>
         </main>
     </div>
 </div>

--- a/src/litoral_trace/templates/app/base_app.html
+++ b/src/litoral_trace/templates/app/base_app.html
@@ -31,7 +31,7 @@
             </button>
         </div>
 
-        <nav class="lt-sidebar__nav min-h-0 flex-1 overflow-y-auto px-3 py-4" aria-label="Navegación principal">
+        <nav class="min-h-0 flex-1 overflow-y-auto px-3 py-4 lt-sidebar__nav" aria-label="Navegación principal">
             {% set nav_sections = [
                 ("operacion", "Operación"),
                 ("compliance", "Trazabilidad y evidencia"),

--- a/tests/test_ui_app_shell_p17_unittest.py
+++ b/tests/test_ui_app_shell_p17_unittest.py
@@ -1,0 +1,96 @@
+from pathlib import Path
+
+from jinja2 import Environment
+
+
+ROOT = Path(__file__).resolve().parents[1]
+TEMPLATES = ROOT / "src" / "litoral_trace" / "templates"
+STATIC_SRC = ROOT / "src" / "litoral_trace" / "static" / "src"
+
+
+def _read(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+def test_p17_app_shell_template_parses_and_loads_semantic_layer() -> None:
+    shell = _read(TEMPLATES / "app" / "base_app.html")
+
+    Environment().parse(shell)
+
+    assert "path='/src/app-shell.css'" in shell
+    for class_name in (
+        "lt-app-shell",
+        "lt-sidebar",
+        "lt-nav-link",
+        "lt-workspace",
+        "lt-topbar",
+        "lt-main",
+    ):
+        assert class_name in shell
+
+
+def test_p17_app_shell_preserves_drawer_accessibility_contract() -> None:
+    shell = _read(TEMPLATES / "app" / "base_app.html")
+
+    assert 'id="app-navigation"' in shell
+    assert "data-app-drawer" in shell
+    assert "data-app-drawer-overlay" in shell
+    assert "data-app-drawer-open" in shell
+    assert "data-app-drawer-close" in shell
+    assert 'aria-controls="app-navigation"' in shell
+    assert 'aria-expanded="false"' in shell
+    assert 'href="#main-content"' in shell
+    assert 'id="main-content"' in shell
+    assert 'tabindex="-1"' in shell
+
+
+def test_p17_app_shell_preserves_navigation_and_session_contracts() -> None:
+    shell = _read(TEMPLATES / "app" / "base_app.html")
+
+    assert '("operacion", "Operación")' in shell
+    assert '("compliance", "Trazabilidad y evidencia")' in shell
+    assert '("administracion", "Administración")' in shell
+    assert 'navigation | selectattr("section", "equalto", section_key)' in shell
+    assert 'aria-current="page"' in shell
+
+    assert 'method="post" action="/logout"' in shell
+    assert 'name="{{ csrf_form_field }}"' in shell
+    assert 'value="{{ csrf_token }}"' in shell
+
+
+def test_p17_app_shell_keeps_existing_responsive_tailwind_candidates() -> None:
+    shell = _read(TEMPLATES / "app" / "base_app.html")
+
+    # B layers semantic CSS on top of the existing responsive mechanics.
+    # These candidates are intentionally retained so drawer behavior and the
+    # tracked Tailwind artifact cannot drift as a side effect of the restyle.
+    for candidate in (
+        "w-72",
+        "-translate-x-full",
+        "lg:translate-x-0",
+        "lg:pl-72",
+        "lg:hidden",
+        "sticky top-0",
+        "max-w-[1536px]",
+    ):
+        assert candidate in shell
+
+
+def test_p17_app_shell_css_defines_primary_shell_states() -> None:
+    css = _read(STATIC_SRC / "app-shell.css")
+
+    for selector in (
+        ".lt-app-shell",
+        ".lt-sidebar",
+        ".lt-nav-link[aria-current=\"page\"]",
+        ".lt-org-card",
+        ".lt-topbar",
+        ".lt-audit-pill",
+        ".lt-user-avatar",
+        ".lt-main",
+    ):
+        assert selector in css
+
+    assert "@media (max-width: 1023px)" in css
+    assert "@media (min-width: 1024px)" in css
+    assert "@media (prefers-reduced-motion: reduce)" in css


### PR DESCRIPTION
## Scope

Stacked UX2.0-B change on top of the green UX2.0-A design-system branch.

### Included
- semantic `app-shell.css` layer for the authenticated shell
- refined sidebar hierarchy, active navigation semantics, organization/session card and audit status treatment
- refined sticky topbar, page context and user identity presentation
- responsive shell refinements without changing the existing drawer mechanism
- reduced-motion-safe transitions
- dedicated unit gate for Jinja syntax, drawer accessibility hooks, navigation/session contracts, legacy responsive Tailwind candidates and shell CSS states

### Contract preservation
- no API/web route changes
- no RBAC/navigation source changes
- no `app.js` changes
- `data-app-drawer*` hooks preserved
- POST `/logout` + CSRF preserved
- `aria-current`, skip-link and `main-content` focus target preserved
- existing Tailwind responsive candidates retained; semantic CSS is layered after generated styles

### Parallel-work safety
This PR targets `p1.7-ui-ux-2.0`, not `p2-enterprise-production`, so UX2.0-A remains independently reviewable and the parallel backend execution remains untouched.