### PR TITLE
P1.7-E: native LTDialog primitive

### DIFF
--- a/src/litoral_trace/static/src/dialog.css
+++ b/src/litoral_trace/static/src/dialog.css
@@ -1,0 +1,142 @@
+.lt-dialog {
+  width: min(36rem, calc(100vw - 2rem));
+  max-width: none;
+  max-height: min(46rem, calc(100dvh - 2rem));
+  margin: auto;
+  border: 1px solid var(--lt-border);
+  border-radius: var(--lt-radius-lg);
+  background: var(--lt-surface);
+  padding: 0;
+  color: var(--lt-text-secondary);
+  box-shadow: 0 28px 80px -28px rgb(15 23 42 / 0.55);
+  overflow: hidden;
+}
+
+.lt-dialog--sm {
+  width: min(28rem, calc(100vw - 2rem));
+}
+
+.lt-dialog--lg {
+  width: min(52rem, calc(100vw - 2rem));
+}
+
+.lt-dialog::backdrop {
+  background: rgb(15 23 42 / 0.64);
+  backdrop-filter: blur(3px);
+}
+
+.lt-dialog[open] {
+  display: grid;
+  grid-template-rows: auto minmax(0, 1fr) auto;
+}
+
+.lt-dialog__header {
+  display: flex;
+  min-width: 0;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1rem;
+  border-bottom: 1px solid var(--lt-border);
+  padding: 1rem 1.25rem;
+}
+
+.lt-dialog__copy {
+  min-width: 0;
+}
+
+.lt-dialog__title {
+  margin: 0;
+  color: var(--lt-text-primary);
+  font-size: 1rem;
+  font-weight: 800;
+  line-height: 1.375rem;
+}
+
+.lt-dialog__description {
+  margin: 0.375rem 0 0;
+  color: var(--lt-text-muted);
+  font-size: 0.8125rem;
+  line-height: 1.25rem;
+}
+
+.lt-dialog__close {
+  width: 2.5rem;
+  height: 2.5rem;
+  flex: 0 0 auto;
+  display: inline-grid;
+  place-items: center;
+  border: 1px solid transparent;
+  border-radius: var(--lt-radius-sm);
+  background: transparent;
+  color: var(--lt-text-muted);
+  cursor: pointer;
+}
+
+.lt-dialog__close:hover {
+  background: var(--lt-surface-subtle);
+  color: var(--lt-text-primary);
+}
+
+.lt-dialog__close:focus-visible {
+  outline: 2px solid var(--lt-focus);
+  outline-offset: 2px;
+}
+
+.lt-dialog__body {
+  min-width: 0;
+  overflow-y: auto;
+  overscroll-behavior: contain;
+  padding: 1.25rem;
+}
+
+.lt-dialog__footer {
+  display: flex;
+  min-width: 0;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 0.625rem;
+  border-top: 1px solid var(--lt-border);
+  background: var(--lt-surface-muted);
+  padding: 0.875rem 1.25rem;
+}
+
+.lt-dialog__notice {
+  border: 1px solid var(--lt-warning-border);
+  border-radius: var(--lt-radius-md);
+  background: var(--lt-warning-bg);
+  padding: 0.75rem;
+  color: #854d0e;
+  font-size: 0.75rem;
+  line-height: 1.25rem;
+}
+
+@media (max-width: 639px) {
+  .lt-dialog {
+    width: calc(100vw - 1rem);
+    max-height: calc(100dvh - 1rem);
+  }
+
+  .lt-dialog__header,
+  .lt-dialog__body,
+  .lt-dialog__footer {
+    padding-left: 1rem;
+    padding-right: 1rem;
+  }
+
+  .lt-dialog__footer {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .lt-dialog__footer > * {
+    width: 100%;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .lt-dialog,
+  .lt-dialog::backdrop {
+    scroll-behavior: auto;
+  }
+}

--- a/src/litoral_trace/static/src/js/dialog.js
+++ b/src/litoral_trace/static/src/js/dialog.js
@@ -1,0 +1,88 @@
+const DIALOG_SELECTOR = "[data-lt-dialog]";
+const OPEN_SELECTOR = "[data-lt-dialog-open]";
+const CLOSE_SELECTOR = "[data-lt-dialog-close]";
+
+const previousFocus = new WeakMap();
+
+function resolveDialog(targetId) {
+  if (!targetId) {
+    return null;
+  }
+
+  const element = document.getElementById(targetId);
+  return element instanceof HTMLDialogElement ? element : null;
+}
+
+function openDialog(dialog, trigger) {
+  if (!dialog || dialog.open) {
+    return;
+  }
+
+  if (trigger instanceof HTMLElement) {
+    previousFocus.set(dialog, trigger);
+  }
+
+  dialog.showModal();
+}
+
+function closeDialog(dialog) {
+  if (!dialog || !dialog.open) {
+    return;
+  }
+
+  dialog.close();
+}
+
+function restoreDialogFocus(dialog) {
+  const trigger = previousFocus.get(dialog);
+  previousFocus.delete(dialog);
+
+  if (trigger instanceof HTMLElement && document.contains(trigger)) {
+    trigger.focus({ preventScroll: true });
+  }
+}
+
+function installDialogController() {
+  document.addEventListener("click", (event) => {
+    const openTrigger = event.target.closest(OPEN_SELECTOR);
+
+    if (openTrigger) {
+      const targetId = openTrigger.getAttribute("data-lt-dialog-open");
+      const dialog = resolveDialog(targetId);
+
+      if (dialog) {
+        event.preventDefault();
+        openDialog(dialog, openTrigger);
+      }
+      return;
+    }
+
+    const closeTrigger = event.target.closest(CLOSE_SELECTOR);
+
+    if (closeTrigger) {
+      const dialog = closeTrigger.closest(DIALOG_SELECTOR);
+
+      if (dialog instanceof HTMLDialogElement) {
+        event.preventDefault();
+        closeDialog(dialog);
+      }
+      return;
+    }
+
+    const dialog = event.target.closest(DIALOG_SELECTOR);
+
+    if (dialog instanceof HTMLDialogElement && event.target === dialog) {
+      closeDialog(dialog);
+    }
+  });
+
+  document.querySelectorAll(DIALOG_SELECTOR).forEach((dialog) => {
+    if (!(dialog instanceof HTMLDialogElement)) {
+      return;
+    }
+
+    dialog.addEventListener("close", () => restoreDialogFocus(dialog));
+  });
+}
+
+installDialogController();

--- a/src/litoral_trace/templates/base.html
+++ b/src/litoral_trace/templates/base.html
@@ -16,10 +16,12 @@
     <link rel="stylesheet" href="{{ url_for('static', path='/src/design-system.css') }}">
     <link rel="stylesheet" href="{{ url_for('static', path='/src/data-table.css') }}">
     <link rel="stylesheet" href="{{ url_for('static', path='/src/form-controls.css') }}">
+    <link rel="stylesheet" href="{{ url_for('static', path='/src/dialog.css') }}">
 
     <script src="{{ url_for('static', path='/vendor/htmx/htmx.min.js') }}" defer></script>
     <script src="{{ url_for('static', path='/vendor/leaflet/leaflet.js') }}" defer></script>
     <script type="module" src="{{ url_for('static', path='/src/js/app.js') }}"></script>
+    <script type="module" src="{{ url_for('static', path='/src/js/dialog.js') }}"></script>
 
     {% block head_extra %}{% endblock %}
 </head>

--- a/src/litoral_trace/templates/components/dialog.html
+++ b/src/litoral_trace/templates/components/dialog.html
@@ -1,0 +1,42 @@
+{% macro dialog_trigger(target_id, label, variant='secondary', icon=None, extra_classes='') -%}
+<button
+    type="button"
+    class="lt-btn lt-btn--{{ variant }} {{ extra_classes }}"
+    data-lt-dialog-open="{{ target_id }}"
+    aria-haspopup="dialog"
+>
+    {% if icon %}<i class="fa-solid {{ icon }}" aria-hidden="true"></i>{% endif %}
+    <span>{{ label }}</span>
+</button>
+{%- endmacro %}
+
+
+{% macro dialog(dialog_id, title, description=None, size='md', close_label='Cerrar diálogo') -%}
+<dialog
+    id="{{ dialog_id }}"
+    class="lt-dialog{% if size != 'md' %} lt-dialog--{{ size }}{% endif %}"
+    data-lt-dialog
+    aria-labelledby="{{ dialog_id }}-title"
+    {% if description %}aria-describedby="{{ dialog_id }}-description"{% endif %}
+>
+    <header class="lt-dialog__header">
+        <div class="lt-dialog__copy">
+            <h2 id="{{ dialog_id }}-title" class="lt-dialog__title">{{ title }}</h2>
+            {% if description %}<p id="{{ dialog_id }}-description" class="lt-dialog__description">{{ description }}</p>{% endif %}
+        </div>
+        <button type="button" class="lt-dialog__close" data-lt-dialog-close aria-label="{{ close_label }}">
+            <i class="fa-solid fa-xmark" aria-hidden="true"></i>
+        </button>
+    </header>
+    <div class="lt-dialog__body">
+        {{ caller() }}
+    </div>
+</dialog>
+{%- endmacro %}
+
+
+{% macro dialog_footer() -%}
+<footer class="lt-dialog__footer">
+    {{ caller() }}
+</footer>
+{%- endmacro %}

--- a/src/litoral_trace/templates/dev/ui_catalog.html
+++ b/src/litoral_trace/templates/dev/ui_catalog.html
@@ -2,6 +2,7 @@
 {% from "components/ui.html" import alert, badge, button, empty_state, page_header, risk_badge, status_badge %}
 {% from "components/data_table.html" import pagination, search_control %}
 {% from "components/form_fields.html" import checkbox_field, select_field, text_field, textarea_field %}
+{% from "components/dialog.html" import dialog, dialog_footer, dialog_trigger %}
 
 {% block title %}UI Catalog | Litoral Trace{% endblock %}
 
@@ -132,42 +133,38 @@
         <h2 id="catalog-form-title" class="lt-catalog-title">LTField</h2>
         {% set catalog_status_options = [("READY", "Ready"), ("REVIEW", "Review"), ("BLOCKED", "Blocked")] %}
         <div class="lt-catalog-form-grid">
-            {{ text_field(
-                "catalog_reference",
-                "Referencia",
-                placeholder="EXP-DE-2026-014",
-                help_text="Identificador visible y estable para el usuario.",
-                required=True
-            ) }}
-            {{ select_field(
-                "catalog_status",
-                "Estado",
-                catalog_status_options,
-                selected_value="REVIEW",
-                help_text="La opción seleccionada proviene del estado server-side."
-            ) }}
-            {{ text_field(
-                "catalog_cuit",
-                "CUIT",
-                value="30-12345678-9",
-                help_text="Ejemplo de validación accesible.",
-                error="El CUIT no supera la validación de ejemplo."
-            ) }}
-            {{ textarea_field(
-                "catalog_note",
-                "Nota operativa",
-                placeholder="Agregar contexto para auditoría…",
-                show_optional=True,
-                rows=3
-            ) }}
+            {{ text_field("catalog_reference", "Referencia", placeholder="EXP-DE-2026-014", help_text="Identificador visible y estable para el usuario.", required=True) }}
+            {{ select_field("catalog_status", "Estado", catalog_status_options, selected_value="REVIEW", help_text="La opción seleccionada proviene del estado server-side.") }}
+            {{ text_field("catalog_cuit", "CUIT", value="30-12345678-9", help_text="Ejemplo de validación accesible.", error="El CUIT no supera la validación de ejemplo.") }}
+            {{ textarea_field("catalog_note", "Nota operativa", placeholder="Agregar contexto para auditoría…", show_optional=True, rows=3) }}
         </div>
         <div class="lt-catalog-stack">
-            {{ checkbox_field(
-                "catalog_confirm",
-                "Confirmé la documentación asociada",
-                help_text="El checkbox representa una decisión del usuario, no un estado inventado por cliente."
-            ) }}
+            {{ checkbox_field("catalog_confirm", "Confirmé la documentación asociada", help_text="El checkbox representa una decisión del usuario, no un estado inventado por cliente.") }}
         </div>
+    </section>
+
+    <section class="lt-card lt-catalog-section" aria-labelledby="catalog-dialog-title">
+        <p class="lt-catalog-eyebrow">Overlay</p>
+        <h2 id="catalog-dialog-title" class="lt-catalog-title">LTDialog</h2>
+        <p class="lt-catalog-copy">Usa el elemento nativo dialog: foco modal del navegador, Escape para cerrar y devolución explícita del foco al disparador.</p>
+        <div class="lt-catalog-cluster">
+            {{ dialog_trigger("catalog-release-dialog", "Revisar liberación", variant="secondary", icon="fa-lock") }}
+        </div>
+
+        {% call dialog(
+            "catalog-release-dialog",
+            "Confirmar liberación del despacho",
+            "La decisión debe apoyarse en evidencia persistida; este componente no modifica por sí mismo el estado de dominio."
+        ) %}
+            <div class="lt-catalog-stack">
+                <p>EXP-DE-2026-014 está listo para una decisión humana de ejemplo.</p>
+                <div class="lt-dialog__notice">Antes de confirmar una acción destructiva o irreversible, la pantalla debe explicar su consecuencia y conservar el endpoint server-side como fuente de verdad.</div>
+                {% call dialog_footer() %}
+                    <button type="button" class="lt-btn lt-btn--secondary" data-lt-dialog-close>Cancelar</button>
+                    <button type="button" class="lt-btn lt-btn--primary" data-lt-dialog-close>Confirmar ejemplo</button>
+                {% endcall %}
+            </div>
+        {% endcall %}
     </section>
 
     <section class="lt-card lt-catalog-section" aria-labelledby="catalog-empty-title">

--- a/tests/test_ui_dialog_p17_unittest.py
+++ b/tests/test_ui_dialog_p17_unittest.py
@@ -1,0 +1,94 @@
+from pathlib import Path
+
+from jinja2 import Environment
+
+
+ROOT = Path(__file__).resolve().parents[1]
+TEMPLATES = ROOT / "src" / "litoral_trace" / "templates"
+STATIC_SRC = ROOT / "src" / "litoral_trace" / "static" / "src"
+JS_SRC = STATIC_SRC / "js"
+
+
+def _read(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+def test_p17_dialog_templates_parse_and_assets_are_loaded() -> None:
+    base = _read(TEMPLATES / "base.html")
+    component = _read(TEMPLATES / "components" / "dialog.html")
+    catalog = _read(TEMPLATES / "dev" / "ui_catalog.html")
+
+    env = Environment()
+    for template in (base, component, catalog):
+        env.parse(template)
+
+    assert "path='/src/dialog.css'" in base
+    assert "path='/src/js/dialog.js'" in base
+    assert "components/dialog.html" in catalog
+
+
+def test_p17_dialog_uses_native_accessible_contract() -> None:
+    component = _read(TEMPLATES / "components" / "dialog.html")
+
+    assert "<dialog" in component
+    assert "data-lt-dialog" in component
+    assert 'aria-labelledby="{{ dialog_id }}-title"' in component
+    assert "aria-describedby=" in component
+    assert "data-lt-dialog-open" in component
+    assert 'aria-haspopup="dialog"' in component
+    assert "data-lt-dialog-close" in component
+    assert 'aria-label="{{ close_label }}"' in component
+
+
+def test_p17_dialog_controller_preserves_native_focus_and_escape_behavior() -> None:
+    js = _read(JS_SRC / "dialog.js")
+
+    for contract in (
+        "HTMLDialogElement",
+        "showModal()",
+        ".close()",
+        "previousFocus",
+        "data-lt-dialog-open",
+        "data-lt-dialog-close",
+        'dialog.addEventListener("close"',
+        "trigger.focus({ preventScroll: true })",
+    ):
+        assert contract in js
+
+    # Native dialog supplies modal focus containment and Escape/cancel semantics.
+    # The controller must not recreate a second manual focus trap.
+    assert 'event.key === "Tab"' not in js
+    assert 'event.key === "Escape"' not in js
+
+
+def test_p17_dialog_catalog_is_non_domain_mutating_canary() -> None:
+    catalog = _read(TEMPLATES / "dev" / "ui_catalog.html")
+
+    assert "catalog-release-dialog" in catalog
+    assert "Revisar liberación" in catalog
+    assert "Confirmar liberación del despacho" in catalog
+    assert "data-lt-dialog-close" in catalog
+    assert "no modifica por sí mismo el estado de dominio" in catalog
+    assert "hx-post=" not in catalog
+
+
+def test_p17_dialog_css_defines_modal_backdrop_and_responsive_states() -> None:
+    css = _read(STATIC_SRC / "dialog.css")
+
+    for selector in (
+        ".lt-dialog",
+        ".lt-dialog--sm",
+        ".lt-dialog--lg",
+        ".lt-dialog::backdrop",
+        ".lt-dialog[open]",
+        ".lt-dialog__header",
+        ".lt-dialog__close:focus-visible",
+        ".lt-dialog__body",
+        ".lt-dialog__footer",
+        ".lt-dialog__notice",
+    ):
+        assert selector in css
+
+    assert "100dvh" in css
+    assert "@media (max-width: 639px)" in css
+    assert "@media (prefers-reduced-motion: reduce)" in css


### PR DESCRIPTION
## Scope

Stacked UX2.0-E change on top of the green UX2.0-D form-field branch.

### Included
- native `<dialog>` semantic CSS layer
- Jinja dialog and trigger primitives
- independent ES-module controller for open/close/backdrop/focus restoration
- UI Catalog interaction canary
- dedicated P1.7 dialog contract gate

### Accessibility / interaction contract
- browser-native modal focus containment
- Escape/cancel remains native; no second manual Tab/Escape trap
- trigger uses `aria-haspopup=dialog`
- title/description relationships are explicit
- focus is restored to the opening trigger after close

### Parallel-work safety
- no API/web/service/model changes
- existing `app.js` is untouched
- only templates/static CSS/static JS/tests are changed
- PR targets the stacked UI branch, not production.