### PR TITLE
P1.7-G: accessible LTSkeleton primitives

### DIFF
--- a/src/litoral_trace/static/src/skeleton.css
+++ b/src/litoral_trace/static/src/skeleton.css
@@ -1,0 +1,109 @@
+.lt-skeleton-region {
+  min-width: 0;
+}
+
+.lt-skeleton {
+  position: relative;
+  overflow: hidden;
+  border-radius: 0.5rem;
+  background: #e2e8f0;
+  color: transparent;
+  user-select: none;
+}
+
+.lt-skeleton::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  transform: translateX(-100%);
+  background: linear-gradient(
+    90deg,
+    transparent,
+    rgb(255 255 255 / 0.72),
+    transparent
+  );
+  animation: lt-skeleton-shimmer 1.4s ease-in-out infinite;
+}
+
+.lt-skeleton--line {
+  width: 100%;
+  height: 0.875rem;
+}
+
+.lt-skeleton--line-sm {
+  width: 55%;
+  height: 0.75rem;
+}
+
+.lt-skeleton--line-lg {
+  width: 78%;
+  height: 1.25rem;
+}
+
+.lt-skeleton--block {
+  width: 100%;
+  min-height: 5rem;
+}
+
+.lt-skeleton--avatar {
+  width: 2.5rem;
+  height: 2.5rem;
+  flex: 0 0 auto;
+  border-radius: 9999px;
+}
+
+.lt-skeleton-stack {
+  display: grid;
+  min-width: 0;
+  gap: 0.625rem;
+}
+
+.lt-skeleton-row {
+  display: grid;
+  min-width: 0;
+  grid-template-columns: auto minmax(0, 1fr);
+  gap: 0.75rem;
+  align-items: center;
+}
+
+.lt-skeleton-table {
+  min-width: 36rem;
+  display: grid;
+  gap: 1px;
+  background: var(--lt-border);
+}
+
+.lt-skeleton-table__row {
+  display: grid;
+  grid-template-columns: 1.2fr 1fr 0.75fr 0.75fr;
+  gap: 1rem;
+  background: var(--lt-surface);
+  padding: 0.75rem;
+}
+
+.lt-skeleton-table__row--header {
+  background: var(--lt-surface-muted);
+}
+
+.lt-skeleton-table__cell {
+  min-width: 0;
+}
+
+@keyframes lt-skeleton-shimmer {
+  100% {
+    transform: translateX(100%);
+  }
+}
+
+@media (max-width: 639px) {
+  .lt-skeleton-table {
+    min-width: 32rem;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .lt-skeleton::after {
+    animation: none;
+    display: none;
+  }
+}

--- a/src/litoral_trace/templates/base.html
+++ b/src/litoral_trace/templates/base.html
@@ -18,6 +18,7 @@
     <link rel="stylesheet" href="{{ url_for('static', path='/src/form-controls.css') }}">
     <link rel="stylesheet" href="{{ url_for('static', path='/src/dialog.css') }}">
     <link rel="stylesheet" href="{{ url_for('static', path='/src/dropdown.css') }}">
+    <link rel="stylesheet" href="{{ url_for('static', path='/src/skeleton.css') }}">
 
     <script src="{{ url_for('static', path='/vendor/htmx/htmx.min.js') }}" defer></script>
     <script src="{{ url_for('static', path='/vendor/leaflet/leaflet.js') }}" defer></script>

--- a/src/litoral_trace/templates/components/skeleton.html
+++ b/src/litoral_trace/templates/components/skeleton.html
@@ -1,0 +1,40 @@
+{% macro skeleton_line(size='md') -%}
+<span class="lt-skeleton lt-skeleton--line{% if size == 'sm' %} lt-skeleton--line-sm{% elif size == 'lg' %} lt-skeleton--line-lg{% endif %}" aria-hidden="true">&nbsp;</span>
+{%- endmacro %}
+
+
+{% macro skeleton_avatar() -%}
+<span class="lt-skeleton lt-skeleton--avatar" aria-hidden="true">&nbsp;</span>
+{%- endmacro %}
+
+
+{% macro skeleton_block() -%}
+<span class="lt-skeleton lt-skeleton--block" aria-hidden="true">&nbsp;</span>
+{%- endmacro %}
+
+
+{% macro loading_region(label='Cargando contenido…') -%}
+<div class="lt-skeleton-region" role="status" aria-live="polite" aria-busy="true">
+    <span class="lt-visually-hidden">{{ label }}</span>
+    {{ caller() }}
+</div>
+{%- endmacro %}
+
+
+{% macro skeleton_table(rows=4) -%}
+<div class="lt-data-table__scroll" aria-hidden="true">
+    <div class="lt-skeleton-table">
+        <div class="lt-skeleton-table__row lt-skeleton-table__row--header">
+            {% for _ in range(4) %}<div class="lt-skeleton-table__cell">{{ skeleton_line('sm') }}</div>{% endfor %}
+        </div>
+        {% for _ in range(rows) %}
+        <div class="lt-skeleton-table__row">
+            <div class="lt-skeleton-table__cell">{{ skeleton_line('lg') }}</div>
+            <div class="lt-skeleton-table__cell">{{ skeleton_line() }}</div>
+            <div class="lt-skeleton-table__cell">{{ skeleton_line('sm') }}</div>
+            <div class="lt-skeleton-table__cell">{{ skeleton_line('sm') }}</div>
+        </div>
+        {% endfor %}
+    </div>
+</div>
+{%- endmacro %}

--- a/tests/test_ui_skeleton_p17_unittest.py
+++ b/tests/test_ui_skeleton_p17_unittest.py
@@ -1,0 +1,68 @@
+from pathlib import Path
+
+from jinja2 import Environment
+
+
+ROOT = Path(__file__).resolve().parents[1]
+TEMPLATES = ROOT / "src" / "litoral_trace" / "templates"
+STATIC_SRC = ROOT / "src" / "litoral_trace" / "static" / "src"
+
+
+def _read(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+def test_p17_skeleton_component_parses_and_layer_is_loaded() -> None:
+    base = _read(TEMPLATES / "base.html")
+    component = _read(TEMPLATES / "components" / "skeleton.html")
+
+    Environment().parse(component)
+    assert "path='/src/skeleton.css'" in base
+
+
+def test_p17_skeleton_exposes_accessible_loading_primitives() -> None:
+    component = _read(TEMPLATES / "components" / "skeleton.html")
+
+    for macro in (
+        "macro skeleton_line",
+        "macro skeleton_avatar",
+        "macro skeleton_block",
+        "macro loading_region",
+        "macro skeleton_table",
+    ):
+        assert macro in component
+
+    assert 'role="status"' in component
+    assert 'aria-live="polite"' in component
+    assert 'aria-busy="true"' in component
+    assert "lt-visually-hidden" in component
+    assert 'aria-hidden="true"' in component
+
+
+def test_p17_skeleton_is_presentational_only() -> None:
+    component = _read(TEMPLATES / "components" / "skeleton.html")
+
+    assert "hx-post=" not in component
+    assert "hx-get=" not in component
+    assert "<script" not in component
+    assert "data-state=" not in component
+
+
+def test_p17_skeleton_css_honors_motion_and_table_density() -> None:
+    css = _read(STATIC_SRC / "skeleton.css")
+
+    for selector in (
+        ".lt-skeleton-region",
+        ".lt-skeleton",
+        ".lt-skeleton::after",
+        ".lt-skeleton--line",
+        ".lt-skeleton--block",
+        ".lt-skeleton--avatar",
+        ".lt-skeleton-table",
+        ".lt-skeleton-table__row",
+    ):
+        assert selector in css
+
+    assert "@keyframes lt-skeleton-shimmer" in css
+    assert "@media (prefers-reduced-motion: reduce)" in css
+    assert "animation: none" in css


### PR DESCRIPTION
## Scope

Stacked UX2.0-G change on top of the green UX2.0-F dropdown branch.

### Included
- semantic skeleton CSS with line/block/avatar/table variants
- Jinja loading-region and skeleton primitives
- accessible `role=status`, `aria-live=polite`, `aria-busy=true` contract
- reduced-motion behavior
- dedicated P1.7 skeleton gate

### Product correctness
No production screen is given a fake loading state in this phase. The primitive is available for a real HTMX/asynchronous flow when that flow has a genuine pending state.

### Parallel-work safety
No API/web/service/model/JS changes. Only shared CSS, Jinja component loading and tests.