### PR TITLE
P1.7-F: native LTDropdown popover

### DIFF
--- a/src/litoral_trace/static/src/dropdown.css
+++ b/src/litoral_trace/static/src/dropdown.css
@@ -1,0 +1,135 @@
+.lt-dropdown-trigger {
+  max-width: 100%;
+}
+
+.lt-dropdown {
+  width: min(20rem, calc(100vw - 2rem));
+  margin: 0;
+  border: 1px solid var(--lt-border);
+  border-radius: var(--lt-radius-md);
+  background: var(--lt-surface);
+  padding: 0.375rem;
+  color: var(--lt-text-secondary);
+  box-shadow: 0 18px 48px -20px rgb(15 23 42 / 0.42);
+}
+
+.lt-dropdown[popover] {
+  inset: auto;
+  position-area: block-end span-inline-end;
+  position-try-fallbacks: flip-block, flip-inline;
+}
+
+.lt-dropdown::backdrop {
+  background: transparent;
+}
+
+.lt-dropdown__label {
+  margin: 0;
+  padding: 0.5rem 0.625rem 0.375rem;
+  color: var(--lt-text-muted);
+  font-size: 0.625rem;
+  font-weight: 800;
+  letter-spacing: 0.1em;
+  line-height: 1rem;
+  text-transform: uppercase;
+}
+
+.lt-dropdown__item {
+  width: 100%;
+  min-height: 2.5rem;
+  display: flex;
+  align-items: center;
+  gap: 0.625rem;
+  border: 0;
+  border-radius: 0.5rem;
+  background: transparent;
+  padding: 0.5625rem 0.625rem;
+  color: var(--lt-text-secondary);
+  font: inherit;
+  font-size: 0.8125rem;
+  font-weight: 650;
+  line-height: 1.125rem;
+  text-align: left;
+  text-decoration: none;
+  cursor: pointer;
+}
+
+.lt-dropdown__item:hover {
+  background: var(--lt-surface-subtle);
+  color: var(--lt-text-primary);
+  text-decoration: none;
+}
+
+.lt-dropdown__item:focus-visible {
+  outline: 2px solid var(--lt-focus);
+  outline-offset: -2px;
+}
+
+.lt-dropdown__item--danger {
+  color: var(--lt-danger);
+}
+
+.lt-dropdown__item--danger:hover {
+  background: var(--lt-danger-bg);
+  color: var(--lt-danger);
+}
+
+.lt-dropdown__icon {
+  width: 1.125rem;
+  flex: 0 0 auto;
+  color: var(--lt-text-muted);
+  text-align: center;
+}
+
+.lt-dropdown__item--danger .lt-dropdown__icon {
+  color: currentColor;
+}
+
+.lt-dropdown__copy {
+  min-width: 0;
+  flex: 1 1 auto;
+}
+
+.lt-dropdown__primary {
+  display: block;
+  color: inherit;
+}
+
+.lt-dropdown__secondary {
+  display: block;
+  margin-top: 0.125rem;
+  color: var(--lt-text-muted);
+  font-size: 0.6875rem;
+  font-weight: 500;
+  line-height: 1rem;
+}
+
+.lt-dropdown__separator {
+  height: 1px;
+  margin: 0.375rem;
+  background: var(--lt-border);
+}
+
+@supports not (position-area: block-end) {
+  .lt-dropdown[popover] {
+    top: 4.5rem;
+    right: 1rem;
+    left: auto;
+  }
+}
+
+@media (max-width: 639px) {
+  .lt-dropdown {
+    width: calc(100vw - 1rem);
+  }
+
+  .lt-dropdown[popover] {
+    right: 0.5rem;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .lt-dropdown__item {
+    scroll-behavior: auto;
+  }
+}

--- a/src/litoral_trace/templates/app/base_app.html
+++ b/src/litoral_trace/templates/app/base_app.html
@@ -1,4 +1,5 @@
 {% extends "base.html" %}
+{% from "components/dropdown.html" import dropdown, dropdown_item %}
 
 {% block head_extra %}
 <link rel="stylesheet" href="{{ url_for('static', path='/src/app-shell.css') }}">
@@ -120,7 +121,17 @@
                         <p class="lt-user-meta__name truncate text-xs font-semibold text-slate-800" title="{{ user.organization_name }}">{{ user.organization_name }}</p>
                         <p class="lt-user-meta__role truncate text-[11px] text-slate-500">{{ user.username }} · {{ user.role|upper }}</p>
                     </div>
-                    <div class="lt-user-avatar flex h-9 w-9 shrink-0 items-center justify-center rounded-full bg-slate-900 text-sm font-bold text-white" aria-hidden="true">{{ user.username[:1]|upper }}</div>
+                    <button
+                        type="button"
+                        class="lt-user-avatar flex h-9 w-9 shrink-0 items-center justify-center rounded-full bg-slate-900 text-sm font-bold text-white"
+                        popovertarget="app-user-dropdown"
+                        aria-label="Abrir menú de cuenta"
+                        title="Cuenta"
+                    >{{ user.username[:1]|upper }}</button>
+                    {% call dropdown("app-user-dropdown", "Cuenta y sesión") %}
+                        {{ dropdown_item("Configuración", href="/settings", icon="fa-sliders", description=user.organization_name) }}
+                        {{ dropdown_item("Cerrar sesión", href="/logout", icon="fa-right-from-bracket", description=user.username) }}
+                    {% endcall %}
                 </div>
             </div>
         </header>

--- a/src/litoral_trace/templates/base.html
+++ b/src/litoral_trace/templates/base.html
@@ -17,6 +17,7 @@
     <link rel="stylesheet" href="{{ url_for('static', path='/src/data-table.css') }}">
     <link rel="stylesheet" href="{{ url_for('static', path='/src/form-controls.css') }}">
     <link rel="stylesheet" href="{{ url_for('static', path='/src/dialog.css') }}">
+    <link rel="stylesheet" href="{{ url_for('static', path='/src/dropdown.css') }}">
 
     <script src="{{ url_for('static', path='/vendor/htmx/htmx.min.js') }}" defer></script>
     <script src="{{ url_for('static', path='/vendor/leaflet/leaflet.js') }}" defer></script>

--- a/src/litoral_trace/templates/components/dropdown.html
+++ b/src/litoral_trace/templates/components/dropdown.html
@@ -1,0 +1,56 @@
+{% macro dropdown_trigger(target_id, label, variant='secondary', icon=None) -%}
+<button
+    type="button"
+    class="lt-btn lt-btn--{{ variant }} lt-dropdown-trigger"
+    popovertarget="{{ target_id }}"
+>
+    {% if icon %}<i class="fa-solid {{ icon }}" aria-hidden="true"></i>{% endif %}
+    <span>{{ label }}</span>
+    <i class="fa-solid fa-chevron-down" aria-hidden="true"></i>
+</button>
+{%- endmacro %}
+
+
+{% macro dropdown(dropdown_id, label='Acciones') -%}
+<div
+    id="{{ dropdown_id }}"
+    class="lt-dropdown"
+    popover="auto"
+    aria-label="{{ label }}"
+>
+    {% if label %}<p class="lt-dropdown__label">{{ label }}</p>{% endif %}
+    {{ caller() }}
+</div>
+{%- endmacro %}
+
+
+{% macro dropdown_item(label, href=None, icon=None, description=None, tone='default', button_type='button', name=None, value=None) -%}
+{% set item_class = "lt-dropdown__item" ~ (" lt-dropdown__item--danger" if tone == "danger" else "") %}
+{% if href %}
+<a href="{{ href }}" class="{{ item_class }}">
+    {% if icon %}<i class="fa-solid {{ icon }} lt-dropdown__icon" aria-hidden="true"></i>{% endif %}
+    <span class="lt-dropdown__copy">
+        <span class="lt-dropdown__primary">{{ label }}</span>
+        {% if description %}<span class="lt-dropdown__secondary">{{ description }}</span>{% endif %}
+    </span>
+</a>
+{% else %}
+<button
+    type="{{ button_type }}"
+    class="{{ item_class }}"
+    {% if name %}name="{{ name }}"{% endif %}
+    {% if value is not none %}value="{{ value }}"{% endif %}
+>
+    {% if icon %}<i class="fa-solid {{ icon }} lt-dropdown__icon" aria-hidden="true"></i>{% endif %}
+    <span class="lt-dropdown__copy">
+        <span class="lt-dropdown__primary">{{ label }}</span>
+        {% if description %}<span class="lt-dropdown__secondary">{{ description }}</span>{% endif %}
+    </span>
+</button>
+{% endif %}
+{%- endmacro %}
+
+
+{% macro dropdown_separator() -%}
+<div class="lt-dropdown__separator" role="separator"></div>
+{%- endmacro %}

--- a/tests/test_ui_dropdown_p17_unittest.py
+++ b/tests/test_ui_dropdown_p17_unittest.py
@@ -1,0 +1,84 @@
+from pathlib import Path
+
+from jinja2 import Environment
+
+
+ROOT = Path(__file__).resolve().parents[1]
+TEMPLATES = ROOT / "src" / "litoral_trace" / "templates"
+STATIC_SRC = ROOT / "src" / "litoral_trace" / "static" / "src"
+
+
+def _read(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+def test_p17_dropdown_templates_parse_and_layer_is_loaded() -> None:
+    base = _read(TEMPLATES / "base.html")
+    component = _read(TEMPLATES / "components" / "dropdown.html")
+    shell = _read(TEMPLATES / "app" / "base_app.html")
+
+    env = Environment()
+    for template in (base, component, shell):
+        env.parse(template)
+
+    assert "path='/src/dropdown.css'" in base
+    assert "components/dropdown.html" in shell
+
+
+def test_p17_dropdown_uses_native_popover_contract_without_new_js() -> None:
+    component = _read(TEMPLATES / "components" / "dropdown.html")
+    base = _read(TEMPLATES / "base.html")
+
+    assert "popovertarget=" in component
+    assert 'popover="auto"' in component
+    assert "macro dropdown_trigger" in component
+    assert "macro dropdown" in component
+    assert "macro dropdown_item" in component
+    assert "macro dropdown_separator" in component
+    assert 'role="separator"' in component
+
+    # F deliberately relies on the native Popover API. It must not add a
+    # second dropdown controller or mutate app.js for open/close behavior.
+    assert "dropdown.js" not in base
+
+
+def test_p17_app_shell_user_dropdown_is_additive_and_keeps_secure_logout() -> None:
+    shell = _read(TEMPLATES / "app" / "base_app.html")
+
+    assert 'popovertarget="app-user-dropdown"' in shell
+    assert 'aria-label="Abrir menú de cuenta"' in shell
+    assert 'dropdown("app-user-dropdown", "Cuenta y sesión")' in shell
+    assert 'dropdown_item("Configuración", href="/settings"' in shell
+    assert 'dropdown_item("Cerrar sesión", href="/logout"' in shell
+
+    # The original CSRF-protected POST logout in the sidebar remains present.
+    assert 'method="post" action="/logout"' in shell
+    assert 'name="{{ csrf_form_field }}"' in shell
+    assert 'value="{{ csrf_token }}"' in shell
+
+    # B drawer and focus contracts remain untouched by the additive menu.
+    assert "data-app-drawer" in shell
+    assert 'href="#main-content"' in shell
+    assert 'id="main-content"' in shell
+
+
+def test_p17_dropdown_css_defines_popover_position_and_interaction_states() -> None:
+    css = _read(STATIC_SRC / "dropdown.css")
+
+    for selector in (
+        ".lt-dropdown-trigger",
+        ".lt-dropdown",
+        ".lt-dropdown[popover]",
+        ".lt-dropdown::backdrop",
+        ".lt-dropdown__item",
+        ".lt-dropdown__item:focus-visible",
+        ".lt-dropdown__item--danger",
+        ".lt-dropdown__secondary",
+        ".lt-dropdown__separator",
+    ):
+        assert selector in css
+
+    assert "position-area: block-end span-inline-end" in css
+    assert "position-try-fallbacks" in css
+    assert "@supports not (position-area: block-end)" in css
+    assert "@media (max-width: 639px)" in css


### PR DESCRIPTION
## Scope

Stacked UX2.0-F change on top of the green UX2.0-E native-dialog branch.

### Included
- semantic dropdown/popover CSS
- Jinja dropdown/item/separator primitives
- App Shell user-avatar canary with Configuración and existing logout flow
- native HTML Popover API; no new dropdown JavaScript
- dedicated P1.7 dropdown gate

### Contract preservation
- original CSRF-protected POST `/logout` remains in the sidebar
- drawer, navigation, skip-link and main-content contracts remain intact
- no API/web/service/model changes
- user menu is additive and uses existing `/settings` and `/logout` routes

### Interaction
The browser handles open/close, outside interaction and Escape through `popover=auto`; the component does not introduce a second client state machine.