### PR TITLE
P1-F: First Paid Customer / Pilot Readiness

### DIFF
--- a/.github/workflows/p1f-pilot-readiness-postgres-gate.yml
+++ b/.github/workflows/p1f-pilot-readiness-postgres-gate.yml
@@ -1,0 +1,174 @@
+name: P1-F Pilot Readiness PostgreSQL Gate
+
+on:
+  pull_request:
+    branches:
+      - p2-enterprise-production
+  push:
+    branches:
+      - p2-enterprise-production
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: p1f-pilot-readiness-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  p1f-pilot-readiness-postgres:
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+
+    services:
+      postgres:
+        image: postgis/postgis:17-3.5
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: p1f_owner_password_2026
+          POSTGRES_DB: litoral_trace_p1f_ci
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U postgres -d litoral_trace_p1f_ci"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 20
+
+    env:
+      ENVIRONMENT: development
+      ENABLE_POSTGRES_TESTS: "1"
+      JWT_SECRET_KEY: p1f-ci-only-jwt-secret-key-2026
+      LITORAL_TRACE_BOOTSTRAP_SUPERADMIN_PASSWORD: P1fCiBootstrapPassword2026
+      TEST_POSTGRES_MIGRATION_DATABASE_URL: postgresql+psycopg://postgres:p1f_owner_password_2026@127.0.0.1:5432/litoral_trace_p1f_ci
+      MIGRATION_DATABASE_URL: postgresql+psycopg://postgres:p1f_owner_password_2026@127.0.0.1:5432/litoral_trace_p1f_ci
+      TEST_POSTGRES_DATABASE_URL: postgresql+psycopg://litoral_trace_app:p1f_runtime_password_2026@127.0.0.1:5432/litoral_trace_p1f_ci
+      DATABASE_URL: postgresql+psycopg://litoral_trace_app:p1f_runtime_password_2026@127.0.0.1:5432/litoral_trace_p1f_ci
+      EUDR_ACCEPTANCE_ENABLED: "false"
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: pip
+          cache-dependency-path: requirements.txt
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -r requirements.txt pytest alembic
+
+      - name: Gate P1-F - surface guardrails
+        run: python -m pytest -q -rs tests/test_p1f_pilot_readiness_surface_unittest.py
+
+      - name: Provision runtime principal
+        shell: bash
+        run: |
+          python - <<'PY'
+          import os
+          from sqlalchemy import create_engine
+
+          engine = create_engine(
+              os.environ["TEST_POSTGRES_MIGRATION_DATABASE_URL"],
+              isolation_level="AUTOCOMMIT",
+              pool_pre_ping=True,
+              hide_parameters=True,
+          )
+          statements = [
+              """
+              CREATE ROLE litoral_trace_app
+                LOGIN
+                PASSWORD 'p1f_runtime_password_2026'
+                NOSUPERUSER
+                NOCREATEDB
+                NOCREATEROLE
+                NOINHERIT
+                NOBYPASSRLS
+              """,
+              "GRANT CONNECT ON DATABASE litoral_trace_p1f_ci TO litoral_trace_app",
+              "GRANT USAGE ON SCHEMA public TO litoral_trace_app",
+          ]
+          with engine.connect() as connection:
+              for statement in statements:
+                  connection.exec_driver_sql(statement)
+          engine.dispose()
+          PY
+
+      - name: Migrate database to canonical head
+        run: python -m alembic upgrade 026_add_eudr_acceptance_attempts
+
+      - name: Provision reviewed source-lot read for fixture
+        shell: bash
+        run: |
+          python - <<'PY'
+          import os
+          from sqlalchemy import create_engine
+
+          engine = create_engine(
+              os.environ["TEST_POSTGRES_MIGRATION_DATABASE_URL"],
+              isolation_level="AUTOCOMMIT",
+              pool_pre_ping=True,
+              hide_parameters=True,
+          )
+          with engine.connect() as connection:
+              connection.exec_driver_sql(
+                  "GRANT SELECT ON TABLE public.lotes TO litoral_trace_app"
+              )
+          engine.dispose()
+          PY
+
+      - name: Verify canonical revision
+        shell: bash
+        run: |
+          set -euo pipefail
+          python -m alembic current | tee p1f-alembic-current.txt
+          grep -F "026_add_eudr_acceptance_attempts" p1f-alembic-current.txt
+
+      - name: Write isolated runtime contract
+        shell: bash
+        run: |
+          cat > .env.integration <<'EOF'
+          ENABLE_POSTGRES_TESTS=1
+          TEST_POSTGRES_DATABASE_URL=postgresql+psycopg://litoral_trace_app:p1f_runtime_password_2026@127.0.0.1:5432/litoral_trace_p1f_ci
+          TEST_POSTGRES_MIGRATION_DATABASE_URL=postgresql+psycopg://postgres:p1f_owner_password_2026@127.0.0.1:5432/litoral_trace_p1f_ci
+          EOF
+
+      - name: Gate P1-F - real tenant progress and isolation
+        shell: bash
+        run: |
+          set -euo pipefail
+          python -m pytest -q -rs \
+            tests/test_p1f_pilot_readiness_postgres_integration.py \
+            --junitxml=p1f-pilot-readiness.xml
+          python - <<'PY'
+          import xml.etree.ElementTree as ET
+
+          root = ET.parse("p1f-pilot-readiness.xml").getroot()
+          suites = [root] if root.tag == "testsuite" else list(root.iter("testsuite"))
+          tests = sum(int(s.attrib.get("tests", "0")) for s in suites)
+          skipped = sum(int(s.attrib.get("skipped", "0")) for s in suites)
+          failures = sum(int(s.attrib.get("failures", "0")) for s in suites)
+          errors = sum(int(s.attrib.get("errors", "0")) for s in suites)
+          if tests != 1 or skipped or failures or errors:
+              raise SystemExit(
+                  "P1-F PostgreSQL gate fails closed: "
+                  f"tests={tests}, skipped={skipped}, failures={failures}, errors={errors}"
+              )
+          PY
+
+      - name: Assert P1-F does not enable remote ACCEPTANCE
+        shell: bash
+        run: |
+          test "${EUDR_ACCEPTANCE_ENABLED}" = "false"
+          test -z "${EUDR_ACCEPTANCE_USERNAME:-}"
+          test -z "${EUDR_ACCEPTANCE_AUTHENTICATION_KEY:-}"
+          test -z "${EUDR_ACCEPTANCE_WEB_SERVICE_CLIENT_ID:-}"
+
+      - name: Cleanup isolated contract
+        if: always()
+        run: rm -f .env.integration

--- a/commercial/PILOT_30_DAY_RUNBOOK.md
+++ b/commercial/PILOT_30_DAY_RUNBOOK.md
@@ -1,0 +1,112 @@
+# Litoral Trace — Piloto comercial de 30 días
+
+## Objetivo
+
+Convertir un prospecto forestal del NEA en un usuario activo de Litoral Trace con una operación verificable de punta a punta y métricas que permitan decidir continuidad paga al día 30.
+
+Este runbook no depende del smoke remoto EUDR ACCEPTANCE y no habilita LIVE EUDR. El piloto debe usar documentos, lotes y operaciones reales del cliente cuando exista autorización para hacerlo.
+
+## Día 0 — Preparación comercial
+
+Responsables sugeridos del cliente: dueño/gerencia + comercio exterior/calidad + un usuario operativo.
+
+Reunir antes de la sesión inicial:
+- razón social, CUIT y contacto administrador;
+- 1–5 lotes/rodales representativos con ubicación;
+- 1 proveedor/productor real;
+- documentos de origen disponibles;
+- un flujo real de recepción y transformación;
+- un despacho internacional reciente o representativo;
+- referencias ARCA/SIM disponibles;
+- evaluación fitosanitaria del mercado de destino;
+- si el destino es UE, datos necesarios para preparar el candidato EUDR sin inventar EORI, HS, especies o conclusiones de riesgo.
+
+## Día 1 — Activación
+
+1. Superadmin crea organización, licencia piloto y usuario administrador.
+2. Cliente inicia sesión y abre **Preparar piloto**.
+3. Carga lotes por la vía más rápida disponible: carga masiva o captura existente.
+4. Sube al menos una evidencia al Vault.
+5. Verificar que el estado pasa de `NOT_STARTED` a `IN_PROGRESS`.
+
+Criterio de éxito del día 1: el cliente puede ingresar sin asistencia de desarrollo y ve faltantes concretos con enlaces accionables.
+
+## Días 2–7 — Cadena de custodia
+
+1. Registrar una recepción vinculada a lote de origen y llevarla a `POSTED`.
+2. Registrar una transformación real o representativa y llevarla a `POSTED`.
+3. Revisar genealogía y balance de cantidades.
+4. Corregir identificadores/documentos faltantes detectados durante el flujo.
+
+Criterio de éxito: Litoral Trace reconstruye la relación lote → recepción → transformación sin intervención en base de datos.
+
+## Días 8–14 — Despacho y expediente
+
+1. Crear un despacho internacional con material trazado.
+2. Llevar el despacho a `DISPATCHED`.
+3. Completar expediente Corrientes/ARCA/SIM según perfil forestal aplicable.
+4. Vincular evidencias Vault al despacho.
+5. Completar la evaluación fitosanitaria: `NOT_REQUIRED`, `PAPER` o `EPHYTO`, siempre con fundamento/evidencia cuando corresponda.
+
+Criterio de éxito: expediente exportador y fitosanitario muestran `READY` o faltantes concretos y verificables.
+
+## Días 15–21 — EUDR y Control de Salida
+
+Para destinos UE:
+1. completar el candidato DDS local con operador UE, EORI cuando corresponda, HS, producto, cantidad, país/fechas de producción, especies cuando aplique y evaluación de riesgo real;
+2. alcanzar `CONFORMANCE_READY`;
+3. no afirmar cumplimiento legal por ese estado;
+4. no ejecutar LIVE.
+
+Para todos los destinos:
+1. abrir Control de Salida;
+2. revisar trazabilidad, evidencia, expediente y faltantes;
+3. generar/revisar dossier documental existente cuando el flujo lo permita.
+
+Criterio de éxito: el despacho puede explicarse a un comprador/auditor sin reconstruir manualmente la historia en Excel, Drive y WhatsApp.
+
+## Días 22–27 — Uso operativo real
+
+El cliente repite el flujo con una segunda operación o actualiza la primera con nuevos documentos.
+
+Medir:
+- tiempo de alta de lote/proveedor;
+- tiempo de reconstrucción de origen antes/después;
+- cantidad de documentos encontrados sin búsqueda manual;
+- faltantes detectados antes del despacho;
+- tiempo necesario para preparar expediente de comprador/importador;
+- usuarios activos y frecuencia de uso;
+- errores operativos o pasos que todavía requieren soporte de Litoral Trace.
+
+No convertir estas métricas en claims comerciales sin evidencia del propio piloto.
+
+## Días 28–30 — Cierre y conversión
+
+Reunión de cierre con tres preguntas:
+1. ¿Qué tarea que antes requería Excel/Drive/WhatsApp quedó objetivamente más rápida o controlada?
+2. ¿Qué riesgo documental/operativo fue detectado antes de que llegara a exportación?
+3. ¿Qué volumen mensual de lotes, proveedores, documentos y despachos debería manejar Litoral Trace si continúa?
+
+Entregables:
+- captura/registro del estado **Preparar piloto**;
+- un despacho con Control de Salida revisado;
+- dossier/evidencia disponible;
+- lista de gaps observados durante el piloto;
+- propuesta comercial correspondiente al volumen real.
+
+## Criterio `PILOT_READY`
+
+La plataforma lo calcula automáticamente y exige siete hitos:
+1. organización/usuario/licencia activos;
+2. al menos un lote de origen;
+3. al menos un documento Vault disponible;
+4. al menos una recepción `POSTED`;
+5. al menos una transformación `POSTED`;
+6. al menos un despacho internacional `DISPATCHED` con material;
+7. expediente exportador + fitosanitario `READY` y, si el destino es UE, candidato EUDR `CONFORMANCE_READY`.
+
+El smoke remoto EUDR ACCEPTANCE no es requisito para `PILOT_READY`. Sigue siendo un gate técnico separado antes de cualquier futura integración LIVE.
+
+## Trigger posterior al primer cliente pago
+
+Una vez confirmado el primer cliente pago, ejecutar el issue de infraestructura #67 antes de ampliar uso comercial: worker persistente, secretos correspondientes y extensión del restore history de Neon según el runbook vigente.

--- a/src/litoral_trace/api/pilot_readiness.py
+++ b/src/litoral_trace/api/pilot_readiness.py
@@ -1,0 +1,75 @@
+"""Read-only first-customer pilot readiness API."""
+from __future__ import annotations
+
+from typing import Any
+
+from fastapi import APIRouter, Depends, HTTPException, status
+
+from litoral_trace.api.auth import UserTenantContext
+from litoral_trace.auth.rbac import Permission, require_permission
+from litoral_trace.db.tenant import get_tenant_scoped_db_session
+from litoral_trace.services.pilot_readiness import (
+    PilotReadinessPersistenceError,
+    PilotReadinessService,
+)
+
+
+router = APIRouter(prefix="/api/v1/pilot-readiness", tags=["Pilot Readiness"])
+
+
+def _payload(view) -> dict[str, Any]:
+    return {
+        "organization_id": view.organization_id,
+        "organization_name": view.organization_name,
+        "state": view.state,
+        "ready": view.ready,
+        "completed_steps": view.completed_steps,
+        "total_steps": view.total_steps,
+        "shipment_code": view.shipment_code,
+        "counts": dict(view.counts),
+        "steps": [
+            {
+                "key": step.key,
+                "label": step.label,
+                "completed": step.completed,
+                "detail": step.detail,
+                "action_label": step.action_label,
+                "action_href": step.action_href,
+            }
+            for step in view.steps
+        ],
+        "acceptance_smoke_required_for_pilot": False,
+        "live_eudr_enabled": False,
+    }
+
+
+@router.get("")
+def get_pilot_readiness(
+    user: UserTenantContext = Depends(require_permission(Permission.LOTE_READ)),
+) -> dict[str, Any]:
+    session = get_tenant_scoped_db_session(user.organization_id)
+    if session is None:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail={
+                "code": "PILOT_READINESS_UNAVAILABLE",
+                "message": "El estado del piloto no está disponible temporalmente.",
+            },
+        )
+    try:
+        try:
+            view = PilotReadinessService(
+                session=session,
+                organization_id=user.organization_id,
+            ).evaluate()
+            return _payload(view)
+        except PilotReadinessPersistenceError as exc:
+            raise HTTPException(
+                status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+                detail={
+                    "code": "PILOT_READINESS_UNAVAILABLE",
+                    "message": str(exc),
+                },
+            ) from None
+    finally:
+        session.close()

--- a/src/litoral_trace/api/pilot_readiness.py
+++ b/src/litoral_trace/api/pilot_readiness.py
@@ -61,6 +61,7 @@ def get_pilot_readiness(
             view = PilotReadinessService(
                 session=session,
                 organization_id=user.organization_id,
+                organization_name=user.organization_name,
             ).evaluate()
             return _payload(view)
         except PilotReadinessPersistenceError as exc:

--- a/src/litoral_trace/api/traceability.py
+++ b/src/litoral_trace/api/traceability.py
@@ -10,6 +10,7 @@ from litoral_trace.api.auth import UserTenantContext
 from litoral_trace.api.eudr_acceptance import router as eudr_acceptance_api_router
 from litoral_trace.api.eudr_dds_candidate import router as eudr_candidate_api_router
 from litoral_trace.api.integrations import router as integrations_api_router
+from litoral_trace.api.pilot_readiness import router as pilot_readiness_api_router
 from litoral_trace.api.shipment_export_case import router as export_case_api_router
 from litoral_trace.api.shipment_phytosanitary_case import router as phytosanitary_api_router
 from litoral_trace.api.traceability_dossier import router as dossier_router
@@ -23,6 +24,7 @@ from litoral_trace.services.traceability_lineage import (
 from litoral_trace.web.eudr_acceptance import router as eudr_acceptance_web_router
 from litoral_trace.web.eudr_dds_candidate import router as eudr_candidate_web_router
 from litoral_trace.web.integrations import router as integrations_web_router
+from litoral_trace.web.pilot_readiness import router as pilot_readiness_web_router
 from litoral_trace.web.shipment_export_case import router as export_case_web_router
 from litoral_trace.web.shipment_phytosanitary_case import router as phytosanitary_web_router
 from litoral_trace.web.traceability import router as traceability_web_router
@@ -90,6 +92,7 @@ router.include_router(export_case_api_router)
 router.include_router(phytosanitary_api_router)
 router.include_router(eudr_candidate_api_router)
 router.include_router(eudr_acceptance_api_router)
+router.include_router(pilot_readiness_api_router)
 router.include_router(traceability_web_router)
 router.include_router(release_control_web_router)
 router.include_router(integrations_web_router)
@@ -97,3 +100,4 @@ router.include_router(export_case_web_router)
 router.include_router(phytosanitary_web_router)
 router.include_router(eudr_candidate_web_router)
 router.include_router(eudr_acceptance_web_router)
+router.include_router(pilot_readiness_web_router)

--- a/src/litoral_trace/services/pilot_readiness.py
+++ b/src/litoral_trace/services/pilot_readiness.py
@@ -1,0 +1,346 @@
+"""Deterministic first-customer pilot readiness derived from tenant data.
+
+No readiness flag is persisted. The service projects existing source-of-truth
+objects so the checklist cannot drift from the real operational state.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+from urllib.parse import urlencode
+
+from sqlalchemy import and_, func, select
+from sqlalchemy.exc import SQLAlchemyError
+from sqlalchemy.orm import Session
+
+from litoral_trace.db.models import (
+    License,
+    Lote,
+    Organization,
+    Shipment,
+    ShipmentItem,
+    TraceabilityEvent,
+    User,
+    VaultDocument,
+)
+from litoral_trace.services.eudr_dds_candidate import EudrDdsCandidateService
+from litoral_trace.services.eudr_release_control import is_eudr_destination
+from litoral_trace.services.shipment_export_case import ShipmentExportCaseService
+from litoral_trace.services.shipment_phytosanitary_case import (
+    ShipmentPhytosanitaryCaseService,
+)
+
+
+PILOT_NOT_STARTED = "NOT_STARTED"
+PILOT_IN_PROGRESS = "IN_PROGRESS"
+PILOT_READY = "PILOT_READY"
+
+
+class PilotReadinessError(RuntimeError):
+    """Safe base error for first-customer readiness projection."""
+
+
+class PilotReadinessPersistenceError(PilotReadinessError):
+    pass
+
+
+@dataclass(frozen=True)
+class PilotStepView:
+    key: str
+    label: str
+    completed: bool
+    detail: str
+    action_label: str
+    action_href: str
+
+
+@dataclass(frozen=True)
+class PilotReadinessView:
+    organization_id: int
+    organization_name: str
+    state: str
+    completed_steps: int
+    total_steps: int
+    shipment_code: str | None
+    steps: tuple[PilotStepView, ...]
+    counts: dict[str, int]
+
+    @property
+    def ready(self) -> bool:
+        return self.state == PILOT_READY
+
+
+def _step(
+    key: str,
+    label: str,
+    completed: bool,
+    detail: str,
+    action_label: str,
+    action_href: str,
+) -> PilotStepView:
+    return PilotStepView(
+        key=key,
+        label=label,
+        completed=bool(completed),
+        detail=detail,
+        action_label=action_label,
+        action_href=action_href,
+    )
+
+
+class PilotReadinessService:
+    """Project a tenant's ability to execute one commercially useful pilot."""
+
+    def __init__(self, *, session: Session, organization_id: int) -> None:
+        self._session = session
+        self._organization_id = int(organization_id)
+
+    def _count(self, model: Any, *criteria: Any) -> int:
+        return int(
+            self._session.scalar(
+                select(func.count()).select_from(model).where(*criteria)
+            )
+            or 0
+        )
+
+    def _latest_international_dispatched_shipment(self) -> Shipment | None:
+        return self._session.scalar(
+            select(Shipment)
+            .join(
+                ShipmentItem,
+                and_(
+                    ShipmentItem.shipment_id == Shipment.id,
+                    ShipmentItem.organization_id == Shipment.organization_id,
+                ),
+            )
+            .where(
+                Shipment.organization_id == self._organization_id,
+                Shipment.status == "DISPATCHED",
+                Shipment.destination_country.is_not(None),
+            )
+            .order_by(
+                Shipment.shipped_at.desc().nullslast(),
+                Shipment.created_at.desc(),
+                Shipment.id.desc(),
+            )
+            .limit(1)
+        )
+
+    def evaluate(self) -> PilotReadinessView:
+        try:
+            organization = self._session.scalar(
+                select(Organization).where(Organization.id == self._organization_id)
+            )
+            if organization is None:
+                raise PilotReadinessPersistenceError(
+                    "La organización activa no está disponible."
+                )
+
+            active_users = self._count(
+                User,
+                User.organization_id == self._organization_id,
+                User.is_active.is_(True),
+            )
+            active_licenses = self._count(
+                License,
+                License.organization_id == self._organization_id,
+                License.is_active.is_(True),
+            )
+            lotes = self._count(
+                Lote,
+                Lote.organization_id == self._organization_id,
+            )
+            vault_documents = self._count(
+                VaultDocument,
+                VaultDocument.organization_id == self._organization_id,
+                VaultDocument.status == "available",
+            )
+            posted_receipts = self._count(
+                TraceabilityEvent,
+                TraceabilityEvent.organization_id == self._organization_id,
+                TraceabilityEvent.event_type == "RECEIPT",
+                TraceabilityEvent.status == "POSTED",
+            )
+            posted_transformations = self._count(
+                TraceabilityEvent,
+                TraceabilityEvent.organization_id == self._organization_id,
+                TraceabilityEvent.event_type == "TRANSFORMATION",
+                TraceabilityEvent.status == "POSTED",
+            )
+            dispatched_shipments = self._count(
+                Shipment,
+                Shipment.organization_id == self._organization_id,
+                Shipment.status == "DISPATCHED",
+                Shipment.destination_country.is_not(None),
+            )
+
+            steps: list[PilotStepView] = [
+                _step(
+                    "TENANT",
+                    "Organización y acceso",
+                    bool(organization.is_active and active_users and active_licenses),
+                    (
+                        f"{active_users} usuario(s) activo(s) y licencia activa."
+                        if active_licenses
+                        else "La organización necesita una licencia activa."
+                    ),
+                    "Abrir configuración",
+                    "/settings",
+                ),
+                _step(
+                    "ORIGIN",
+                    "Origen y lotes",
+                    lotes > 0,
+                    (
+                        f"{lotes} lote(s) de origen disponible(s)."
+                        if lotes
+                        else "Cargá al menos un lote real de origen."
+                    ),
+                    "Cargar lotes",
+                    "/imports",
+                ),
+                _step(
+                    "EVIDENCE",
+                    "Evidencia documental",
+                    vault_documents > 0,
+                    (
+                        f"{vault_documents} documento(s) disponible(s) en Vault."
+                        if vault_documents
+                        else "Subí al menos una evidencia documental al Vault."
+                    ),
+                    "Abrir evidencias",
+                    "/evidence",
+                ),
+                _step(
+                    "RECEIPT",
+                    "Recepción trazable",
+                    posted_receipts > 0,
+                    (
+                        f"{posted_receipts} recepción(es) POSTED."
+                        if posted_receipts
+                        else "Registrá y publicá una recepción vinculada al origen."
+                    ),
+                    "Abrir operaciones",
+                    "/operations",
+                ),
+                _step(
+                    "TRANSFORMATION",
+                    "Transformación / cadena de custodia",
+                    posted_transformations > 0,
+                    (
+                        f"{posted_transformations} transformación(es) POSTED."
+                        if posted_transformations
+                        else "Publicá una transformación para demostrar genealogía industrial."
+                    ),
+                    "Abrir operaciones",
+                    "/operations",
+                ),
+            ]
+
+            shipment = self._latest_international_dispatched_shipment()
+            shipment_code = shipment.shipment_code if shipment is not None else None
+            steps.append(
+                _step(
+                    "SHIPMENT",
+                    "Despacho internacional",
+                    shipment is not None,
+                    (
+                        f"Despacho {shipment.shipment_code} DISPATCHED hacia {shipment.destination_country}."
+                        if shipment is not None
+                        else "Creá y despachá una salida internacional con material trazado."
+                    ),
+                    "Abrir operaciones",
+                    "/operations",
+                )
+            )
+
+            compliance_ready = False
+            compliance_detail = "Primero necesitás un despacho internacional DISPATCHED."
+            compliance_href = "/release-control"
+
+            if shipment is not None:
+                query = urlencode({"shipment_code": shipment.shipment_code})
+                compliance_href = f"/release-control?{query}"
+                export_readiness = ShipmentExportCaseService(
+                    session=self._session,
+                    organization_id=self._organization_id,
+                ).readiness(shipment.shipment_code)
+                phytosanitary_readiness = ShipmentPhytosanitaryCaseService(
+                    session=self._session,
+                    organization_id=self._organization_id,
+                ).readiness(shipment.shipment_code)
+
+                eudr_required = is_eudr_destination(
+                    {
+                        "shipment": {
+                            "destination_country": shipment.destination_country,
+                            "shipment_code": shipment.shipment_code,
+                        }
+                    }
+                )
+                eudr_ready = True
+                if eudr_required:
+                    eudr_ready = EudrDdsCandidateService(
+                        session=self._session,
+                        organization_id=self._organization_id,
+                    ).conformance(shipment.shipment_code).ready
+
+                compliance_ready = bool(
+                    export_readiness.ready
+                    and phytosanitary_readiness.ready
+                    and eudr_ready
+                )
+                parts = [
+                    f"expediente {'READY' if export_readiness.ready else 'BLOCKED'}",
+                    f"fitosanitario {'READY' if phytosanitary_readiness.ready else 'BLOCKED'}",
+                ]
+                if eudr_required:
+                    parts.append(
+                        f"EUDR {'CONFORMANCE_READY' if eudr_ready else 'BLOCKED'}"
+                    )
+                compliance_detail = " · ".join(parts) + "."
+
+            steps.append(
+                _step(
+                    "RELEASE",
+                    "Expediente y Control de Salida",
+                    compliance_ready,
+                    compliance_detail,
+                    "Abrir Control de Salida",
+                    compliance_href,
+                )
+            )
+
+            completed_steps = sum(step.completed for step in steps)
+            operational_started = any(step.completed for step in steps[1:])
+            if completed_steps == len(steps):
+                state = PILOT_READY
+            elif operational_started:
+                state = PILOT_IN_PROGRESS
+            else:
+                state = PILOT_NOT_STARTED
+
+            return PilotReadinessView(
+                organization_id=self._organization_id,
+                organization_name=str(organization.name),
+                state=state,
+                completed_steps=completed_steps,
+                total_steps=len(steps),
+                shipment_code=shipment_code,
+                steps=tuple(steps),
+                counts={
+                    "active_users": active_users,
+                    "active_licenses": active_licenses,
+                    "lotes": lotes,
+                    "vault_documents": vault_documents,
+                    "posted_receipts": posted_receipts,
+                    "posted_transformations": posted_transformations,
+                    "dispatched_shipments": dispatched_shipments,
+                },
+            )
+        except PilotReadinessError:
+            raise
+        except SQLAlchemyError as exc:
+            raise PilotReadinessPersistenceError(
+                "No fue posible calcular el estado del piloto."
+            ) from exc

--- a/src/litoral_trace/services/pilot_readiness.py
+++ b/src/litoral_trace/services/pilot_readiness.py
@@ -2,6 +2,11 @@
 
 No readiness flag is persisted. The service projects existing source-of-truth
 objects so the checklist cannot drift from the real operational state.
+
+The caller supplies the already-authenticated organization display name. This
+service deliberately does not re-read control-plane organization/user/license
+tables: authentication has already validated active user + active tenant, and
+pilot readiness must remain compatible with a least-privilege runtime role.
 """
 from __future__ import annotations
 
@@ -14,13 +19,10 @@ from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.orm import Session
 
 from litoral_trace.db.models import (
-    License,
     Lote,
-    Organization,
     Shipment,
     ShipmentItem,
     TraceabilityEvent,
-    User,
     VaultDocument,
 )
 from litoral_trace.services.eudr_dds_candidate import EudrDdsCandidateService
@@ -91,9 +93,16 @@ def _step(
 class PilotReadinessService:
     """Project a tenant's ability to execute one commercially useful pilot."""
 
-    def __init__(self, *, session: Session, organization_id: int) -> None:
+    def __init__(
+        self,
+        *,
+        session: Session,
+        organization_id: int,
+        organization_name: str = "Organización activa",
+    ) -> None:
         self._session = session
         self._organization_id = int(organization_id)
+        self._organization_name = str(organization_name or "Organización activa").strip()
 
     def _count(self, model: Any, *criteria: Any) -> int:
         return int(
@@ -128,24 +137,6 @@ class PilotReadinessService:
 
     def evaluate(self) -> PilotReadinessView:
         try:
-            organization = self._session.scalar(
-                select(Organization).where(Organization.id == self._organization_id)
-            )
-            if organization is None:
-                raise PilotReadinessPersistenceError(
-                    "La organización activa no está disponible."
-                )
-
-            active_users = self._count(
-                User,
-                User.organization_id == self._organization_id,
-                User.is_active.is_(True),
-            )
-            active_licenses = self._count(
-                License,
-                License.organization_id == self._organization_id,
-                License.is_active.is_(True),
-            )
             lotes = self._count(
                 Lote,
                 Lote.organization_id == self._organization_id,
@@ -178,12 +169,8 @@ class PilotReadinessService:
                 _step(
                     "TENANT",
                     "Organización y acceso",
-                    bool(organization.is_active and active_users and active_licenses),
-                    (
-                        f"{active_users} usuario(s) activo(s) y licencia activa."
-                        if active_licenses
-                        else "La organización necesita una licencia activa."
-                    ),
+                    True,
+                    "Sesión tenant activa, usuario vigente y permiso de lectura verificado por autenticación.",
                     "Abrir configuración",
                     "/settings",
                 ),
@@ -322,15 +309,14 @@ class PilotReadinessService:
 
             return PilotReadinessView(
                 organization_id=self._organization_id,
-                organization_name=str(organization.name),
+                organization_name=self._organization_name,
                 state=state,
                 completed_steps=completed_steps,
                 total_steps=len(steps),
                 shipment_code=shipment_code,
                 steps=tuple(steps),
                 counts={
-                    "active_users": active_users,
-                    "active_licenses": active_licenses,
+                    "authenticated_tenant": 1,
                     "lotes": lotes,
                     "vault_documents": vault_documents,
                     "posted_receipts": posted_receipts,

--- a/src/litoral_trace/services/pilot_readiness.py
+++ b/src/litoral_trace/services/pilot_readiness.py
@@ -7,6 +7,11 @@ The caller supplies the already-authenticated organization display name. This
 service deliberately does not re-read control-plane organization/user/license
 tables: authentication has already validated active user + active tenant, and
 pilot readiness must remain compatible with a least-privilege runtime role.
+
+Once a dispatched shipment exists, the origin/receipt/transformation milestones
+are anchored to that shipment's reverse genealogy. A tenant can therefore only
+reach ``PILOT_READY`` with one demonstrable end-to-end chain; unrelated tenant
+activity cannot be combined to manufacture readiness.
 """
 from __future__ import annotations
 
@@ -14,22 +19,20 @@ from dataclasses import dataclass
 from typing import Any
 from urllib.parse import urlencode
 
-from sqlalchemy import and_, func, select
+from sqlalchemy import func, select
 from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.orm import Session
 
-from litoral_trace.db.models import (
-    Lote,
-    Shipment,
-    ShipmentItem,
-    TraceabilityEvent,
-    VaultDocument,
-)
+from litoral_trace.db.models import Lote, Shipment, TraceabilityEvent, VaultDocument
 from litoral_trace.services.eudr_dds_candidate import EudrDdsCandidateService
 from litoral_trace.services.eudr_release_control import is_eudr_destination
 from litoral_trace.services.shipment_export_case import ShipmentExportCaseService
 from litoral_trace.services.shipment_phytosanitary_case import (
     ShipmentPhytosanitaryCaseService,
+)
+from litoral_trace.services.traceability_lineage import (
+    TraceabilityLineageError,
+    TraceabilityLineageService,
 )
 
 
@@ -72,6 +75,40 @@ class PilotReadinessView:
         return self.state == PILOT_READY
 
 
+@dataclass(frozen=True)
+class _ShipmentPilotProjection:
+    shipment: Shipment
+    lineage_complete: bool
+    source_lotes: int
+    posted_receipts: int
+    posted_transformations: int
+    export_ready: bool
+    phytosanitary_ready: bool
+    eudr_required: bool
+    eudr_ready: bool
+
+    @property
+    def chain_ready(self) -> bool:
+        return bool(
+            self.lineage_complete
+            and self.source_lotes > 0
+            and self.posted_receipts > 0
+            and self.posted_transformations > 0
+        )
+
+    @property
+    def release_ready(self) -> bool:
+        return bool(
+            self.export_ready
+            and self.phytosanitary_ready
+            and self.eudr_ready
+        )
+
+    @property
+    def qualifies(self) -> bool:
+        return self.chain_ready and self.release_ready
+
+
 def _step(
     key: str,
     label: str,
@@ -112,32 +149,105 @@ class PilotReadinessService:
             or 0
         )
 
-    def _latest_international_dispatched_shipment(self) -> Shipment | None:
-        return self._session.scalar(
-            select(Shipment)
-            .join(
-                ShipmentItem,
-                and_(
-                    ShipmentItem.shipment_id == Shipment.id,
-                    ShipmentItem.organization_id == Shipment.organization_id,
-                ),
-            )
-            .where(
-                Shipment.organization_id == self._organization_id,
-                Shipment.status == "DISPATCHED",
-                Shipment.destination_country.is_not(None),
-            )
-            .order_by(
-                Shipment.shipped_at.desc().nullslast(),
-                Shipment.created_at.desc(),
-                Shipment.id.desc(),
-            )
-            .limit(1)
+    def _dispatched_international_shipments(self) -> list[Shipment]:
+        return list(
+            self._session.execute(
+                select(Shipment)
+                .where(
+                    Shipment.organization_id == self._organization_id,
+                    Shipment.status == "DISPATCHED",
+                    Shipment.destination_country.is_not(None),
+                )
+                .order_by(
+                    Shipment.shipped_at.desc().nullslast(),
+                    Shipment.created_at.desc(),
+                    Shipment.id.desc(),
+                )
+            ).scalars().all()
         )
+
+    def _project_shipment(self, shipment: Shipment) -> _ShipmentPilotProjection:
+        lineage_complete = False
+        source_lotes = 0
+        posted_receipts = 0
+        posted_transformations = 0
+        try:
+            lineage = TraceabilityLineageService(
+                session=self._session,
+                organization_id=self._organization_id,
+            ).trace_shipment(shipment.shipment_code)
+            lineage_complete = bool(lineage.get("complete"))
+            source_lotes = len(lineage.get("source_lotes") or ())
+            events = tuple(lineage.get("events") or ())
+            posted_receipts = sum(
+                1
+                for event in events
+                if event.get("status") == "POSTED"
+                and event.get("event_type") == "RECEIPT"
+            )
+            posted_transformations = sum(
+                1
+                for event in events
+                if event.get("status") == "POSTED"
+                and event.get("event_type") == "TRANSFORMATION"
+            )
+        except TraceabilityLineageError:
+            # A broken lineage is a BLOCKED pilot candidate, not a reason to
+            # expose internal traceability errors or abort the whole checklist.
+            pass
+
+        export_readiness = ShipmentExportCaseService(
+            session=self._session,
+            organization_id=self._organization_id,
+        ).readiness(shipment.shipment_code)
+        phytosanitary_readiness = ShipmentPhytosanitaryCaseService(
+            session=self._session,
+            organization_id=self._organization_id,
+        ).readiness(shipment.shipment_code)
+
+        eudr_required = is_eudr_destination(
+            {
+                "shipment": {
+                    "destination_country": shipment.destination_country,
+                    "shipment_code": shipment.shipment_code,
+                }
+            }
+        )
+        eudr_ready = True
+        if eudr_required:
+            eudr_ready = EudrDdsCandidateService(
+                session=self._session,
+                organization_id=self._organization_id,
+            ).conformance(shipment.shipment_code).ready
+
+        return _ShipmentPilotProjection(
+            shipment=shipment,
+            lineage_complete=lineage_complete,
+            source_lotes=source_lotes,
+            posted_receipts=posted_receipts,
+            posted_transformations=posted_transformations,
+            export_ready=bool(export_readiness.ready),
+            phytosanitary_ready=bool(phytosanitary_readiness.ready),
+            eudr_required=bool(eudr_required),
+            eudr_ready=bool(eudr_ready),
+        )
+
+    def _select_shipment_projection(
+        self,
+        shipments: list[Shipment],
+    ) -> _ShipmentPilotProjection | None:
+        fallback: _ShipmentPilotProjection | None = None
+        for shipment in shipments:
+            projection = self._project_shipment(shipment)
+            if fallback is None:
+                fallback = projection
+            if projection.qualifies:
+                return projection
+        return fallback
 
     def evaluate(self) -> PilotReadinessView:
         try:
-            lotes = self._count(
+            tenant_lotes = self._count(
                 Lote,
                 Lote.organization_id == self._organization_id,
             )
@@ -146,24 +256,61 @@ class PilotReadinessService:
                 VaultDocument.organization_id == self._organization_id,
                 VaultDocument.status == "available",
             )
-            posted_receipts = self._count(
+            tenant_posted_receipts = self._count(
                 TraceabilityEvent,
                 TraceabilityEvent.organization_id == self._organization_id,
                 TraceabilityEvent.event_type == "RECEIPT",
                 TraceabilityEvent.status == "POSTED",
             )
-            posted_transformations = self._count(
+            tenant_posted_transformations = self._count(
                 TraceabilityEvent,
                 TraceabilityEvent.organization_id == self._organization_id,
                 TraceabilityEvent.event_type == "TRANSFORMATION",
                 TraceabilityEvent.status == "POSTED",
             )
-            dispatched_shipments = self._count(
-                Shipment,
-                Shipment.organization_id == self._organization_id,
-                Shipment.status == "DISPATCHED",
-                Shipment.destination_country.is_not(None),
-            )
+            shipments = self._dispatched_international_shipments()
+            projection = self._select_shipment_projection(shipments)
+
+            if projection is None:
+                origin_count = tenant_lotes
+                receipt_count = tenant_posted_receipts
+                transformation_count = tenant_posted_transformations
+                origin_detail = (
+                    f"{origin_count} lote(s) de origen disponible(s)."
+                    if origin_count
+                    else "Cargá al menos un lote real de origen."
+                )
+                receipt_detail = (
+                    f"{receipt_count} recepción(es) POSTED."
+                    if receipt_count
+                    else "Registrá y publicá una recepción vinculada al origen."
+                )
+                transformation_detail = (
+                    f"{transformation_count} transformación(es) POSTED."
+                    if transformation_count
+                    else "Publicá una transformación para demostrar genealogía industrial."
+                )
+            else:
+                origin_count = projection.source_lotes if projection.lineage_complete else 0
+                receipt_count = projection.posted_receipts if projection.lineage_complete else 0
+                transformation_count = (
+                    projection.posted_transformations if projection.lineage_complete else 0
+                )
+                origin_detail = (
+                    f"{origin_count} lote(s) de origen reconstruido(s) para {projection.shipment.shipment_code}."
+                    if origin_count
+                    else f"El despacho {projection.shipment.shipment_code} no tiene origen completo reconstruible."
+                )
+                receipt_detail = (
+                    f"{receipt_count} recepción(es) POSTED dentro de la genealogía de {projection.shipment.shipment_code}."
+                    if receipt_count
+                    else f"La genealogía de {projection.shipment.shipment_code} no contiene una recepción POSTED válida."
+                )
+                transformation_detail = (
+                    f"{transformation_count} transformación(es) POSTED dentro de la genealogía de {projection.shipment.shipment_code}."
+                    if transformation_count
+                    else f"La genealogía de {projection.shipment.shipment_code} no contiene una transformación POSTED."
+                )
 
             steps: list[PilotStepView] = [
                 _step(
@@ -177,12 +324,8 @@ class PilotReadinessService:
                 _step(
                     "ORIGIN",
                     "Origen y lotes",
-                    lotes > 0,
-                    (
-                        f"{lotes} lote(s) de origen disponible(s)."
-                        if lotes
-                        else "Cargá al menos un lote real de origen."
-                    ),
+                    origin_count > 0,
+                    origin_detail,
                     "Cargar lotes",
                     "/imports",
                 ),
@@ -201,30 +344,22 @@ class PilotReadinessService:
                 _step(
                     "RECEIPT",
                     "Recepción trazable",
-                    posted_receipts > 0,
-                    (
-                        f"{posted_receipts} recepción(es) POSTED."
-                        if posted_receipts
-                        else "Registrá y publicá una recepción vinculada al origen."
-                    ),
+                    receipt_count > 0,
+                    receipt_detail,
                     "Abrir operaciones",
                     "/operations",
                 ),
                 _step(
                     "TRANSFORMATION",
                     "Transformación / cadena de custodia",
-                    posted_transformations > 0,
-                    (
-                        f"{posted_transformations} transformación(es) POSTED."
-                        if posted_transformations
-                        else "Publicá una transformación para demostrar genealogía industrial."
-                    ),
+                    transformation_count > 0,
+                    transformation_detail,
                     "Abrir operaciones",
                     "/operations",
                 ),
             ]
 
-            shipment = self._latest_international_dispatched_shipment()
+            shipment = projection.shipment if projection is not None else None
             shipment_code = shipment.shipment_code if shipment is not None else None
             steps.append(
                 _step(
@@ -241,49 +376,19 @@ class PilotReadinessService:
                 )
             )
 
-            compliance_ready = False
+            compliance_ready = bool(projection and projection.release_ready)
             compliance_detail = "Primero necesitás un despacho internacional DISPATCHED."
             compliance_href = "/release-control"
-
-            if shipment is not None:
-                query = urlencode({"shipment_code": shipment.shipment_code})
+            if projection is not None:
+                query = urlencode({"shipment_code": projection.shipment.shipment_code})
                 compliance_href = f"/release-control?{query}"
-                export_readiness = ShipmentExportCaseService(
-                    session=self._session,
-                    organization_id=self._organization_id,
-                ).readiness(shipment.shipment_code)
-                phytosanitary_readiness = ShipmentPhytosanitaryCaseService(
-                    session=self._session,
-                    organization_id=self._organization_id,
-                ).readiness(shipment.shipment_code)
-
-                eudr_required = is_eudr_destination(
-                    {
-                        "shipment": {
-                            "destination_country": shipment.destination_country,
-                            "shipment_code": shipment.shipment_code,
-                        }
-                    }
-                )
-                eudr_ready = True
-                if eudr_required:
-                    eudr_ready = EudrDdsCandidateService(
-                        session=self._session,
-                        organization_id=self._organization_id,
-                    ).conformance(shipment.shipment_code).ready
-
-                compliance_ready = bool(
-                    export_readiness.ready
-                    and phytosanitary_readiness.ready
-                    and eudr_ready
-                )
                 parts = [
-                    f"expediente {'READY' if export_readiness.ready else 'BLOCKED'}",
-                    f"fitosanitario {'READY' if phytosanitary_readiness.ready else 'BLOCKED'}",
+                    f"expediente {'READY' if projection.export_ready else 'BLOCKED'}",
+                    f"fitosanitario {'READY' if projection.phytosanitary_ready else 'BLOCKED'}",
                 ]
-                if eudr_required:
+                if projection.eudr_required:
                     parts.append(
-                        f"EUDR {'CONFORMANCE_READY' if eudr_ready else 'BLOCKED'}"
+                        f"EUDR {'CONFORMANCE_READY' if projection.eudr_ready else 'BLOCKED'}"
                     )
                 compliance_detail = " · ".join(parts) + "."
 
@@ -300,7 +405,12 @@ class PilotReadinessService:
 
             completed_steps = sum(step.completed for step in steps)
             operational_started = any(step.completed for step in steps[1:])
-            if completed_steps == len(steps):
+            selected_chain_ready = bool(projection and projection.chain_ready)
+            if (
+                completed_steps == len(steps)
+                and selected_chain_ready
+                and compliance_ready
+            ):
                 state = PILOT_READY
             elif operational_started:
                 state = PILOT_IN_PROGRESS
@@ -317,11 +427,11 @@ class PilotReadinessService:
                 steps=tuple(steps),
                 counts={
                     "authenticated_tenant": 1,
-                    "lotes": lotes,
+                    "lotes": origin_count,
                     "vault_documents": vault_documents,
-                    "posted_receipts": posted_receipts,
-                    "posted_transformations": posted_transformations,
-                    "dispatched_shipments": dispatched_shipments,
+                    "posted_receipts": receipt_count,
+                    "posted_transformations": transformation_count,
+                    "dispatched_shipments": len(shipments),
                 },
             )
         except PilotReadinessError:

--- a/src/litoral_trace/templates/pilot_readiness.html
+++ b/src/litoral_trace/templates/pilot_readiness.html
@@ -1,0 +1,76 @@
+{% extends "app/base_app.html" %}
+
+{% block title %}Preparar piloto | Litoral Trace{% endblock %}
+
+{% block content %}
+<div class="mb-6 flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+    <div>
+        <p class="text-xs font-semibold uppercase tracking-wider text-emerald-700">Primer cliente</p>
+        <h1 class="mt-1 text-2xl font-bold text-slate-950">Preparar piloto de 30 días</h1>
+        <p class="mt-2 max-w-3xl text-sm leading-6 text-slate-600">Este checklist se calcula desde datos reales de tu organización. No guarda tildes manuales ni reemplaza los controles regulatorios de cada módulo.</p>
+    </div>
+    {% if pilot_readiness %}
+    <div class="rounded-xl border border-slate-200 bg-white px-4 py-3 shadow-sm">
+        <p class="text-xs font-semibold uppercase tracking-wider text-slate-500">Estado</p>
+        {% if pilot_readiness.ready %}
+        <p class="mt-1 text-sm font-bold text-emerald-700">PILOT_READY</p>
+        {% elif pilot_readiness.state == "IN_PROGRESS" %}
+        <p class="mt-1 text-sm font-bold text-slate-900">IN_PROGRESS</p>
+        {% else %}
+        <p class="mt-1 text-sm font-bold text-slate-700">NOT_STARTED</p>
+        {% endif %}
+        <p class="mt-1 text-xs text-slate-500">{{ pilot_readiness.completed_steps }} de {{ pilot_readiness.total_steps }} hitos cerrados</p>
+    </div>
+    {% endif %}
+</div>
+
+{% if pilot_error %}
+<section class="rounded-xl border border-slate-200 bg-white p-5 shadow-sm">
+    <h2 class="text-base font-bold text-slate-950">Estado temporalmente no disponible</h2>
+    <p class="mt-2 text-sm text-slate-600">{{ pilot_error }}</p>
+</section>
+{% elif pilot_readiness %}
+<section class="mb-6 rounded-2xl border border-slate-200 bg-white p-5 shadow-sm">
+    <div class="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+        <div>
+            <h2 class="text-base font-bold text-slate-950">{{ pilot_readiness.organization_name }}</h2>
+            <p class="mt-1 text-xs text-slate-500">El objetivo es completar una operación forestal demostrable de punta a punta con evidencia verificable.</p>
+        </div>
+        {% if pilot_readiness.shipment_code %}
+        <span class="rounded-full bg-slate-100 px-3 py-1 text-xs font-semibold text-slate-700">Despacho: {{ pilot_readiness.shipment_code }}</span>
+        {% endif %}
+    </div>
+</section>
+
+<div class="space-y-4">
+    {% for step in pilot_readiness.steps %}
+    <section class="rounded-2xl border {% if step.completed %}border-emerald-200{% else %}border-slate-200{% endif %} bg-white p-5 shadow-sm">
+        <div class="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+            <div class="flex items-start gap-3">
+                <div class="mt-0.5 flex h-8 w-8 items-center justify-center rounded-full {% if step.completed %}bg-emerald-50 text-emerald-700{% else %}bg-slate-100 text-slate-600{% endif %}">
+                    {% if step.completed %}<i class="fa-solid fa-check" aria-hidden="true"></i>{% else %}<i class="fa-solid fa-arrow-right" aria-hidden="true"></i>{% endif %}
+                </div>
+                <div>
+                    <div class="flex flex-wrap items-center gap-2">
+                        <h2 class="text-sm font-bold text-slate-950">{{ loop.index }}. {{ step.label }}</h2>
+                        {% if step.completed %}
+                        <span class="rounded-full bg-emerald-50 px-2 py-1 text-xs font-semibold text-emerald-700">Listo</span>
+                        {% else %}
+                        <span class="rounded-full bg-slate-100 px-2 py-1 text-xs font-semibold text-slate-600">Pendiente</span>
+                        {% endif %}
+                    </div>
+                    <p class="mt-1 text-sm leading-6 text-slate-600">{{ step.detail }}</p>
+                </div>
+            </div>
+            <a href="{{ step.action_href }}" class="inline-flex items-center justify-center rounded-lg border border-slate-300 px-3 py-2 text-xs font-semibold text-slate-700 hover:bg-slate-50">{{ step.action_label }}</a>
+        </div>
+    </section>
+    {% endfor %}
+</div>
+
+<section class="mt-6 rounded-2xl border border-slate-200 bg-slate-50 p-5">
+    <h2 class="text-sm font-bold text-slate-950">Qué significa PILOT_READY</h2>
+    <p class="mt-2 text-xs leading-5 text-slate-600">La organización ya puede demostrar una cadena con origen, evidencia, recepción, transformación, despacho internacional y controles documentales aplicables. Para destinos UE se exige candidato EUDR conformance-ready. El smoke remoto de ACCEPTANCE no bloquea este piloto y ningún resultado implica certificación oficial EUDR.</p>
+</section>
+{% endif %}
+{% endblock %}

--- a/src/litoral_trace/web/navigation.py
+++ b/src/litoral_trace/web/navigation.py
@@ -36,6 +36,14 @@ _NAVIGATION = (
         active_prefixes=("/dashboard",),
     ),
     NavigationItem(
+        key="pilot_readiness",
+        label="Preparar piloto",
+        href="/pilot-readiness",
+        section="operacion",
+        permission=Permission.LOTE_READ,
+        active_prefixes=("/pilot-readiness",),
+    ),
+    NavigationItem(
         key="operations",
         label="Operaciones",
         href="/operations",

--- a/src/litoral_trace/web/navigation.py
+++ b/src/litoral_trace/web/navigation.py
@@ -126,9 +126,18 @@ def build_navigation(
     """Devuelve sólo las opciones que el rol autenticado puede utilizar."""
 
     visible: list[NavigationView] = []
+    role = str(getattr(user, "role", "") or "").strip().lower()
 
     for item in _NAVIGATION:
         if not has_permission(user, item.permission):
+            continue
+
+        # Pilot readiness is an onboarding workspace for the tenant roles that
+        # actually operate the pilot. Superadmin remains a platform control-
+        # plane role, while auditor/cliente retain read-only direct-route/API
+        # access through LOTE_READ without adding onboarding clutter to their
+        # sidebar.
+        if item.key == "pilot_readiness" and role not in {"admin", "manager"}:
             continue
 
         visible.append(

--- a/src/litoral_trace/web/pilot_readiness.py
+++ b/src/litoral_trace/web/pilot_readiness.py
@@ -47,6 +47,7 @@ async def render_pilot_readiness(request: Request) -> HTMLResponse:
         view = PilotReadinessService(
             session=session,
             organization_id=user.organization_id,
+            organization_name=user.organization_name,
         ).evaluate()
         return render_web_template(
             request,

--- a/src/litoral_trace/web/pilot_readiness.py
+++ b/src/litoral_trace/web/pilot_readiness.py
@@ -1,0 +1,69 @@
+"""Server-rendered first-customer pilot readiness workspace."""
+from __future__ import annotations
+
+from fastapi import APIRouter, Request, status
+from fastapi.responses import HTMLResponse
+
+from litoral_trace.auth.rbac import Permission
+from litoral_trace.db.tenant import get_tenant_scoped_db_session
+from litoral_trace.services.pilot_readiness import (
+    PilotReadinessPersistenceError,
+    PilotReadinessService,
+)
+from litoral_trace.web.runtime import get_html_route_user, render_web_template
+
+
+router = APIRouter(tags=["Frontend B2B"])
+
+
+@router.get(
+    "/pilot-readiness",
+    response_class=HTMLResponse,
+    include_in_schema=False,
+    name="render_pilot_readiness",
+)
+async def render_pilot_readiness(request: Request) -> HTMLResponse:
+    user, denied = get_html_route_user(
+        request,
+        required_permission=Permission.LOTE_READ,
+    )
+    if denied is not None:
+        return denied
+
+    session = get_tenant_scoped_db_session(user.organization_id)
+    if session is None:
+        return render_web_template(
+            request,
+            "pilot_readiness.html",
+            user=user,
+            context={
+                "pilot_readiness": None,
+                "pilot_error": "El estado del piloto no está disponible temporalmente.",
+            },
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+        )
+
+    try:
+        view = PilotReadinessService(
+            session=session,
+            organization_id=user.organization_id,
+        ).evaluate()
+        return render_web_template(
+            request,
+            "pilot_readiness.html",
+            user=user,
+            context={"pilot_readiness": view, "pilot_error": None},
+        )
+    except PilotReadinessPersistenceError:
+        return render_web_template(
+            request,
+            "pilot_readiness.html",
+            user=user,
+            context={
+                "pilot_readiness": None,
+                "pilot_error": "No fue posible calcular el estado real del piloto.",
+            },
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+        )
+    finally:
+        session.close()

--- a/tests/test_frontend_p2fea_unittest.py
+++ b/tests/test_frontend_p2fea_unittest.py
@@ -142,6 +142,7 @@ def test_navigation_is_server_side_rbac_derived():
     )
     assert [item.key for item in admin_nav] == [
         "dashboard",
+        "pilot_readiness",
         "operations",
         "imports",
         "traceability",

--- a/tests/test_p1f_pilot_readiness_postgres_integration.py
+++ b/tests/test_p1f_pilot_readiness_postgres_integration.py
@@ -1,0 +1,343 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from decimal import Decimal
+from pathlib import Path
+from types import SimpleNamespace
+from uuid import uuid4
+
+import pytest
+from sqlalchemy import create_engine, text
+from sqlalchemy.orm import sessionmaker
+
+from litoral_trace.config.settings import normalize_database_url
+from litoral_trace.db.tenant import set_tenant_db_context
+from litoral_trace.services.audit import AuditActor
+from litoral_trace.services.pilot_readiness import (
+    PILOT_NOT_STARTED,
+    PILOT_READY,
+    PilotReadinessService,
+)
+from litoral_trace.services.traceability_operations import (
+    ProcessInputDraft,
+    ProcessOutputDraft,
+    ShipmentItemDraft,
+    TraceabilityOperationService,
+)
+
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+ENV_PATH = ROOT_DIR / ".env.integration"
+EXPECTED_REVISION = "026_add_eudr_acceptance_attempts"
+
+
+def _read_env() -> dict[str, str]:
+    values: dict[str, str] = {}
+    if not ENV_PATH.exists():
+        return values
+    for raw_line in ENV_PATH.read_text(encoding="utf-8-sig").splitlines():
+        line = raw_line.strip()
+        if line and not line.startswith("#") and "=" in line:
+            name, value = line.split("=", 1)
+            values[name.strip()] = value.strip()
+    return values
+
+
+ENV = _read_env()
+ENABLED = (ENV.get("ENABLE_POSTGRES_TESTS") or "").lower() in {"1", "true", "yes", "on"}
+RUNTIME_URL = ENV.get("TEST_POSTGRES_DATABASE_URL")
+OWNER_URL = ENV.get("TEST_POSTGRES_MIGRATION_DATABASE_URL")
+
+pytestmark = pytest.mark.skipif(
+    not (ENABLED and RUNTIME_URL and OWNER_URL),
+    reason="P1-F PostgreSQL tests require the isolated integration contract.",
+)
+
+
+def _engine(url: str):
+    return create_engine(
+        normalize_database_url(url),
+        pool_pre_ping=True,
+        hide_parameters=True,
+    )
+
+
+def _actor(org_id: int) -> AuditActor:
+    return AuditActor(
+        organization_id=org_id,
+        user_id=None,
+        username="p1f.pilot@test.invalid",
+        role="admin",
+    )
+
+
+class _ReadyService:
+    def readiness(self, shipment_code: str):
+        return SimpleNamespace(ready=True)
+
+
+class _ReadyCandidateService:
+    def conformance(self, shipment_code: str):
+        return SimpleNamespace(ready=True)
+
+
+def test_p1f_readiness_tracks_real_tenant_progress_and_isolation(monkeypatch) -> None:
+    owner_engine = _engine(OWNER_URL)
+    runtime_engine = _engine(RUNTIME_URL)
+    RuntimeSession = sessionmaker(bind=runtime_engine, autoflush=False)
+    suffix = uuid4().hex[:10]
+    org_ids: list[int] = []
+
+    with owner_engine.begin() as connection:
+        revision = connection.execute(text("SELECT version_num FROM alembic_version")).scalar_one()
+        assert revision == EXPECTED_REVISION
+
+        for label in ("A", "B"):
+            org_id = int(
+                connection.execute(
+                    text(
+                        """
+                        INSERT INTO public.organizations
+                            (name, slug, tax_id, tier, description, is_active)
+                        VALUES
+                            (:name, :slug, :tax_id, 'pro', 'P1-F pilot gate', true)
+                        RETURNING id
+                        """
+                    ),
+                    {
+                        "name": f"P1F Pilot Org {label} {suffix}",
+                        "slug": f"p1f-pilot-{label.lower()}-{suffix}",
+                        "tax_id": f"P1F-{label}-{suffix}",
+                    },
+                ).scalar_one()
+            )
+            org_ids.append(org_id)
+            connection.execute(
+                text(
+                    """
+                    INSERT INTO public.users
+                        (organization_id, email, username, password_hash, role, is_active)
+                    VALUES
+                        (:org, :email, :username, 'test-hash', 'admin', true)
+                    """
+                ),
+                {
+                    "org": org_id,
+                    "email": f"p1f-{label.lower()}-{suffix}@test.invalid",
+                    "username": f"p1f-{label.lower()}-{suffix}",
+                },
+            )
+            connection.execute(
+                text(
+                    """
+                    INSERT INTO public.licenses
+                        (organization_id, plan_type, max_lotes, max_volume_tons, max_batch_rows, is_active)
+                    VALUES
+                        (:org, 'pro', 50, 3000, 500, true)
+                    """
+                ),
+                {"org": org_id},
+            )
+
+    org_a, org_b = org_ids
+
+    session_b = RuntimeSession()
+    try:
+        set_tenant_db_context(session_b, org_b)
+        initial_b = PilotReadinessService(session=session_b, organization_id=org_b).evaluate()
+        assert initial_b.state == PILOT_NOT_STARTED
+        assert initial_b.completed_steps == 1
+        assert initial_b.counts["lotes"] == 0
+        assert initial_b.shipment_code is None
+    finally:
+        session_b.close()
+
+    with owner_engine.begin() as connection:
+        connection.execute(
+            text(
+                """
+                INSERT INTO public.lotes (
+                    organization_id, identificador, productor_id,
+                    producto_forestal, hectareas, latitud, longitud,
+                    polygon_wkt, geom, estatus,
+                    volumen_ingresado_ton, volumen_exportar_ton
+                ) VALUES (
+                    :org, :identifier, :producer,
+                    'Pino taeda', 12.0, -28.05, -56.03,
+                    :polygon_wkt,
+                    ST_SetSRID(ST_GeomFromText(:polygon_wkt), 4326),
+                    'Pendiente', 0.0, 0.0
+                )
+                """
+            ),
+            {
+                "org": org_a,
+                "identifier": f"RODAL-P1F-{suffix}",
+                "producer": f"PROV-P1F-{suffix}",
+                "polygon_wkt": (
+                    "POLYGON((-56.04 -28.06,-56.02 -28.06,-56.02 -28.04,"
+                    "-56.04 -28.04,-56.04 -28.06))"
+                ),
+            },
+        )
+        connection.execute(
+            text(
+                """
+                INSERT INTO public.vault_documents (
+                    organization_id, original_filename, content_type, size_bytes,
+                    sha256, object_key, storage_backend, storage_bucket,
+                    document_type, status
+                ) VALUES (
+                    :org, 'p1f-evidence.pdf', 'application/pdf', 128,
+                    :sha, :object_key, 's3', 'p1f-ci-bucket',
+                    'OTHER_EVIDENCE', 'available'
+                )
+                """
+            ),
+            {
+                "org": org_a,
+                "sha": "a" * 64,
+                "object_key": f"p1f/{suffix}/evidence.pdf",
+            },
+        )
+
+    operations = TraceabilityOperationService(session_factory=RuntimeSession)
+    actor = _actor(org_a)
+    t0 = datetime.now(timezone.utc) - timedelta(hours=4)
+    receipt = operations.create_receipt_draft(
+        organization_id=org_a,
+        actor=actor,
+        source_identifier=f"RODAL-P1F-{suffix}",
+        event_code=f"REC-P1F-{suffix}",
+        batch_code=f"MP-P1F-{suffix}",
+        product_name="Madera rolliza Pino taeda",
+        quantity="100",
+        unit="M3",
+        occurred_at=t0,
+        facility_reference="Planta piloto Corrientes",
+    )
+    operations.post_event(
+        organization_id=org_a,
+        event_public_id=receipt.event_public_id,
+        actor=actor,
+    )
+    process = operations.create_process_draft(
+        organization_id=org_a,
+        actor=actor,
+        event_code=f"PROC-P1F-{suffix}",
+        event_type="TRANSFORMATION",
+        occurred_at=t0 + timedelta(hours=1),
+        inputs=(
+            ProcessInputDraft(
+                batch_public_id=receipt.output_batch_public_ids[0],
+                quantity=Decimal("70"),
+            ),
+        ),
+        outputs=(
+            ProcessOutputDraft(
+                code=f"ASERRADO-P1F-{suffix}",
+                product_name="Madera aserrada Pino taeda",
+                stage="FINISHED_GOOD",
+                unit="M3",
+                quantity=Decimal("65"),
+            ),
+        ),
+        facility_reference="Planta piloto Corrientes",
+    )
+    operations.post_event(
+        organization_id=org_a,
+        event_public_id=process.event_public_id,
+        actor=actor,
+    )
+    shipment = operations.create_shipment_draft(
+        organization_id=org_a,
+        actor=actor,
+        shipment_code=f"EXP-P1F-{suffix}",
+        sale_reference=f"FAC-P1F-{suffix}",
+        buyer_reference="Importador UE piloto",
+        destination_country="DE",
+        items=(
+            ShipmentItemDraft(
+                batch_public_id=process.output_batch_public_ids[0],
+                quantity=Decimal("60"),
+            ),
+        ),
+    )
+    operations.dispatch_shipment(
+        organization_id=org_a,
+        shipment_public_id=shipment.shipment_public_id,
+        actor=actor,
+    )
+
+    monkeypatch.setattr(
+        "litoral_trace.services.pilot_readiness.ShipmentExportCaseService",
+        lambda **kwargs: _ReadyService(),
+    )
+    monkeypatch.setattr(
+        "litoral_trace.services.pilot_readiness.ShipmentPhytosanitaryCaseService",
+        lambda **kwargs: _ReadyService(),
+    )
+    monkeypatch.setattr(
+        "litoral_trace.services.pilot_readiness.EudrDdsCandidateService",
+        lambda **kwargs: _ReadyCandidateService(),
+    )
+
+    session_a = RuntimeSession()
+    try:
+        set_tenant_db_context(session_a, org_a)
+        ready_a = PilotReadinessService(session=session_a, organization_id=org_a).evaluate()
+        assert ready_a.state == PILOT_READY
+        assert ready_a.ready is True
+        assert ready_a.completed_steps == ready_a.total_steps == 7
+        assert ready_a.shipment_code == shipment.shipment_code
+        assert ready_a.counts["lotes"] == 1
+        assert ready_a.counts["vault_documents"] == 1
+        assert ready_a.counts["posted_receipts"] == 1
+        assert ready_a.counts["posted_transformations"] == 1
+        assert ready_a.counts["dispatched_shipments"] == 1
+        assert all(step.completed for step in ready_a.steps)
+    finally:
+        session_a.close()
+
+    session_b = RuntimeSession()
+    try:
+        set_tenant_db_context(session_b, org_b)
+        unchanged_b = PilotReadinessService(session=session_b, organization_id=org_b).evaluate()
+        assert unchanged_b.state == PILOT_NOT_STARTED
+        assert unchanged_b.completed_steps == 1
+        assert unchanged_b.counts["lotes"] == 0
+        assert unchanged_b.counts["vault_documents"] == 0
+        assert unchanged_b.counts["dispatched_shipments"] == 0
+    finally:
+        session_b.close()
+
+    with owner_engine.begin() as connection:
+        params = {"org_a": org_a, "org_b": org_b}
+        for table_name in (
+            "audit_logs",
+            "traceability_evidence_links",
+            "shipment_items",
+            "shipments",
+            "traceability_event_inputs",
+            "traceability_event_outputs",
+            "traceability_events",
+            "traceability_batches",
+            "vault_documents",
+            "lotes",
+            "licenses",
+            "users",
+        ):
+            connection.execute(
+                text(
+                    f"DELETE FROM public.{table_name} "
+                    "WHERE organization_id IN (:org_a, :org_b)"
+                ),
+                params,
+            )
+        connection.execute(
+            text("DELETE FROM public.organizations WHERE id IN (:org_a, :org_b)"),
+            params,
+        )
+
+    runtime_engine.dispose()
+    owner_engine.dispose()

--- a/tests/test_p1f_pilot_readiness_postgres_integration.py
+++ b/tests/test_p1f_pilot_readiness_postgres_integration.py
@@ -144,7 +144,11 @@ def test_p1f_readiness_tracks_real_tenant_progress_and_isolation(monkeypatch) ->
     session_b = RuntimeSession()
     try:
         set_tenant_db_context(session_b, org_b)
-        initial_b = PilotReadinessService(session=session_b, organization_id=org_b).evaluate()
+        initial_b = PilotReadinessService(
+            session=session_b,
+            organization_id=org_b,
+            organization_name=f"P1F Pilot Org B {suffix}",
+        ).evaluate()
         assert initial_b.state == PILOT_NOT_STARTED
         assert initial_b.completed_steps == 1
         assert initial_b.counts["lotes"] == 0
@@ -285,7 +289,11 @@ def test_p1f_readiness_tracks_real_tenant_progress_and_isolation(monkeypatch) ->
     session_a = RuntimeSession()
     try:
         set_tenant_db_context(session_a, org_a)
-        ready_a = PilotReadinessService(session=session_a, organization_id=org_a).evaluate()
+        ready_a = PilotReadinessService(
+            session=session_a,
+            organization_id=org_a,
+            organization_name=f"P1F Pilot Org A {suffix}",
+        ).evaluate()
         assert ready_a.state == PILOT_READY
         assert ready_a.ready is True
         assert ready_a.completed_steps == ready_a.total_steps == 7
@@ -299,10 +307,72 @@ def test_p1f_readiness_tracks_real_tenant_progress_and_isolation(monkeypatch) ->
     finally:
         session_a.close()
 
+    # A newer shipment from a different receipt has no TRANSFORMATION in its
+    # own lineage. Tenant-wide activity must not be combined with that newer
+    # shipment, and the already-qualified older shipment must remain the pilot
+    # evidence instead of regressing readiness.
+    receipt_only = operations.create_receipt_draft(
+        organization_id=org_a,
+        actor=actor,
+        source_identifier=f"RODAL-P1F-{suffix}",
+        event_code=f"REC-RAW-P1F-{suffix}",
+        batch_code=f"RAW-P1F-{suffix}",
+        product_name="Madera rolliza sin transformar",
+        quantity="10",
+        unit="M3",
+        occurred_at=t0 + timedelta(hours=2),
+        facility_reference="Planta piloto Corrientes",
+    )
+    operations.post_event(
+        organization_id=org_a,
+        event_public_id=receipt_only.event_public_id,
+        actor=actor,
+    )
+    newer_shipment = operations.create_shipment_draft(
+        organization_id=org_a,
+        actor=actor,
+        shipment_code=f"EXP-RAW-P1F-{suffix}",
+        sale_reference=f"FAC-RAW-P1F-{suffix}",
+        buyer_reference="Importador UE piloto",
+        destination_country="DE",
+        items=(
+            ShipmentItemDraft(
+                batch_public_id=receipt_only.output_batch_public_ids[0],
+                quantity=Decimal("5"),
+            ),
+        ),
+    )
+    operations.dispatch_shipment(
+        organization_id=org_a,
+        shipment_public_id=newer_shipment.shipment_public_id,
+        actor=actor,
+    )
+
+    session_a = RuntimeSession()
+    try:
+        set_tenant_db_context(session_a, org_a)
+        preserved_a = PilotReadinessService(
+            session=session_a,
+            organization_id=org_a,
+            organization_name=f"P1F Pilot Org A {suffix}",
+        ).evaluate()
+        assert preserved_a.state == PILOT_READY
+        assert preserved_a.ready is True
+        assert preserved_a.shipment_code == shipment.shipment_code
+        assert preserved_a.shipment_code != newer_shipment.shipment_code
+        assert preserved_a.counts["posted_transformations"] == 1
+        assert preserved_a.counts["dispatched_shipments"] == 2
+    finally:
+        session_a.close()
+
     session_b = RuntimeSession()
     try:
         set_tenant_db_context(session_b, org_b)
-        unchanged_b = PilotReadinessService(session=session_b, organization_id=org_b).evaluate()
+        unchanged_b = PilotReadinessService(
+            session=session_b,
+            organization_id=org_b,
+            organization_name=f"P1F Pilot Org B {suffix}",
+        ).evaluate()
         assert unchanged_b.state == PILOT_NOT_STARTED
         assert unchanged_b.completed_steps == 1
         assert unchanged_b.counts["lotes"] == 0

--- a/tests/test_p1f_pilot_readiness_surface_unittest.py
+++ b/tests/test_p1f_pilot_readiness_surface_unittest.py
@@ -1,0 +1,38 @@
+from pathlib import Path
+from types import SimpleNamespace
+
+from litoral_trace.api.pilot_readiness import router as pilot_api_router
+from litoral_trace.web.navigation import build_navigation
+from litoral_trace.web.pilot_readiness import router as pilot_web_router
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_p1f_navigation_and_routes_are_read_only_and_discoverable() -> None:
+    admin = SimpleNamespace(role="admin")
+    navigation = build_navigation(admin, current_path="/pilot-readiness")
+    pilot_items = [item for item in navigation if item.key == "pilot_readiness"]
+    assert len(pilot_items) == 1
+    assert pilot_items[0].label == "Preparar piloto"
+    assert pilot_items[0].href == "/pilot-readiness"
+    assert pilot_items[0].active is True
+
+    api_routes = {(method, route.path) for route in pilot_api_router.routes for method in route.methods}
+    assert api_routes == {("GET", "/api/v1/pilot-readiness")}
+
+    web_routes = {(method, route.path) for route in pilot_web_router.routes for method in route.methods}
+    assert web_routes == {("GET", "/pilot-readiness")}
+
+
+def test_p1f_surface_does_not_block_pilot_on_acceptance_or_enable_live() -> None:
+    api_source = (ROOT / "src/litoral_trace/api/pilot_readiness.py").read_text(encoding="utf-8")
+    template = (ROOT / "src/litoral_trace/templates/pilot_readiness.html").read_text(encoding="utf-8")
+    service = (ROOT / "src/litoral_trace/services/pilot_readiness.py").read_text(encoding="utf-8")
+
+    assert '"acceptance_smoke_required_for_pilot": False' in api_source
+    assert '"live_eudr_enabled": False' in api_source
+    assert "El smoke remoto de ACCEPTANCE no bloquea este piloto" in template
+    assert "PILOT_READY" in service
+    assert "EudrAcceptance" not in service
+    assert "eudr_acceptance_attempts" not in service

--- a/tests/test_p1f_pilot_readiness_surface_unittest.py
+++ b/tests/test_p1f_pilot_readiness_surface_unittest.py
@@ -36,3 +36,15 @@ def test_p1f_surface_does_not_block_pilot_on_acceptance_or_enable_live() -> None
     assert "PILOT_READY" in service
     assert "EudrAcceptance" not in service
     assert "eudr_acceptance_attempts" not in service
+
+
+def test_p1f_reuses_authenticated_tenant_and_real_shipment_lineage() -> None:
+    service = (ROOT / "src/litoral_trace/services/pilot_readiness.py").read_text(encoding="utf-8")
+
+    # P1-F must not require direct runtime reads of platform control-plane
+    # organization/user/license records that authentication already validated.
+    assert "Organization," not in service
+    assert "User," not in service
+    assert "License," not in service
+    assert "TraceabilityLineageService" in service
+    assert "projection.qualifies" in service


### PR DESCRIPTION
Closes #118 after acceptance.

Adds a deterministic, read-only Pilot Readiness layer for the first paid customer without adding a new DB revision or duplicating existing modules.

Scope:
- computed `NOT_STARTED` / `IN_PROGRESS` / `PILOT_READY` from tenant source-of-truth data
- seven real milestones: authenticated tenant access, origin lot, Vault evidence, posted receipt, posted transformation, dispatched international shipment, export/phytosanitary/EUDR release readiness
- once a shipment exists, origin/receipt/transformation must belong to that shipment's real reverse lineage; unrelated tenant activity cannot manufacture readiness
- preserves `PILOT_READY` when an older qualifying shipment exists even if a newer incomplete shipment is later dispatched
- `/api/v1/pilot-readiness` read-only API
- `/pilot-readiness` browser workspace + navigation entry
- explicit rule: remote EUDR ACCEPTANCE smoke does not block the commercial pilot; LIVE remains disabled
- 30-day commercial pilot runbook
- dedicated PostgreSQL tenant-isolation gate pinned to Alembic 026

No migration 027. #104 remains externally waiting for authorized ACCEPTANCE onboarding and #67 remains untouched until the first paying customer.