### PR TITLE
P1.7-D: LTField form primitives

### DIFF
--- a/src/litoral_trace/static/src/form-controls.css
+++ b/src/litoral_trace/static/src/form-controls.css
@@ -1,0 +1,145 @@
+.lt-form {
+  min-width: 0;
+}
+
+.lt-form__section {
+  min-width: 0;
+  display: grid;
+  gap: 1rem;
+}
+
+.lt-form__grid {
+  min-width: 0;
+  display: grid;
+  grid-template-columns: repeat(12, minmax(0, 1fr));
+  gap: 1rem;
+}
+
+.lt-form__actions {
+  display: flex;
+  min-width: 0;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 0.625rem;
+}
+
+.lt-field {
+  min-width: 0;
+}
+
+.lt-field__label-row {
+  display: flex;
+  min-width: 0;
+  align-items: baseline;
+  gap: 0.375rem;
+}
+
+.lt-field__required {
+  color: var(--lt-danger);
+  font-size: 0.75rem;
+  font-weight: 800;
+}
+
+.lt-field__optional {
+  color: var(--lt-text-muted);
+  font-size: 0.6875rem;
+  font-weight: 500;
+}
+
+.lt-field__error {
+  margin: 0;
+  color: var(--lt-danger);
+  font-size: 0.6875rem;
+  font-weight: 650;
+  line-height: 1rem;
+}
+
+.lt-field[data-state="error"] .lt-field__label {
+  color: var(--lt-danger);
+}
+
+.lt-field[data-state="success"] .lt-control {
+  border-color: var(--lt-positive);
+}
+
+.lt-control[type="search"]::-webkit-search-cancel-button {
+  cursor: pointer;
+}
+
+textarea.lt-control {
+  min-height: 7rem;
+  resize: vertical;
+}
+
+select.lt-control {
+  appearance: auto;
+}
+
+.lt-check-field {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr);
+  gap: 0.625rem;
+  align-items: start;
+  color: var(--lt-text-secondary);
+  cursor: pointer;
+}
+
+.lt-check-field__control {
+  width: 1rem;
+  height: 1rem;
+  margin-top: 0.125rem;
+  accent-color: var(--lt-accent);
+}
+
+.lt-check-field__label {
+  color: var(--lt-text-primary);
+  font-size: 0.8125rem;
+  font-weight: 700;
+  line-height: 1.125rem;
+}
+
+.lt-check-field__help {
+  display: block;
+  margin-top: 0.25rem;
+  color: var(--lt-text-muted);
+  font-size: 0.6875rem;
+  line-height: 1rem;
+}
+
+.lt-fieldset {
+  min-width: 0;
+  margin: 0;
+  border: 1px solid var(--lt-border);
+  border-radius: var(--lt-radius-md);
+  padding: 1rem;
+}
+
+.lt-fieldset__legend {
+  padding: 0 0.375rem;
+  color: var(--lt-text-primary);
+  font-size: 0.8125rem;
+  font-weight: 800;
+}
+
+@media (max-width: 639px) {
+  .lt-form__grid {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .lt-form__actions {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .lt-form__actions > * {
+    width: 100%;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .lt-check-field__control {
+    scroll-behavior: auto;
+  }
+}

--- a/src/litoral_trace/templates/base.html
+++ b/src/litoral_trace/templates/base.html
@@ -15,6 +15,7 @@
     <link rel="stylesheet" href="{{ url_for('static', path='/vendor/leaflet/leaflet.css') }}">
     <link rel="stylesheet" href="{{ url_for('static', path='/src/design-system.css') }}">
     <link rel="stylesheet" href="{{ url_for('static', path='/src/data-table.css') }}">
+    <link rel="stylesheet" href="{{ url_for('static', path='/src/form-controls.css') }}">
 
     <script src="{{ url_for('static', path='/vendor/htmx/htmx.min.js') }}" defer></script>
     <script src="{{ url_for('static', path='/vendor/leaflet/leaflet.js') }}" defer></script>

--- a/src/litoral_trace/templates/components/form_fields.html
+++ b/src/litoral_trace/templates/components/form_fields.html
@@ -1,8 +1,8 @@
-{% macro text_field(name, label, value='', type='text', placeholder='', help_text=None, required=False, autocomplete=None, error=None) -%}
+{% macro text_field(name, label, value='', type='text', placeholder='', help_text=None, required=False, show_optional=False, autocomplete=None, error=None) -%}
 <label class="lt-field" {% if error %}data-state="error"{% endif %}>
     <span class="lt-field__label-row">
         <span class="lt-field__label">{{ label }}</span>
-        {% if required %}<span class="lt-field__required" aria-hidden="true">*</span>{% else %}<span class="lt-field__optional">Opcional</span>{% endif %}
+        {% if required %}<span class="lt-field__required" aria-hidden="true">*</span>{% elif show_optional %}<span class="lt-field__optional">Opcional</span>{% endif %}
     </span>
     <input
         type="{{ type }}"
@@ -21,11 +21,11 @@
 {%- endmacro %}
 
 
-{% macro select_field(name, label, options, selected_value=None, help_text=None, required=False, error=None) -%}
+{% macro select_field(name, label, options, selected_value=None, help_text=None, required=False, show_optional=False, error=None) -%}
 <label class="lt-field" {% if error %}data-state="error"{% endif %}>
     <span class="lt-field__label-row">
         <span class="lt-field__label">{{ label }}</span>
-        {% if required %}<span class="lt-field__required" aria-hidden="true">*</span>{% else %}<span class="lt-field__optional">Opcional</span>{% endif %}
+        {% if required %}<span class="lt-field__required" aria-hidden="true">*</span>{% elif show_optional %}<span class="lt-field__optional">Opcional</span>{% endif %}
     </span>
     <select
         name="{{ name }}"
@@ -44,11 +44,11 @@
 {%- endmacro %}
 
 
-{% macro textarea_field(name, label, value='', placeholder='', help_text=None, required=False, error=None, rows=4) -%}
+{% macro textarea_field(name, label, value='', placeholder='', help_text=None, required=False, show_optional=False, error=None, rows=4) -%}
 <label class="lt-field" {% if error %}data-state="error"{% endif %}>
     <span class="lt-field__label-row">
         <span class="lt-field__label">{{ label }}</span>
-        {% if required %}<span class="lt-field__required" aria-hidden="true">*</span>{% else %}<span class="lt-field__optional">Opcional</span>{% endif %}
+        {% if required %}<span class="lt-field__required" aria-hidden="true">*</span>{% elif show_optional %}<span class="lt-field__optional">Opcional</span>{% endif %}
     </span>
     <textarea
         name="{{ name }}"

--- a/src/litoral_trace/templates/components/form_fields.html
+++ b/src/litoral_trace/templates/components/form_fields.html
@@ -1,0 +1,76 @@
+{% macro text_field(name, label, value='', type='text', placeholder='', help_text=None, required=False, autocomplete=None, error=None) -%}
+<label class="lt-field" {% if error %}data-state="error"{% endif %}>
+    <span class="lt-field__label-row">
+        <span class="lt-field__label">{{ label }}</span>
+        {% if required %}<span class="lt-field__required" aria-hidden="true">*</span>{% else %}<span class="lt-field__optional">Opcional</span>{% endif %}
+    </span>
+    <input
+        type="{{ type }}"
+        name="{{ name }}"
+        value="{{ value }}"
+        {% if placeholder %}placeholder="{{ placeholder }}"{% endif %}
+        {% if autocomplete %}autocomplete="{{ autocomplete }}"{% endif %}
+        {% if required %}required{% endif %}
+        {% if error %}aria-invalid="true"{% endif %}
+        {% if help_text and error %}aria-describedby="{{ name }}-help {{ name }}-error"{% elif help_text %}aria-describedby="{{ name }}-help"{% elif error %}aria-describedby="{{ name }}-error"{% endif %}
+        class="w-full rounded-lg border border-slate-300 px-3 py-2.5 text-sm outline-none focus:ring-2 focus:ring-forest-600 lt-control"
+    >
+    {% if help_text %}<span id="{{ name }}-help" class="lt-field__help">{{ help_text }}</span>{% endif %}
+    {% if error %}<span id="{{ name }}-error" class="lt-field__error" role="alert">{{ error }}</span>{% endif %}
+</label>
+{%- endmacro %}
+
+
+{% macro select_field(name, label, options, selected_value=None, help_text=None, required=False, error=None) -%}
+<label class="lt-field" {% if error %}data-state="error"{% endif %}>
+    <span class="lt-field__label-row">
+        <span class="lt-field__label">{{ label }}</span>
+        {% if required %}<span class="lt-field__required" aria-hidden="true">*</span>{% else %}<span class="lt-field__optional">Opcional</span>{% endif %}
+    </span>
+    <select
+        name="{{ name }}"
+        {% if required %}required{% endif %}
+        {% if error %}aria-invalid="true"{% endif %}
+        {% if help_text and error %}aria-describedby="{{ name }}-help {{ name }}-error"{% elif help_text %}aria-describedby="{{ name }}-help"{% elif error %}aria-describedby="{{ name }}-error"{% endif %}
+        class="w-full rounded-lg border border-slate-300 bg-white px-3 py-2.5 text-sm outline-none lt-control"
+    >
+        {% for option_value, option_label in options %}
+        <option value="{{ option_value }}" {% if selected_value is not none and option_value == selected_value %}selected{% endif %}>{{ option_label }}</option>
+        {% endfor %}
+    </select>
+    {% if help_text %}<span id="{{ name }}-help" class="lt-field__help">{{ help_text }}</span>{% endif %}
+    {% if error %}<span id="{{ name }}-error" class="lt-field__error" role="alert">{{ error }}</span>{% endif %}
+</label>
+{%- endmacro %}
+
+
+{% macro textarea_field(name, label, value='', placeholder='', help_text=None, required=False, error=None, rows=4) -%}
+<label class="lt-field" {% if error %}data-state="error"{% endif %}>
+    <span class="lt-field__label-row">
+        <span class="lt-field__label">{{ label }}</span>
+        {% if required %}<span class="lt-field__required" aria-hidden="true">*</span>{% else %}<span class="lt-field__optional">Opcional</span>{% endif %}
+    </span>
+    <textarea
+        name="{{ name }}"
+        rows="{{ rows }}"
+        {% if placeholder %}placeholder="{{ placeholder }}"{% endif %}
+        {% if required %}required{% endif %}
+        {% if error %}aria-invalid="true"{% endif %}
+        {% if help_text and error %}aria-describedby="{{ name }}-help {{ name }}-error"{% elif help_text %}aria-describedby="{{ name }}-help"{% elif error %}aria-describedby="{{ name }}-error"{% endif %}
+        class="w-full rounded-lg border border-slate-300 px-3 py-2.5 text-sm outline-none focus:ring-2 focus:ring-forest-600 lt-control"
+    >{{ value }}</textarea>
+    {% if help_text %}<span id="{{ name }}-help" class="lt-field__help">{{ help_text }}</span>{% endif %}
+    {% if error %}<span id="{{ name }}-error" class="lt-field__error" role="alert">{{ error }}</span>{% endif %}
+</label>
+{%- endmacro %}
+
+
+{% macro checkbox_field(name, label, checked=False, value='1', help_text=None) -%}
+<label class="lt-check-field">
+    <input class="lt-check-field__control" type="checkbox" name="{{ name }}" value="{{ value }}" {% if checked %}checked{% endif %}>
+    <span>
+        <span class="lt-check-field__label">{{ label }}</span>
+        {% if help_text %}<span class="lt-check-field__help">{{ help_text }}</span>{% endif %}
+    </span>
+</label>
+{%- endmacro %}

--- a/src/litoral_trace/templates/dev/ui_catalog.html
+++ b/src/litoral_trace/templates/dev/ui_catalog.html
@@ -1,6 +1,7 @@
 {% extends "app/base_app.html" %}
 {% from "components/ui.html" import alert, badge, button, empty_state, page_header, risk_badge, status_badge %}
 {% from "components/data_table.html" import pagination, search_control %}
+{% from "components/form_fields.html" import checkbox_field, select_field, text_field, textarea_field %}
 
 {% block title %}UI Catalog | Litoral Trace{% endblock %}
 
@@ -128,22 +129,44 @@
 
     <section class="lt-card lt-catalog-section" aria-labelledby="catalog-form-title">
         <p class="lt-catalog-eyebrow">Forms</p>
-        <h2 id="catalog-form-title" class="lt-catalog-title">Controls</h2>
+        <h2 id="catalog-form-title" class="lt-catalog-title">LTField</h2>
+        {% set catalog_status_options = [("READY", "Ready"), ("REVIEW", "Review"), ("BLOCKED", "Blocked")] %}
         <div class="lt-catalog-form-grid">
-            <label class="lt-field">
-                <span class="lt-field__label">Referencia</span>
-                <input class="lt-control" type="text" placeholder="EXP-DE-2026-014">
-                <span class="lt-field__help">Identificador visible y estable para el usuario.</span>
-            </label>
-            <label class="lt-field">
-                <span class="lt-field__label">Estado</span>
-                <select class="lt-control">
-                    <option>READY</option>
-                    <option>REVIEW</option>
-                    <option>BLOCKED</option>
-                </select>
-                <span class="lt-field__help">Los colores se derivan del significado, no de la pantalla.</span>
-            </label>
+            {{ text_field(
+                "catalog_reference",
+                "Referencia",
+                placeholder="EXP-DE-2026-014",
+                help_text="Identificador visible y estable para el usuario.",
+                required=True
+            ) }}
+            {{ select_field(
+                "catalog_status",
+                "Estado",
+                catalog_status_options,
+                selected_value="REVIEW",
+                help_text="La opción seleccionada proviene del estado server-side."
+            ) }}
+            {{ text_field(
+                "catalog_cuit",
+                "CUIT",
+                value="30-12345678-9",
+                help_text="Ejemplo de validación accesible.",
+                error="El CUIT no supera la validación de ejemplo."
+            ) }}
+            {{ textarea_field(
+                "catalog_note",
+                "Nota operativa",
+                placeholder="Agregar contexto para auditoría…",
+                show_optional=True,
+                rows=3
+            ) }}
+        </div>
+        <div class="lt-catalog-stack">
+            {{ checkbox_field(
+                "catalog_confirm",
+                "Confirmé la documentación asociada",
+                help_text="El checkbox representa una decisión del usuario, no un estado inventado por cliente."
+            ) }}
         </div>
     </section>
 

--- a/src/litoral_trace/templates/settings.html
+++ b/src/litoral_trace/templates/settings.html
@@ -1,4 +1,5 @@
 {% extends "app/base_app.html" %}
+{% from "components/form_fields.html" import select_field, text_field %}
 
 {% block title %}Configuración | Litoral Trace{% endblock %}
 
@@ -29,11 +30,17 @@
         <article class="rounded-2xl border border-slate-200 bg-white p-6 shadow-sm">
             <div class="flex items-start gap-3"><span class="flex h-10 w-10 shrink-0 items-center justify-center rounded-xl bg-slate-100 text-slate-700" aria-hidden="true"><i class="fa-solid fa-user-plus"></i></span><div><h2 class="text-lg font-bold text-slate-950">Crear acceso de demostración</h2><p class="mt-1 text-sm leading-6 text-slate-600">Generá credenciales temporales sólo para una demostración comercial autorizada. El formulario comienza vacío para evitar confundir datos de ejemplo con información real.</p></div></div>
 
-            <form hx-post="/api/v1/settings/invite_demo_user" hx-target="#inviteFeedback" class="mt-6 space-y-4">
-                <div><label class="mb-1 block text-xs font-semibold uppercase tracking-wide text-slate-700">CUIT de la empresa</label><input type="text" name="cuit_empresa" placeholder="30-XXXXXXXX-X" required class="w-full rounded-lg border border-slate-300 px-3 py-2.5 text-sm outline-none focus:ring-2 focus:ring-forest-600"></div>
-                <div><label class="mb-1 block text-xs font-semibold uppercase tracking-wide text-slate-700">Nombre del contacto</label><input type="text" name="nombre_contacto" placeholder="Nombre y apellido" required class="w-full rounded-lg border border-slate-300 px-3 py-2.5 text-sm outline-none focus:ring-2 focus:ring-forest-600"></div>
-                <div><label class="mb-1 block text-xs font-semibold uppercase tracking-wide text-slate-700">Correo electrónico</label><input type="email" name="email_contacto" placeholder="contacto@empresa.com" required class="w-full rounded-lg border border-slate-300 px-3 py-2.5 text-sm outline-none focus:ring-2 focus:ring-forest-600"></div>
-                <div><label class="mb-1 block text-xs font-semibold uppercase tracking-wide text-slate-700">Actividad principal</label><select name="especie_principal" class="w-full rounded-lg border border-slate-300 bg-white px-3 py-2.5 text-sm outline-none"><option value="Madera Aserrada (Pino)">Madera aserrada de pino</option><option value="Madera Aserrada (Eucalipto)">Madera aserrada de eucalipto</option><option value="Extracto de Quebracho (Tanino)">Extracto de quebracho / tanino</option><option value="Carbón Vegetal">Carbón vegetal</option></select></div>
+            {% set activity_options = [
+                ("Madera Aserrada (Pino)", "Madera aserrada de pino"),
+                ("Madera Aserrada (Eucalipto)", "Madera aserrada de eucalipto"),
+                ("Extracto de Quebracho (Tanino)", "Extracto de quebracho / tanino"),
+                ("Carbón Vegetal", "Carbón vegetal")
+            ] %}
+            <form hx-post="/api/v1/settings/invite_demo_user" hx-target="#inviteFeedback" class="mt-6 space-y-4 lt-form">
+                {{ text_field("cuit_empresa", "CUIT de la empresa", placeholder="30-XXXXXXXX-X", required=True) }}
+                {{ text_field("nombre_contacto", "Nombre del contacto", placeholder="Nombre y apellido", required=True) }}
+                {{ text_field("email_contacto", "Correo electrónico", type="email", placeholder="contacto@empresa.com", required=True) }}
+                {{ select_field("especie_principal", "Actividad principal", activity_options) }}
                 <button type="submit" class="inline-flex w-full items-center justify-center gap-2 rounded-lg bg-slate-950 px-4 py-3 text-sm font-semibold text-white shadow-sm hover:bg-slate-800"><i class="fa-solid fa-key" aria-hidden="true"></i>Generar acceso temporal</button>
             </form>
             <div id="inviteFeedback" class="mt-4"></div>

--- a/tests/test_ui_form_fields_p17_unittest.py
+++ b/tests/test_ui_form_fields_p17_unittest.py
@@ -1,0 +1,109 @@
+from pathlib import Path
+
+from jinja2 import Environment
+
+
+ROOT = Path(__file__).resolve().parents[1]
+TEMPLATES = ROOT / "src" / "litoral_trace" / "templates"
+STATIC_SRC = ROOT / "src" / "litoral_trace" / "static" / "src"
+
+
+def _read(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+def test_p17_form_field_templates_parse_and_layer_is_loaded() -> None:
+    base = _read(TEMPLATES / "base.html")
+    component = _read(TEMPLATES / "components" / "form_fields.html")
+    settings = _read(TEMPLATES / "settings.html")
+    catalog = _read(TEMPLATES / "dev" / "ui_catalog.html")
+
+    env = Environment()
+    for template in (base, component, settings, catalog):
+        env.parse(template)
+
+    assert "path='/src/form-controls.css'" in base
+    assert "components/form_fields.html" in settings
+    assert "components/form_fields.html" in catalog
+
+
+def test_p17_form_field_component_exposes_accessible_primitives() -> None:
+    component = _read(TEMPLATES / "components" / "form_fields.html")
+
+    for macro in (
+        "macro text_field",
+        "macro select_field",
+        "macro textarea_field",
+        "macro checkbox_field",
+    ):
+        assert macro in component
+
+    assert 'aria-invalid="true"' in component
+    assert "aria-describedby=" in component
+    assert 'role="alert"' in component
+    assert "lt-field__required" in component
+    assert "lt-field__optional" in component
+    assert "lt-field__help" in component
+    assert "lt-field__error" in component
+
+
+def test_p17_settings_canary_preserves_htmx_and_payload_contract() -> None:
+    settings = _read(TEMPLATES / "settings.html")
+
+    assert 'hx-post="/api/v1/settings/invite_demo_user"' in settings
+    assert 'hx-target="#inviteFeedback"' in settings
+    assert 'id="inviteFeedback"' in settings
+
+    for field_name in (
+        "cuit_empresa",
+        "nombre_contacto",
+        "email_contacto",
+        "especie_principal",
+    ):
+        assert field_name in settings
+
+    for option_value in (
+        "Madera Aserrada (Pino)",
+        "Madera Aserrada (Eucalipto)",
+        "Extracto de Quebracho (Tanino)",
+        "Carbón Vegetal",
+    ):
+        assert option_value in settings
+
+    assert "Generar acceso temporal" in settings
+    assert "lt-form" in settings
+
+
+def test_p17_form_macros_keep_historical_tailwind_candidates() -> None:
+    component = _read(TEMPLATES / "components" / "form_fields.html")
+
+    # The canary removes repeated control markup from settings.html, so the
+    # historical utilities intentionally live in the shared macro instead.
+    # This keeps Tailwind's tracked candidate graph stable during migration.
+    for candidate in (
+        "w-full rounded-lg border border-slate-300 px-3 py-2.5 text-sm outline-none focus:ring-2 focus:ring-forest-600",
+        "w-full rounded-lg border border-slate-300 bg-white px-3 py-2.5 text-sm outline-none",
+    ):
+        assert candidate in component
+
+
+def test_p17_form_css_defines_required_error_and_responsive_states() -> None:
+    css = _read(STATIC_SRC / "form-controls.css")
+
+    for selector in (
+        ".lt-form__grid",
+        ".lt-form__actions",
+        ".lt-field__label-row",
+        ".lt-field__required",
+        ".lt-field__optional",
+        ".lt-field__error",
+        ".lt-field[data-state=\"error\"] .lt-field__label",
+        ".lt-field[data-state=\"success\"] .lt-control",
+        "textarea.lt-control",
+        ".lt-check-field",
+        ".lt-fieldset",
+    ):
+        assert selector in css
+
+    assert "@media (max-width: 639px)" in css
+    assert "@media (prefers-reduced-motion: reduce)" in css


### PR DESCRIPTION
## Scope

Stacked UX2.0-D change on top of the green UX2.0-C LTDataTable branch.

### Included
- semantic form-control states for required/optional/help/error/success/responsive layouts
- Jinja primitives for text, select, textarea and checkbox fields
- settings demo-access form migrated as canary
- UI Catalog coverage for normal, selected, optional and validation-error states
- dedicated P1.7 form-field gate

### Contract preservation
- no API/service/model changes
- existing `hx-post=/api/v1/settings/invite_demo_user` and `hx-target=#inviteFeedback` preserved
- field names and activity option values preserved
- existing Tailwind control candidates retained inside the shared macros so `dist/app.css` remains reproducible

### Parallel-work safety
This PR targets `p1.7-c-data-table`, not production, and contains only templates/static CSS/tests.