### PR TITLE
Pre-pilot hardening — session, evidence context, dates and business language

### DIFF
--- a/src/litoral_trace/auth/sessions.py
+++ b/src/litoral_trace/auth/sessions.py
@@ -237,10 +237,15 @@ def rotate_refresh_session(
         raise SessionSecurityError("Refresh token invalido o expirado.")
 
     set_tenant_db_context(db_session, session_lookup.organization_id)
+    # The bootstrap SECURITY DEFINER function already serializes PostgreSQL
+    # consumers with FOR UPDATE before tenant context exists. Lock the same
+    # parent again under the tenant-scoped ORM path as defense in depth so the
+    # reuse/rotation invariant remains explicit even if bootstrap internals
+    # change later.
     current_session = _get_session_by_id(
         db_session,
         session_id=session_lookup.id,
-        for_update=False,
+        for_update=True,
     )
     if current_session is None:
         raise SessionSecurityError("Refresh token invalido o expirado.")

--- a/src/litoral_trace/auth/sessions.py
+++ b/src/litoral_trace/auth/sessions.py
@@ -318,7 +318,15 @@ def revoke_session(
     session_id: int | None = None,
     now: datetime | None = None,
 ) -> UserSession | None:
-    revoked_at = now or utc_now()
+    """Revoca una sesión y toda su familia de rotación.
+
+    Una familia representa un único linaje de login/refresh. Revocarla completa
+    garantiza que un logout explícito prevalezca incluso si una renovación
+    keepalive concurrente ya creó un sucesor antes de que el logout obtenga el
+    lock de la sesión padre.
+    """
+
+    revoked_at = ensure_utc_datetime(now or utc_now())
     session_record: UserSession | None = None
 
     if refresh_token:
@@ -328,10 +336,13 @@ def revoke_session(
         )
         if session_lookup is not None:
             set_tenant_db_context(db_session, session_lookup.organization_id)
+            # The bootstrap lookup already takes FOR UPDATE on PostgreSQL. Lock
+            # again through the tenant-scoped path for the same explicit
+            # serialization invariant used by refresh rotation.
             session_record = _get_session_by_id(
                 db_session,
                 session_id=session_lookup.id,
-                for_update=False,
+                for_update=True,
             )
     elif session_id is not None:
         session_record = _get_session_by_id(
@@ -343,8 +354,12 @@ def revoke_session(
     if session_record is None:
         return None
 
-    if session_record.revoked_at is None:
-        session_record.revoked_at = revoked_at
-        db_session.flush()
+    _revoke_family(
+        db_session,
+        family_id=session_record.family_id,
+        organization_id=session_record.organization_id,
+        revoked_at=revoked_at,
+    )
+    db_session.flush()
 
     return session_record

--- a/src/litoral_trace/auth/sessions.py
+++ b/src/litoral_trace/auth/sessions.py
@@ -7,7 +7,8 @@ from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 from uuid import uuid4
 
-from sqlalchemy import Select, select
+from sqlalchemy import Select, select, text
+from sqlalchemy.engine import Connection, Engine
 from sqlalchemy.orm import Session
 
 from litoral_trace.config import get_settings
@@ -86,6 +87,114 @@ def sanitize_user_agent(user_agent: str | None) -> str | None:
 def _supports_row_locking(db_session: Session) -> bool:
     bind = db_session.get_bind()
     return bind is not None and bind.dialect.name == "postgresql"
+
+
+def _engine_from_session(db_session: Session) -> Engine | None:
+    bind = db_session.get_bind()
+    if isinstance(bind, Engine):
+        return bind
+    if isinstance(bind, Connection):
+        return bind.engine
+    return None
+
+
+def _lookup_session_bootstrap_without_retained_row_lock(
+    db_session: Session,
+    *,
+    token_hash: str,
+):
+    """Resolve pre-tenant session identity without retaining its bootstrap row lock.
+
+    The legacy SECURITY DEFINER bootstrap function intentionally uses
+    ``FOR UPDATE``. For family-level serialization we must not carry that row
+    lock into the transaction that will acquire the family advisory lock,
+    otherwise logout on an ancestor and refresh on a descendant can deadlock by
+    taking row/family locks in opposite orders.
+
+    PostgreSQL therefore performs the bootstrap lookup in a short independent
+    transaction. Closing that transaction releases its bootstrap row lock before
+    the caller establishes tenant context and acquires the shared family lock.
+    SQLite/non-locking test paths keep the original in-session lookup.
+    """
+
+    if not _supports_row_locking(db_session):
+        return lookup_session_bootstrap_by_token_hash(
+            db_session,
+            token_hash=token_hash,
+        )
+
+    engine = _engine_from_session(db_session)
+    if engine is None:
+        raise SessionSecurityError("Refresh token invalido o expirado.")
+
+    with Session(bind=engine) as bootstrap_session:
+        session_lookup = lookup_session_bootstrap_by_token_hash(
+            bootstrap_session,
+            token_hash=token_hash,
+        )
+        # The lookup is read-only. Rollback is deliberate: it releases the
+        # SECURITY DEFINER FOR UPDATE lock without persisting any state.
+        bootstrap_session.rollback()
+        return session_lookup
+
+
+def _family_advisory_lock_key(*, organization_id: int, family_id: str) -> int:
+    material = f"litoral-trace:user-session-family:{organization_id}:{family_id}"
+    digest = hashlib.sha256(material.encode("utf-8")).digest()
+    return int.from_bytes(digest[:8], byteorder="big", signed=True)
+
+
+def _acquire_refresh_family_lock(
+    db_session: Session,
+    *,
+    organization_id: int,
+    family_id: str,
+) -> None:
+    """Serialize every refresh/logout mutation for one session family.
+
+    PostgreSQL transaction advisory locks are independent of which generation
+    (ancestor/descendant) the caller currently holds. This gives rotation and
+    logout one stable mutex for the entire login lineage and avoids the distinct
+    row-lock race identified during pre-pilot review.
+    """
+
+    normalized_family_id = str(family_id).strip()
+    if organization_id <= 0 or not normalized_family_id:
+        raise SessionSecurityError("Refresh token invalido o expirado.")
+
+    if not _supports_row_locking(db_session):
+        return
+
+    db_session.execute(
+        text("SELECT pg_advisory_xact_lock(:family_lock_key)"),
+        {
+            "family_lock_key": _family_advisory_lock_key(
+                organization_id=organization_id,
+                family_id=normalized_family_id,
+            )
+        },
+    )
+
+
+def _get_session_family_reference(
+    db_session: Session,
+    *,
+    session_id: int,
+) -> tuple[str, int] | None:
+    row = db_session.execute(
+        select(
+            UserSession.family_id,
+            UserSession.organization_id,
+        ).where(UserSession.id == session_id)
+    ).one_or_none()
+    if row is None:
+        return None
+
+    family_id = str(row.family_id).strip()
+    organization_id = int(row.organization_id)
+    if not family_id or organization_id <= 0:
+        return None
+    return family_id, organization_id
 
 
 def _build_session_lookup_statement(token_hash: str) -> Select[tuple[UserSession]]:
@@ -228,26 +337,47 @@ def rotate_refresh_session(
     now: datetime | None = None,
 ) -> RotatedSession:
     rotation_time = ensure_utc_datetime(now or utc_now())
-    session_lookup = lookup_session_bootstrap_by_token_hash(
+    token_hash = hash_refresh_token(refresh_token)
+    session_lookup = _lookup_session_bootstrap_without_retained_row_lock(
         db_session,
-        token_hash=hash_refresh_token(refresh_token),
+        token_hash=token_hash,
     )
 
     if session_lookup is None:
         raise SessionSecurityError("Refresh token invalido o expirado.")
 
     set_tenant_db_context(db_session, session_lookup.organization_id)
-    # The bootstrap SECURITY DEFINER function already serializes PostgreSQL
-    # consumers with FOR UPDATE before tenant context exists. Lock the same
-    # parent again under the tenant-scoped ORM path as defense in depth so the
-    # reuse/rotation invariant remains explicit even if bootstrap internals
-    # change later.
+    family_reference = _get_session_family_reference(
+        db_session,
+        session_id=session_lookup.id,
+    )
+    if family_reference is None:
+        raise SessionSecurityError("Refresh token invalido o expirado.")
+
+    family_id, family_organization_id = family_reference
+    if family_organization_id != session_lookup.organization_id:
+        raise SessionSecurityError("Refresh token invalido o expirado.")
+
+    # Family lock must precede every tenant-scoped row lock. Logout can target an
+    # ancestor while refresh targets a descendant, so a generation-specific row
+    # lock is not a sufficient mutex for the login lineage.
+    _acquire_refresh_family_lock(
+        db_session,
+        organization_id=family_organization_id,
+        family_id=family_id,
+    )
     current_session = _get_session_by_id(
         db_session,
         session_id=session_lookup.id,
         for_update=True,
     )
     if current_session is None:
+        raise SessionSecurityError("Refresh token invalido o expirado.")
+    if (
+        current_session.organization_id != family_organization_id
+        or current_session.family_id != family_id
+        or current_session.token_hash != token_hash
+    ):
         raise SessionSecurityError("Refresh token invalido o expirado.")
 
     if current_session.revoked_at is not None:
@@ -320,44 +450,68 @@ def revoke_session(
 ) -> UserSession | None:
     """Revoca una sesión y toda su familia de rotación.
 
-    Una familia representa un único linaje de login/refresh. Revocarla completa
-    garantiza que un logout explícito prevalezca incluso si una renovación
-    keepalive concurrente ya creó un sucesor antes de que el logout obtenga el
-    lock de la sesión padre.
+    Rotación y logout comparten el mismo advisory lock de familia antes de tomar
+    locks de filas. Por eso un logout dirigido a cualquier ancestro puede esperar
+    una rotación concurrente y luego revocar también su sucesor, o bien ganar
+    primero e impedir que la rotación cree un sucesor válido.
     """
 
     revoked_at = ensure_utc_datetime(now or utc_now())
-    session_record: UserSession | None = None
+    target_session_id: int | None = None
+    expected_organization_id: int | None = None
 
     if refresh_token:
-        session_lookup = lookup_session_bootstrap_by_token_hash(
+        token_hash = hash_refresh_token(refresh_token)
+        session_lookup = _lookup_session_bootstrap_without_retained_row_lock(
             db_session,
-            token_hash=hash_refresh_token(refresh_token),
+            token_hash=token_hash,
         )
-        if session_lookup is not None:
-            set_tenant_db_context(db_session, session_lookup.organization_id)
-            # The bootstrap lookup already takes FOR UPDATE on PostgreSQL. Lock
-            # again through the tenant-scoped path for the same explicit
-            # serialization invariant used by refresh rotation.
-            session_record = _get_session_by_id(
-                db_session,
-                session_id=session_lookup.id,
-                for_update=True,
-            )
+        if session_lookup is None:
+            return None
+        set_tenant_db_context(db_session, session_lookup.organization_id)
+        target_session_id = session_lookup.id
+        expected_organization_id = session_lookup.organization_id
     elif session_id is not None:
-        session_record = _get_session_by_id(
-            db_session,
-            session_id=session_id,
-            for_update=True,
-        )
+        target_session_id = session_id
+    else:
+        return None
 
+    family_reference = _get_session_family_reference(
+        db_session,
+        session_id=target_session_id,
+    )
+    if family_reference is None:
+        return None
+
+    family_id, family_organization_id = family_reference
+    if (
+        expected_organization_id is not None
+        and family_organization_id != expected_organization_id
+    ):
+        raise SessionSecurityError("Refresh token invalido o expirado.")
+
+    _acquire_refresh_family_lock(
+        db_session,
+        organization_id=family_organization_id,
+        family_id=family_id,
+    )
+    session_record = _get_session_by_id(
+        db_session,
+        session_id=target_session_id,
+        for_update=True,
+    )
     if session_record is None:
         return None
+    if (
+        session_record.organization_id != family_organization_id
+        or session_record.family_id != family_id
+    ):
+        raise SessionSecurityError("Refresh token invalido o expirado.")
 
     _revoke_family(
         db_session,
-        family_id=session_record.family_id,
-        organization_id=session_record.organization_id,
+        family_id=family_id,
+        organization_id=family_organization_id,
         revoked_at=revoked_at,
     )
     db_session.flush()

--- a/src/litoral_trace/static/src/js/business-language.js
+++ b/src/litoral_trace/static/src/js/business-language.js
@@ -54,11 +54,38 @@ const ORDERED_LABELS = Array.from(PRESENTATION_LABELS.entries())
   .sort((left, right) => right[0].length - left[0].length);
 
 function presentText(rawText) {
-  let rendered = rawText;
-  ORDERED_LABELS.forEach(([technical, business]) => {
-    rendered = rendered.replaceAll(technical, business);
-  });
-  return rendered;
+  const original = String(rawText ?? "");
+  const trimmed = original.trim();
+
+  if (!trimmed) {
+    return original;
+  }
+
+  // Exact badges/options are safe to translate because there is no business
+  // identifier around the token. Preserve whitespace emitted by the template.
+  const exact = PRESENTATION_LABELS.get(trimmed);
+  if (exact) {
+    const start = original.indexOf(trimmed);
+    return `${original.slice(0, start)}${exact}${original.slice(start + trimmed.length)}`;
+  }
+
+  // Technical source keys in checklists are rendered as a terminal segment,
+  // usually "Fuente legible · RISK_CONCLUSION". Translate only that terminal
+  // segment. Never replace substrings inside filenames, shipment codes, notes,
+  // hashes or other audit-relevant user/business data.
+  for (const [technical, business] of ORDERED_LABELS) {
+    const suffixes = [` · ${technical}`, `: ${technical}`];
+    for (const suffix of suffixes) {
+      if (trimmed.endsWith(suffix)) {
+        const technicalStart = original.lastIndexOf(technical);
+        if (technicalStart >= 0) {
+          return `${original.slice(0, technicalStart)}${business}${original.slice(technicalStart + technical.length)}`;
+        }
+      }
+    }
+  }
+
+  return original;
 }
 
 function translateTextNodes(root = document.body) {

--- a/src/litoral_trace/static/src/js/business-language.js
+++ b/src/litoral_trace/static/src/js/business-language.js
@@ -1,0 +1,106 @@
+const PRESENTATION_LABELS = new Map([
+  ["CONFORMANCE_READY", "Preparado para conformidad"],
+  ["NON_NEGLIGIBLE_RISK", "Riesgo no despreciable"],
+  ["NO_OR_NEGLIGIBLE_RISK", "Riesgo nulo o despreciable"],
+  ["UNASSESSED", "Sin evaluar"],
+  ["DISPATCHED", "Despachado"],
+  ["POSTED", "Contabilizado"],
+  ["ATTENTION", "Requiere atención"],
+  ["BLOCKED", "Bloqueado"],
+  ["READY", "Listo"],
+  ["DRAFT", "Borrador"],
+  ["IMPORT", "Importación"],
+  ["DOMESTIC", "Mercado interno"],
+  ["EXPORT", "Exportación"],
+  ["DDS_CANDIDATE", "Candidato DDS"],
+  ["LINEAGE_COMPLETE", "Genealogía completa"],
+  ["SOURCE_PLOTS", "Parcelas de origen"],
+  ["ALL_PLOTS_GEOLOCATED", "Parcelas geolocalizadas"],
+  ["SHIPMENT_DESTINATION", "País de destino"],
+  ["OPERATOR_NAME", "Nombre del operador"],
+  ["OPERATOR_ADDRESS", "Domicilio del operador"],
+  ["OPERATOR_COUNTRY", "País del operador"],
+  ["OPERATOR_EORI", "EORI del operador"],
+  ["HS_CODE", "Código HS/CN"],
+  ["TRADE_NAME", "Nombre comercial"],
+  ["PRODUCT_DESCRIPTION", "Descripción del producto"],
+  ["NET_MASS_KG", "Masa neta"],
+  ["PRODUCTION_COUNTRY", "País de producción"],
+  ["PRODUCTION_DATES", "Fechas de producción"],
+  ["WOOD_COMMON_SPECIES", "Especie común"],
+  ["WOOD_SCIENTIFIC_SPECIES", "Especie científica"],
+  ["PREVIOUS_DDS_REFERENCE", "Referencia DDS previa"],
+  ["PREVIOUS_DDS_VERIFICATION", "Verificación DDS previa"],
+  ["RISK_CONCLUSION", "Conclusión de riesgo"],
+  ["RISK_ASSESSMENT_REFERENCE", "Referencia de evaluación de riesgo"],
+  ["RISK_ASSESSED_AT", "Fecha de evaluación de riesgo"],
+  ["SPEC_PROFILE_CURRENT", "Perfil técnico vigente"],
+  ["REQUIREMENTS_REFERENCE", "Referencia oficial de requisitos"],
+  ["REQUIREMENTS_CHECKED_AT", "Fecha de evaluación de requisitos"],
+  ["CERT_POV_REFERENCE", "Referencia CERT-POV"],
+  ["PHYTOSANITARY_CERTIFICATE_NUMBER", "Número de certificado fitosanitario"],
+  ["PHYTOSANITARY_CERTIFICATE_EVIDENCE", "Certificado fitosanitario en evidencias"],
+  ["CULTIVATED_INVOICE_OR_REMITO", "Factura o remito del traslado"],
+  ["FRUIT_GUIDE", "Guía de Frutos"],
+  ["EXPORT_INVOICE_E", "Factura E de exportación"],
+  ["SIM_DESTINATION", "Destinación aduanera SIM"],
+  ["SIM_SUBREGIME", "Subrégimen SIM"],
+  ["RECEIPT", "Recepción"],
+  ["TRANSFORMATION", "Transformación"],
+]);
+
+const SKIP_TAGS = new Set(["SCRIPT", "STYLE", "TEXTAREA", "PRE", "CODE"]);
+const ORDERED_LABELS = Array.from(PRESENTATION_LABELS.entries())
+  .sort((left, right) => right[0].length - left[0].length);
+
+function presentText(rawText) {
+  let rendered = rawText;
+  ORDERED_LABELS.forEach(([technical, business]) => {
+    rendered = rendered.replaceAll(technical, business);
+  });
+  return rendered;
+}
+
+function translateTextNodes(root = document.body) {
+  if (!root) {
+    return;
+  }
+
+  const walker = document.createTreeWalker(root, NodeFilter.SHOW_TEXT);
+  const nodes = [];
+  while (walker.nextNode()) {
+    nodes.push(walker.currentNode);
+  }
+
+  nodes.forEach((node) => {
+    const parent = node.parentElement;
+    if (!parent || SKIP_TAGS.has(parent.tagName) || parent.closest("[data-technical-code]")) {
+      return;
+    }
+
+    const current = node.nodeValue || "";
+    const translated = presentText(current);
+    if (translated !== current) {
+      node.nodeValue = translated;
+    }
+  });
+}
+
+function installBusinessLanguage() {
+  translateTextNodes();
+
+  // HTMX can replace fragments after the first render. Translate only the
+  // incoming fragment; data attributes, form values and backend enums remain
+  // unchanged and therefore safe for application logic.
+  document.body?.addEventListener("htmx:afterSwap", (event) => {
+    translateTextNodes(event.detail?.target || document.body);
+  });
+}
+
+if (document.readyState === "loading") {
+  document.addEventListener("DOMContentLoaded", installBusinessLanguage, {once: true});
+} else {
+  installBusinessLanguage();
+}
+
+export {PRESENTATION_LABELS, presentText};

--- a/src/litoral_trace/static/src/js/business-language.js
+++ b/src/litoral_trace/static/src/js/business-language.js
@@ -12,7 +12,7 @@ const PRESENTATION_LABELS = new Map([
   ["IMPORT", "Importación"],
   ["DOMESTIC", "Mercado interno"],
   ["EXPORT", "Exportación"],
-  ["DDS_CANDIDATE", "Candidato DDS"],
+  ["DDS_CANDIDATE", "Candidato DDS configurado"],
   ["LINEAGE_COMPLETE", "Genealogía completa"],
   ["SOURCE_PLOTS", "Parcelas de origen"],
   ["ALL_PLOTS_GEOLOCATED", "Parcelas geolocalizadas"],
@@ -52,40 +52,54 @@ const PRESENTATION_LABELS = new Map([
 const SKIP_TAGS = new Set(["SCRIPT", "STYLE", "TEXTAREA", "PRE", "CODE"]);
 const ORDERED_LABELS = Array.from(PRESENTATION_LABELS.entries())
   .sort((left, right) => right[0].length - left[0].length);
+const TERMINAL_SEPARATORS = [" · ", ": "];
 
-function presentText(rawText) {
-  const original = String(rawText ?? "");
-  const trimmed = original.trim();
+function translateIsolatedToken(rawText, technical, business) {
+  const leadingLength = rawText.length - rawText.trimStart().length;
+  const trailingLength = rawText.length - rawText.trimEnd().length;
+  const leading = rawText.slice(0, leadingLength);
+  const trailing = trailingLength ? rawText.slice(rawText.length - trailingLength) : "";
+  const trimmed = rawText.trim();
 
-  if (!trimmed) {
-    return original;
+  if (trimmed === technical) {
+    return `${leading}${business}${trailing}`;
   }
 
-  // Exact badges/options are safe to translate because there is no business
-  // identifier around the token. Preserve whitespace emitted by the template.
-  const exact = PRESENTATION_LABELS.get(trimmed);
-  if (exact) {
-    const start = original.indexOf(trimmed);
-    return `${original.slice(0, start)}${exact}${original.slice(start + trimmed.length)}`;
-  }
-
-  // Technical source keys in checklists are rendered as a terminal segment,
-  // usually "Fuente legible · RISK_CONCLUSION". Translate only that terminal
-  // segment. Never replace substrings inside filenames, shipment codes, notes,
-  // hashes or other audit-relevant user/business data.
-  for (const [technical, business] of ORDERED_LABELS) {
-    const suffixes = [` · ${technical}`, `: ${technical}`];
-    for (const suffix of suffixes) {
-      if (trimmed.endsWith(suffix)) {
-        const technicalStart = original.lastIndexOf(technical);
-        if (technicalStart >= 0) {
-          return `${original.slice(0, technicalStart)}${business}${original.slice(technicalStart + technical.length)}`;
-        }
-      }
+  for (const separator of TERMINAL_SEPARATORS) {
+    const suffix = `${separator}${technical}`;
+    if (trimmed.endsWith(suffix)) {
+      const prefix = trimmed.slice(0, -technical.length);
+      return `${leading}${prefix}${business}${trailing}`;
     }
   }
 
-  return original;
+  return rawText;
+}
+
+function presentText(rawText) {
+  const trimmed = String(rawText || "").trim();
+  if (!trimmed) {
+    return rawText;
+  }
+
+  const direct = PRESENTATION_LABELS.get(trimmed);
+  if (direct) {
+    const leadingLength = rawText.length - rawText.trimStart().length;
+    const trailingLength = rawText.length - rawText.trimEnd().length;
+    const leading = rawText.slice(0, leadingLength);
+    const trailing = trailingLength ? rawText.slice(rawText.length - trailingLength) : "";
+    return `${leading}${direct}${trailing}`;
+  }
+
+  let rendered = rawText;
+  for (const [technical, business] of ORDERED_LABELS) {
+    const translated = translateIsolatedToken(rendered, technical, business);
+    if (translated !== rendered) {
+      rendered = translated;
+      break;
+    }
+  }
+  return rendered;
 }
 
 function translateTextNodes(root = document.body) {

--- a/src/litoral_trace/static/src/js/datetime-local.js
+++ b/src/litoral_trace/static/src/js/datetime-local.js
@@ -1,0 +1,42 @@
+function normalizeDatetimeLocal(rawValue) {
+  const raw = String(rawValue || "").trim();
+  if (!raw) {
+    return "";
+  }
+
+  // PostgreSQL timestamptz values may render as ISO-8601 with Z/offset, while
+  // HTML datetime-local accepts no timezone designator. Preserve the recorded
+  // wall-clock fields instead of silently shifting timezones in the browser.
+  const match = raw.match(/^(\d{4}-\d{2}-\d{2}T\d{2}:\d{2})/);
+  return match ? match[1] : raw;
+}
+
+function rehydrateDatetimeLocalInputs() {
+  document.querySelectorAll('input[type="datetime-local"]').forEach((input) => {
+    if (input.value) {
+      return;
+    }
+
+    const rawValue = input.getAttribute("value");
+    const normalized = normalizeDatetimeLocal(rawValue);
+    if (!normalized || normalized === rawValue) {
+      return;
+    }
+
+    try {
+      input.value = normalized;
+      input.setAttribute("value", normalized);
+    } catch (_error) {
+      // Fail closed visually: never invent a replacement if the browser still
+      // rejects the persisted value.
+    }
+  });
+}
+
+if (document.readyState === "loading") {
+  document.addEventListener("DOMContentLoaded", rehydrateDatetimeLocalInputs, {once: true});
+} else {
+  rehydrateDatetimeLocalInputs();
+}
+
+export {normalizeDatetimeLocal};

--- a/src/litoral_trace/static/src/js/evidence-context.js
+++ b/src/litoral_trace/static/src/js/evidence-context.js
@@ -73,22 +73,49 @@ function findShipmentSubject(selector, shipmentCode) {
   return option?.value || "";
 }
 
+function selectorContainsSubject(selector, subject) {
+  const normalized = String(subject || "").trim();
+  if (!normalized) {
+    return false;
+  }
+  return Array.from(selector.options).some(
+    (option) => option.value === normalized,
+  );
+}
+
+function requireExplicitSelection(selector) {
+  if (!selector.querySelector('option[data-evidence-placeholder="true"]')) {
+    const placeholder = document.createElement("option");
+    placeholder.value = "";
+    placeholder.textContent = "Confirmá un eslabón antes de continuar";
+    placeholder.disabled = true;
+    placeholder.selected = true;
+    placeholder.dataset.evidencePlaceholder = "true";
+    selector.insertBefore(placeholder, selector.firstChild);
+  }
+  selector.value = "";
+}
+
 function disableMutationFormsUntilSubjectConfirmed(selector) {
-  const guard = document.createElement("div");
-  guard.dataset.evidenceContextGuard = "true";
-  guard.setAttribute("role", "status");
-  guard.style.cssText = [
-    "margin-top:0.75rem",
-    "border:1px solid #fcd34d",
-    "border-radius:0.5rem",
-    "background:#fffbeb",
-    "padding:0.75rem",
-    "font-size:0.75rem",
-    "line-height:1.25rem",
-    "color:#78350f",
-  ].join(";");
-  guard.innerHTML = "<strong>Confirmá el eslabón antes de vincular.</strong> La pantalla no reutiliza silenciosamente el primer origen después de un reingreso. Elegí el origen, movimiento, lote o despacho que el documento respalda.";
-  selector.closest("form")?.appendChild(guard);
+  requireExplicitSelection(selector);
+
+  if (!document.querySelector("[data-evidence-context-guard]")) {
+    const guard = document.createElement("div");
+    guard.dataset.evidenceContextGuard = "true";
+    guard.setAttribute("role", "status");
+    guard.style.cssText = [
+      "margin-top:0.75rem",
+      "border:1px solid #fcd34d",
+      "border-radius:0.5rem",
+      "background:#fffbeb",
+      "padding:0.75rem",
+      "font-size:0.75rem",
+      "line-height:1.25rem",
+      "color:#78350f",
+    ].join(";");
+    guard.innerHTML = "<strong>Confirmá el eslabón antes de vincular.</strong> La pantalla no reutiliza silenciosamente el primer origen después de un reingreso. Elegí el origen, movimiento, lote o despacho que el documento respalda.";
+    selector.closest("form")?.appendChild(guard);
+  }
 
   document.querySelectorAll(
     'form[action="/evidence/link"], form[action="/evidence/upload-link"]',
@@ -109,12 +136,24 @@ function resolveOrGuardEvidenceSubject() {
   }
 
   const params = new URLSearchParams(window.location.search);
-  if (params.has(SUBJECT_PARAM)) {
+  const selector = document.querySelector("#subject-select");
+  if (!selector) {
     return;
   }
 
-  const selector = document.querySelector("#subject-select");
-  if (!selector) {
+  const explicitSubject = (params.get(SUBJECT_PARAM) || "").trim();
+  if (explicitSubject) {
+    if (selectorContainsSubject(selector, explicitSubject)) {
+      return;
+    }
+
+    // A stale, malformed or cross-context key must never make the server's
+    // fallback first option look confirmed. Remove it immediately and reload a
+    // neutral evidence workspace before any mutation can be intentionally used.
+    params.delete(SUBJECT_PARAM);
+    params.delete(SHIPMENT_PARAM);
+    const cleanQuery = params.toString();
+    window.location.replace(cleanQuery ? `${EVIDENCE_PATH}?${cleanQuery}` : EVIDENCE_PATH);
     return;
   }
 

--- a/src/litoral_trace/static/src/js/evidence-context.js
+++ b/src/litoral_trace/static/src/js/evidence-context.js
@@ -2,11 +2,6 @@ const EVIDENCE_PATH = "/evidence";
 const SHIPMENT_PARAM = "shipment_code";
 const SUBJECT_PARAM = "subject";
 
-function shipmentSubject(code) {
-  const normalized = String(code || "").trim();
-  return normalized ? `SHIPMENT|${normalized}` : "";
-}
-
 function currentShipmentCode() {
   const params = new URLSearchParams(window.location.search);
   return (params.get(SHIPMENT_PARAM) || "").trim();
@@ -18,7 +13,6 @@ function preserveShipmentOnEvidenceLinks() {
     return;
   }
 
-  const subject = shipmentSubject(code);
   document.querySelectorAll('a[href]').forEach((anchor) => {
     let target;
     try {
@@ -31,16 +25,21 @@ function preserveShipmentOnEvidenceLinks() {
       target.origin !== window.location.origin
       || target.pathname !== EVIDENCE_PATH
       || target.searchParams.has(SUBJECT_PARAM)
+      || target.searchParams.has(SHIPMENT_PARAM)
     ) {
       return;
     }
 
-    target.searchParams.set(SUBJECT_PARAM, subject);
+    // Shipment evidence subjects use the shipment public UUID internally, not
+    // the commercial shipment code. Preserve the code only as navigation
+    // context; /evidence resolves it against the tenant-scoped selector before
+    // adding an explicit subject key.
+    target.searchParams.set(SHIPMENT_PARAM, code);
     anchor.href = `${target.pathname}${target.search}${target.hash}`;
   });
 }
 
-function subjectFromSafeReferrer() {
+function shipmentCodeFromSafeReferrer() {
   if (!document.referrer) {
     return "";
   }
@@ -51,35 +50,30 @@ function subjectFromSafeReferrer() {
       return "";
     }
 
-    const code = (referrer.searchParams.get(SHIPMENT_PARAM) || "").trim();
-    return shipmentSubject(code);
+    return (referrer.searchParams.get(SHIPMENT_PARAM) || "").trim();
   } catch (_error) {
     return "";
   }
 }
 
-function addSubjectConfirmationGuard() {
-  if (window.location.pathname !== EVIDENCE_PATH) {
-    return;
+function findShipmentSubject(selector, shipmentCode) {
+  const normalizedCode = String(shipmentCode || "").trim();
+  if (!normalizedCode) {
+    return "";
   }
 
-  const params = new URLSearchParams(window.location.search);
-  if (params.has(SUBJECT_PARAM)) {
-    return;
-  }
+  const expectedPrefix = `Despacho · ${normalizedCode}`.toLocaleLowerCase("es");
+  const option = Array.from(selector.options).find((candidate) => {
+    const text = String(candidate.textContent || "").trim().toLocaleLowerCase("es");
+    return text === expectedPrefix || text.startsWith(`${expectedPrefix} ·`);
+  });
 
-  const recoveredSubject = subjectFromSafeReferrer();
-  if (recoveredSubject) {
-    params.set(SUBJECT_PARAM, recoveredSubject);
-    window.location.replace(`${EVIDENCE_PATH}?${params.toString()}`);
-    return;
-  }
+  // The value is the tenant-scoped key rendered by the server, e.g.
+  // SHIPMENT|<public UUID>. We never manufacture that UUID in the browser.
+  return option?.value || "";
+}
 
-  const selector = document.querySelector("#subject-select");
-  if (!selector) {
-    return;
-  }
-
+function disableMutationFormsUntilSubjectConfirmed(selector) {
   const guard = document.createElement("div");
   guard.dataset.evidenceContextGuard = "true";
   guard.setAttribute("role", "status");
@@ -87,11 +81,9 @@ function addSubjectConfirmationGuard() {
   guard.innerHTML = "<strong>Confirmá el eslabón antes de vincular.</strong> La pantalla no reutiliza silenciosamente el primer origen después de un reingreso. Elegí el origen, movimiento, lote o despacho que el documento respalda.";
   selector.closest("form")?.appendChild(guard);
 
-  const guardedForms = document.querySelectorAll(
+  document.querySelectorAll(
     'form[action="/evidence/link"], form[action="/evidence/upload-link"]',
-  );
-
-  guardedForms.forEach((form) => {
+  ).forEach((form) => {
     form.querySelectorAll('button[type="submit"], button:not([type])').forEach((button) => {
       button.disabled = true;
       button.setAttribute("aria-disabled", "true");
@@ -101,9 +93,40 @@ function addSubjectConfirmationGuard() {
   });
 }
 
+function resolveOrGuardEvidenceSubject() {
+  if (window.location.pathname !== EVIDENCE_PATH) {
+    return;
+  }
+
+  const params = new URLSearchParams(window.location.search);
+  if (params.has(SUBJECT_PARAM)) {
+    return;
+  }
+
+  const selector = document.querySelector("#subject-select");
+  if (!selector) {
+    return;
+  }
+
+  const shipmentCode = (
+    (params.get(SHIPMENT_PARAM) || "").trim()
+    || shipmentCodeFromSafeReferrer()
+  );
+  const resolvedSubject = findShipmentSubject(selector, shipmentCode);
+
+  if (resolvedSubject) {
+    params.delete(SHIPMENT_PARAM);
+    params.set(SUBJECT_PARAM, resolvedSubject);
+    window.location.replace(`${EVIDENCE_PATH}?${params.toString()}`);
+    return;
+  }
+
+  disableMutationFormsUntilSubjectConfirmed(selector);
+}
+
 function bootEvidenceContext() {
   preserveShipmentOnEvidenceLinks();
-  addSubjectConfirmationGuard();
+  resolveOrGuardEvidenceSubject();
 }
 
 if (document.readyState === "loading") {

--- a/src/litoral_trace/static/src/js/evidence-context.js
+++ b/src/litoral_trace/static/src/js/evidence-context.js
@@ -77,7 +77,16 @@ function disableMutationFormsUntilSubjectConfirmed(selector) {
   const guard = document.createElement("div");
   guard.dataset.evidenceContextGuard = "true";
   guard.setAttribute("role", "status");
-  guard.className = "mt-3 rounded-lg border border-amber-300 bg-amber-50 p-3 text-xs leading-5 text-amber-900";
+  guard.style.cssText = [
+    "margin-top:0.75rem",
+    "border:1px solid #fcd34d",
+    "border-radius:0.5rem",
+    "background:#fffbeb",
+    "padding:0.75rem",
+    "font-size:0.75rem",
+    "line-height:1.25rem",
+    "color:#78350f",
+  ].join(";");
   guard.innerHTML = "<strong>Confirmá el eslabón antes de vincular.</strong> La pantalla no reutiliza silenciosamente el primer origen después de un reingreso. Elegí el origen, movimiento, lote o despacho que el documento respalda.";
   selector.closest("form")?.appendChild(guard);
 
@@ -88,7 +97,8 @@ function disableMutationFormsUntilSubjectConfirmed(selector) {
       button.disabled = true;
       button.setAttribute("aria-disabled", "true");
       button.title = "Elegí y confirmá primero el eslabón de trazabilidad.";
-      button.classList.add("opacity-50", "cursor-not-allowed");
+      button.style.opacity = "0.5";
+      button.style.cursor = "not-allowed";
     });
   });
 }

--- a/src/litoral_trace/static/src/js/evidence-context.js
+++ b/src/litoral_trace/static/src/js/evidence-context.js
@@ -1,0 +1,113 @@
+const EVIDENCE_PATH = "/evidence";
+const SHIPMENT_PARAM = "shipment_code";
+const SUBJECT_PARAM = "subject";
+
+function shipmentSubject(code) {
+  const normalized = String(code || "").trim();
+  return normalized ? `SHIPMENT|${normalized}` : "";
+}
+
+function currentShipmentCode() {
+  const params = new URLSearchParams(window.location.search);
+  return (params.get(SHIPMENT_PARAM) || "").trim();
+}
+
+function preserveShipmentOnEvidenceLinks() {
+  const code = currentShipmentCode();
+  if (!code) {
+    return;
+  }
+
+  const subject = shipmentSubject(code);
+  document.querySelectorAll('a[href]').forEach((anchor) => {
+    let target;
+    try {
+      target = new URL(anchor.href, window.location.href);
+    } catch (_error) {
+      return;
+    }
+
+    if (
+      target.origin !== window.location.origin
+      || target.pathname !== EVIDENCE_PATH
+      || target.searchParams.has(SUBJECT_PARAM)
+    ) {
+      return;
+    }
+
+    target.searchParams.set(SUBJECT_PARAM, subject);
+    anchor.href = `${target.pathname}${target.search}${target.hash}`;
+  });
+}
+
+function subjectFromSafeReferrer() {
+  if (!document.referrer) {
+    return "";
+  }
+
+  try {
+    const referrer = new URL(document.referrer);
+    if (referrer.origin !== window.location.origin) {
+      return "";
+    }
+
+    const code = (referrer.searchParams.get(SHIPMENT_PARAM) || "").trim();
+    return shipmentSubject(code);
+  } catch (_error) {
+    return "";
+  }
+}
+
+function addSubjectConfirmationGuard() {
+  if (window.location.pathname !== EVIDENCE_PATH) {
+    return;
+  }
+
+  const params = new URLSearchParams(window.location.search);
+  if (params.has(SUBJECT_PARAM)) {
+    return;
+  }
+
+  const recoveredSubject = subjectFromSafeReferrer();
+  if (recoveredSubject) {
+    params.set(SUBJECT_PARAM, recoveredSubject);
+    window.location.replace(`${EVIDENCE_PATH}?${params.toString()}`);
+    return;
+  }
+
+  const selector = document.querySelector("#subject-select");
+  if (!selector) {
+    return;
+  }
+
+  const guard = document.createElement("div");
+  guard.dataset.evidenceContextGuard = "true";
+  guard.setAttribute("role", "status");
+  guard.className = "mt-3 rounded-lg border border-amber-300 bg-amber-50 p-3 text-xs leading-5 text-amber-900";
+  guard.innerHTML = "<strong>Confirmá el eslabón antes de vincular.</strong> La pantalla no reutiliza silenciosamente el primer origen después de un reingreso. Elegí el origen, movimiento, lote o despacho que el documento respalda.";
+  selector.closest("form")?.appendChild(guard);
+
+  const guardedForms = document.querySelectorAll(
+    'form[action="/evidence/link"], form[action="/evidence/upload-link"]',
+  );
+
+  guardedForms.forEach((form) => {
+    form.querySelectorAll('button[type="submit"], button:not([type])').forEach((button) => {
+      button.disabled = true;
+      button.setAttribute("aria-disabled", "true");
+      button.title = "Elegí y confirmá primero el eslabón de trazabilidad.";
+      button.classList.add("opacity-50", "cursor-not-allowed");
+    });
+  });
+}
+
+function bootEvidenceContext() {
+  preserveShipmentOnEvidenceLinks();
+  addSubjectConfirmationGuard();
+}
+
+if (document.readyState === "loading") {
+  document.addEventListener("DOMContentLoaded", bootEvidenceContext, {once: true});
+} else {
+  bootEvidenceContext();
+}

--- a/src/litoral_trace/static/src/js/session-refresh-coordination.js
+++ b/src/litoral_trace/static/src/js/session-refresh-coordination.js
@@ -1,0 +1,185 @@
+const REFRESH_URL = "/api/v1/auth/refresh";
+const ACCESS_PROBE_URL = "/api/v1/auth/me";
+const COORDINATION_COOKIE_NAME = "lt_refresh_inflight";
+const COORDINATION_MAX_AGE_SECONDS = 15;
+const COORDINATION_POLL_MS = 150;
+const ACCESS_EXPIRES_AT_META_NAME = "lt-session-access-expires-at";
+const SERVER_NOW_META_NAME = "lt-session-server-now";
+const REFRESH_AFTER_META_NAME = "lt-session-refresh-after";
+
+function cookieIsPresent(name) {
+  return document.cookie
+    .split(";")
+    .map((item) => item.trim())
+    .some((item) => item.startsWith(`${name}=`));
+}
+
+function secureCookieSuffix() {
+  return window.location.protocol === "https:" ? "; Secure" : "";
+}
+
+function markRefreshInFlight() {
+  document.cookie = [
+    `${COORDINATION_COOKIE_NAME}=1`,
+    "Path=/",
+    `Max-Age=${COORDINATION_MAX_AGE_SECONDS}`,
+    "SameSite=Strict",
+  ].join("; ") + secureCookieSuffix();
+}
+
+function clearRefreshInFlight() {
+  document.cookie = [
+    `${COORDINATION_COOKIE_NAME}=`,
+    "Path=/",
+    "Max-Age=0",
+    "SameSite=Strict",
+  ].join("; ") + secureCookieSuffix();
+}
+
+function sleep(milliseconds) {
+  return new Promise((resolve) => window.setTimeout(resolve, milliseconds));
+}
+
+async function waitForOutstandingRefresh() {
+  const maxPolls = Math.ceil(
+    (COORDINATION_MAX_AGE_SECONDS * 1000) / COORDINATION_POLL_MS,
+  ) + 2;
+
+  for (let poll = 0; poll < maxPolls; poll += 1) {
+    if (!cookieIsPresent(COORDINATION_COOKIE_NAME)) {
+      return true;
+    }
+    await sleep(COORDINATION_POLL_MS);
+  }
+
+  return !cookieIsPresent(COORDINATION_COOKIE_NAME);
+}
+
+function parseEpochSeconds(documentNode, metaName) {
+  const rawValue = documentNode
+    .querySelector(`meta[name="${metaName}"]`)
+    ?.getAttribute("content")
+    ?.trim();
+  const value = Number.parseInt(rawValue || "", 10);
+  return Number.isFinite(value) && value > 0 ? value : null;
+}
+
+async function refreshedCookieJarHasFutureRenewalWindow(rawFetch) {
+  try {
+    const accessProbe = await rawFetch(
+      ACCESS_PROBE_URL,
+      {
+        method: "GET",
+        credentials: "same-origin",
+        cache: "no-store",
+        headers: {"Accept": "application/json"},
+      },
+    );
+    if (!accessProbe.ok) {
+      return false;
+    }
+
+    const pageResponse = await rawFetch(
+      window.location.href,
+      {
+        method: "GET",
+        credentials: "same-origin",
+        cache: "no-store",
+        headers: {"Accept": "text/html"},
+      },
+    );
+    if (!pageResponse.ok) {
+      return false;
+    }
+
+    const parsed = new DOMParser().parseFromString(
+      await pageResponse.text(),
+      "text/html",
+    );
+    const expiresAt = parseEpochSeconds(parsed, ACCESS_EXPIRES_AT_META_NAME);
+    const serverNow = parseEpochSeconds(parsed, SERVER_NOW_META_NAME);
+    const refreshAfter = parseEpochSeconds(parsed, REFRESH_AFTER_META_NAME);
+
+    if (expiresAt === null || serverNow === null || refreshAfter === null) {
+      return false;
+    }
+
+    return expiresAt - serverNow - refreshAfter > 0;
+  } catch (_error) {
+    return false;
+  }
+}
+
+function isRefreshRequest(input, init = {}) {
+  const method = String(
+    init.method || (input instanceof Request ? input.method : "GET"),
+  ).toUpperCase();
+  if (method !== "POST") {
+    return false;
+  }
+
+  const rawUrl = input instanceof Request ? input.url : String(input);
+  const requestUrl = new URL(rawUrl, window.location.href);
+  return (
+    requestUrl.origin === window.location.origin
+    && requestUrl.pathname === REFRESH_URL
+  );
+}
+
+function installCrossDocumentRefreshCoordination() {
+  if (
+    typeof window.fetch !== "function"
+    || window.fetch.__litoralTraceRefreshCoordination
+  ) {
+    return;
+  }
+
+  const rawFetch = window.fetch.bind(window);
+
+  const coordinatedFetch = async (input, init = {}) => {
+    if (!isRefreshRequest(input, init)) {
+      return rawFetch(input, init);
+    }
+
+    if (cookieIsPresent(COORDINATION_COOKIE_NAME)) {
+      const leaseReleased = await waitForOutstandingRefresh();
+      if (!leaseReleased) {
+        // Never race another refresh whose document may have been destroyed.
+        // The normal session-renewal retry path will attempt again after the
+        // short coordination lease expires.
+        return new Response(null, {
+          status: 425,
+          statusText: "Refresh coordination pending",
+        });
+      }
+
+      if (await refreshedCookieJarHasFutureRenewalWindow(rawFetch)) {
+        // The previous keepalive already rotated the shared HttpOnly cookies.
+        // Return success so the caller rehydrates its CSRF/timing metadata
+        // without rotating the new refresh token again.
+        return new Response("{}", {
+          status: 200,
+          headers: {"Content-Type": "application/json"},
+        });
+      }
+    }
+
+    markRefreshInFlight();
+    try {
+      return await rawFetch(input, init);
+    } finally {
+      // If this document survives, release immediately. If navigation destroys
+      // it, the browser keeps the non-sensitive marker only until Max-Age.
+      clearRefreshInFlight();
+    }
+  };
+
+  Object.defineProperty(
+    coordinatedFetch,
+    "__litoralTraceRefreshCoordination",
+    {value: true, enumerable: false},
+  );
+  window.fetch = coordinatedFetch;
+}
+
+installCrossDocumentRefreshCoordination();

--- a/src/litoral_trace/static/src/js/session-refresh-coordination.js
+++ b/src/litoral_trace/static/src/js/session-refresh-coordination.js
@@ -1,8 +1,9 @@
 const REFRESH_URL = "/api/v1/auth/refresh";
 const ACCESS_PROBE_URL = "/api/v1/auth/me";
 const COORDINATION_COOKIE_NAME = "lt_refresh_inflight";
-const COORDINATION_MAX_AGE_SECONDS = 15;
-const COORDINATION_POLL_MS = 150;
+const COORDINATION_WAIT_SECONDS = 30;
+const COORDINATION_POLL_MS = 250;
+const COORDINATION_PROBE_EVERY_POLLS = 4;
 const ACCESS_EXPIRES_AT_META_NAME = "lt-session-access-expires-at";
 const SERVER_NOW_META_NAME = "lt-session-server-now";
 const REFRESH_AFTER_META_NAME = "lt-session-refresh-after";
@@ -19,10 +20,12 @@ function secureCookieSuffix() {
 }
 
 function markRefreshInFlight() {
+  // Session cookie on purpose: there is no wall-clock lease that can expire
+  // while an HTTP keepalive request is still active. The marker is not a
+  // credential and contains no user, tenant, token or business information.
   document.cookie = [
     `${COORDINATION_COOKIE_NAME}=1`,
     "Path=/",
-    `Max-Age=${COORDINATION_MAX_AGE_SECONDS}`,
     "SameSite=Strict",
   ].join("; ") + secureCookieSuffix();
 }
@@ -38,21 +41,6 @@ function clearRefreshInFlight() {
 
 function sleep(milliseconds) {
   return new Promise((resolve) => window.setTimeout(resolve, milliseconds));
-}
-
-async function waitForOutstandingRefresh() {
-  const maxPolls = Math.ceil(
-    (COORDINATION_MAX_AGE_SECONDS * 1000) / COORDINATION_POLL_MS,
-  ) + 2;
-
-  for (let poll = 0; poll < maxPolls; poll += 1) {
-    if (!cookieIsPresent(COORDINATION_COOKIE_NAME)) {
-      return true;
-    }
-    await sleep(COORDINATION_POLL_MS);
-  }
-
-  return !cookieIsPresent(COORDINATION_COOKIE_NAME);
 }
 
 function parseEpochSeconds(documentNode, metaName) {
@@ -110,6 +98,53 @@ async function refreshedCookieJarHasFutureRenewalWindow(rawFetch) {
   }
 }
 
+async function waitForOutstandingRefresh(rawFetch) {
+  const maxPolls = Math.ceil(
+    (COORDINATION_WAIT_SECONDS * 1000) / COORDINATION_POLL_MS,
+  );
+
+  for (let poll = 0; poll < maxPolls; poll += 1) {
+    if (!cookieIsPresent(COORDINATION_COOKIE_NAME)) {
+      return "released";
+    }
+
+    if (
+      poll % COORDINATION_PROBE_EVERY_POLLS === 0
+      && await refreshedCookieJarHasFutureRenewalWindow(rawFetch)
+    ) {
+      // The prior keepalive finished after destroying its document. The shared
+      // HttpOnly cookie jar now proves that rotation succeeded, so this
+      // successor document owns cleanup of the non-sensitive marker.
+      clearRefreshInFlight();
+      return "refreshed";
+    }
+
+    await sleep(COORDINATION_POLL_MS);
+  }
+
+  // Important: timeout only bounds how long this document waits. It does NOT
+  // expire or clear the marker and therefore can never authorize a second
+  // rotation while the first request has an unknown outcome.
+  return "ambiguous";
+}
+
+function ambiguousRefreshResponse() {
+  // Use a forbidden response so session-renewal surfaces its existing
+  // reauthentication warning. The marker remains present, so later automatic
+  // retries are intercepted again and never send the old refresh token.
+  return new Response(null, {
+    status: 403,
+    statusText: "Refresh outcome ambiguous",
+  });
+}
+
+function syntheticRefreshSuccess() {
+  return new Response("{}", {
+    status: 200,
+    headers: {"Content-Type": "application/json"},
+  });
+}
+
 function isRefreshRequest(input, init = {}) {
   const method = String(
     init.method || (input instanceof Request ? input.method : "GET"),
@@ -142,36 +177,46 @@ function installCrossDocumentRefreshCoordination() {
     }
 
     if (cookieIsPresent(COORDINATION_COOKIE_NAME)) {
-      const leaseReleased = await waitForOutstandingRefresh();
-      if (!leaseReleased) {
-        // Never race another refresh whose document may have been destroyed.
-        // The normal session-renewal retry path will attempt again after the
-        // short coordination lease expires.
-        return new Response(null, {
-          status: 425,
-          statusText: "Refresh coordination pending",
-        });
+      const outstandingState = await waitForOutstandingRefresh(rawFetch);
+
+      if (outstandingState === "refreshed") {
+        return syntheticRefreshSuccess();
+      }
+
+      if (outstandingState === "ambiguous") {
+        return ambiguousRefreshResponse();
       }
 
       if (await refreshedCookieJarHasFutureRenewalWindow(rawFetch)) {
-        // The previous keepalive already rotated the shared HttpOnly cookies.
-        // Return success so the caller rehydrates its CSRF/timing metadata
-        // without rotating the new refresh token again.
-        return new Response("{}", {
-          status: 200,
-          headers: {"Content-Type": "application/json"},
-        });
+        // A surviving document released the marker after receiving the refresh
+        // response. Revalidate the cookie jar before deciding whether another
+        // rotation is necessary.
+        return syntheticRefreshSuccess();
       }
     }
 
     markRefreshInFlight();
+
+    let response;
     try {
-      return await rawFetch(input, init);
-    } finally {
-      // If this document survives, release immediately. If navigation destroys
-      // it, the browser keeps the non-sensitive marker only until Max-Age.
-      clearRefreshInFlight();
+      response = await rawFetch(input, init);
+    } catch (_error) {
+      // Once the POST was sent, a transport failure cannot prove whether the
+      // server committed rotation and Set-Cookie was lost. Keep the marker and
+      // fail closed; never feed this outcome into the ordinary refresh retry.
+      return ambiguousRefreshResponse();
     }
+
+    if (response.status >= 500) {
+      // A gateway/server failure can also be ambiguous after the request left
+      // the browser. Keep the marker rather than risk replaying the parent token.
+      return ambiguousRefreshResponse();
+    }
+
+    // A concrete success or client-side rejection is a known outcome observed
+    // by this live document, so it can safely release the coordination marker.
+    clearRefreshInFlight();
+    return response;
   };
 
   Object.defineProperty(

--- a/src/litoral_trace/static/src/js/session-renewal.js
+++ b/src/litoral_trace/static/src/js/session-renewal.js
@@ -2,6 +2,7 @@ const CSRF_META_NAME = "csrf-token";
 const REFRESH_CSRF_META_NAME = "lt-refresh-csrf-token";
 const REFRESH_AFTER_META_NAME = "lt-session-refresh-after";
 const ACCESS_EXPIRES_AT_META_NAME = "lt-session-access-expires-at";
+const SERVER_NOW_META_NAME = "lt-session-server-now";
 const CSRF_HEADER_NAME = "X-CSRF-Token";
 const REFRESH_URL = "/api/v1/auth/refresh";
 const REFRESH_LOCK_NAME = "litoral-trace-session-refresh";
@@ -53,6 +54,9 @@ function extractSecurityMeta(htmlText) {
       ?.getAttribute("content")
       ?.trim() || "",
     accessExpiresAt: parsed.querySelector(`meta[name="${ACCESS_EXPIRES_AT_META_NAME}"]`)
+      ?.getAttribute("content")
+      ?.trim() || "",
+    serverNow: parsed.querySelector(`meta[name="${SERVER_NOW_META_NAME}"]`)
       ?.getAttribute("content")
       ?.trim() || "",
   };
@@ -161,6 +165,7 @@ async function synchronizeSecurityMeta() {
       !securityMeta.csrfToken
       || !securityMeta.refreshCsrfToken
       || !securityMeta.accessExpiresAt
+      || !securityMeta.serverNow
     ) {
       return false;
     }
@@ -168,6 +173,7 @@ async function synchronizeSecurityMeta() {
     updateRenderedCsrfToken(securityMeta.csrfToken);
     updateMeta(REFRESH_CSRF_META_NAME, securityMeta.refreshCsrfToken);
     updateMeta(ACCESS_EXPIRES_AT_META_NAME, securityMeta.accessExpiresAt);
+    updateMeta(SERVER_NOW_META_NAME, securityMeta.serverNow);
     return true;
   } catch (_error) {
     return false;
@@ -208,8 +214,8 @@ async function rotateSession() {
   }
 
   // Set-Cookie has been applied when fetch resolves. Rehydrate this tab's
-  // session-bound CSRF material and the new absolute access expiry without
-  // reloading the page or losing inputs.
+  // session-bound CSRF material and fresh server-relative timing metadata
+  // without reloading the page or losing inputs.
   const synchronized = await synchronizeSecurityMeta();
   if (!synchronized) {
     showSessionWarning("La sesión se renovó, pero la página no pudo sincronizar su protección CSRF.");
@@ -221,12 +227,14 @@ function installSessionRenewal() {
   const refreshCsrfToken = readMeta(REFRESH_CSRF_META_NAME);
   const rawInterval = Number.parseInt(readMeta(REFRESH_AFTER_META_NAME), 10);
   const initialExpiryMs = readEpochMilliseconds(ACCESS_EXPIRES_AT_META_NAME);
+  const initialServerNowMs = readEpochMilliseconds(SERVER_NOW_META_NAME);
 
   if (
     !refreshCsrfToken
     || !Number.isFinite(rawInterval)
     || rawInterval < 15
     || initialExpiryMs === null
+    || initialServerNowMs === null
   ) {
     return;
   }
@@ -247,16 +255,21 @@ function installSessionRenewal() {
   const duplicateSuppressionMs = Math.max(5000, Math.min(30000, Math.floor(intervalMs / 3)));
   const channel = new window.BroadcastChannel(REFRESH_CHANNEL_NAME);
   let renewalTimer = null;
+  let renewalDeadlineMonotonicMs = null;
   let sharedRefreshAt = 0;
   let inFlight = null;
   let peerSyncInFlight = null;
 
-  function accessRefreshDueAtMs() {
+  function serverRelativeRefreshDelayMs() {
     const expiryMs = readEpochMilliseconds(ACCESS_EXPIRES_AT_META_NAME);
-    if (expiryMs === null) {
+    const serverNowMs = readEpochMilliseconds(SERVER_NOW_META_NAME);
+    if (expiryMs === null || serverNowMs === null) {
       return null;
     }
-    return expiryMs - intervalMs;
+
+    // Both values are emitted by the server from the verified authenticated
+    // response. The workstation wall clock never participates in expiry math.
+    return Math.max(0, expiryMs - serverNowMs - intervalMs);
   }
 
   function rememberSharedRefresh(value) {
@@ -273,26 +286,26 @@ function installSessionRenewal() {
     channel.postMessage({type: "refreshed", at: timestamp});
   }
 
-  function scheduleRenewal({retry = false} = {}) {
+  function armRenewalTimer(delay) {
     if (renewalTimer !== null) {
       window.clearTimeout(renewalTimer);
-      renewalTimer = null;
     }
 
-    const dueAt = accessRefreshDueAtMs();
-    if (dueAt === null) {
-      showSessionWarning("No fue posible verificar cuándo vence la sesión actual.");
-      return;
-    }
-
-    const minimumDelay = retry ? retryDelayMs : 0;
-    const delay = Math.max(minimumDelay, dueAt - Date.now(), 0);
-
+    renewalDeadlineMonotonicMs = performance.now() + delay;
     renewalTimer = window.setTimeout(async () => {
       renewalTimer = null;
       const synchronized = await renew();
       scheduleRenewal({retry: !synchronized});
     }, delay);
+  }
+
+  function scheduleRenewal({retry = false} = {}) {
+    const delay = retry ? retryDelayMs : serverRelativeRefreshDelayMs();
+    if (delay === null) {
+      showSessionWarning("No fue posible verificar cuándo vence la sesión actual.");
+      return;
+    }
+    armRenewalTimer(delay);
   }
 
   async function synchronizeFromPeer(timestamp) {
@@ -344,7 +357,7 @@ function installSessionRenewal() {
 
     // A peer may have rotated the shared HttpOnly cookies while this tab waited
     // for the Web Lock. If so, never perform a second immediate rotation: just
-    // rehydrate this tab's session-bound CSRF and expiry metadata.
+    // rehydrate this tab's session-bound CSRF and timing metadata.
     if (sharedRefreshAt && now - sharedRefreshAt < duplicateSuppressionMs) {
       return synchronizeSecurityMeta();
     }
@@ -378,25 +391,25 @@ function installSessionRenewal() {
   }
 
   function renewIfDue() {
-    const dueAt = accessRefreshDueAtMs();
-    if (dueAt === null) {
-      showSessionWarning("No fue posible verificar cuándo vence la sesión actual.");
+    if (renewalDeadlineMonotonicMs === null) {
+      scheduleRenewal();
       return;
     }
 
-    if (Date.now() >= dueAt) {
+    if (performance.now() >= renewalDeadlineMonotonicMs) {
+      if (renewalTimer !== null) {
+        window.clearTimeout(renewalTimer);
+        renewalTimer = null;
+      }
       void renew().then((synchronized) => {
         scheduleRenewal({retry: !synchronized});
       });
-      return;
     }
-
-    scheduleRenewal();
   }
 
-  // The deadline is absolute and comes from the verified JWT expiry. A normal
-  // full-page navigation therefore cannot postpone renewal by starting a fresh
-  // interval from page-load time.
+  // The delay is based on verified JWT expiry minus server render time. A normal
+  // full-page navigation cannot postpone renewal, and workstation clock skew
+  // cannot make the client refresh too late or spin in an immediate loop.
   scheduleRenewal();
 
   document.addEventListener("visibilitychange", () => {

--- a/src/litoral_trace/static/src/js/session-renewal.js
+++ b/src/litoral_trace/static/src/js/session-renewal.js
@@ -3,6 +3,9 @@ const REFRESH_CSRF_META_NAME = "lt-refresh-csrf-token";
 const REFRESH_AFTER_META_NAME = "lt-session-refresh-after";
 const CSRF_HEADER_NAME = "X-CSRF-Token";
 const REFRESH_URL = "/api/v1/auth/refresh";
+const REFRESH_LOCK_NAME = "litoral-trace-session-refresh";
+const LAST_REFRESH_KEY = "litoral-trace:last-session-refresh-at";
+const SAFE_METHODS = new Set(["GET", "HEAD", "OPTIONS", "TRACE"]);
 
 function readMeta(name) {
   return (
@@ -43,7 +46,26 @@ function extractSecurityMeta(htmlText) {
   };
 }
 
-function showSessionWarning() {
+function readSharedRefreshAt() {
+  try {
+    const value = Number.parseInt(window.localStorage.getItem(LAST_REFRESH_KEY) || "0", 10);
+    return Number.isFinite(value) ? value : 0;
+  } catch (_error) {
+    return 0;
+  }
+}
+
+function writeSharedRefreshAt(value) {
+  try {
+    // This is coordination metadata only. No access token, refresh token, CSRF
+    // token, tenant id or other credential is ever persisted in Web Storage.
+    window.localStorage.setItem(LAST_REFRESH_KEY, String(value));
+  } catch (_error) {
+    // Storage may be disabled. Web Locks still serialize rotations safely.
+  }
+}
+
+function showSessionWarning(message = "La sesión necesita reautenticación.") {
   if (document.querySelector("[data-session-renewal-warning]")) {
     return;
   }
@@ -68,8 +90,133 @@ function showSessionWarning() {
     "color:#451a03",
     "box-shadow:0 10px 15px -3px rgb(0 0 0 / 0.1)",
   ].join(";");
-  warning.innerHTML = "<strong>La sesión necesita reautenticación.</strong> Para proteger los datos, Litoral Trace no renovó la sesión automáticamente. Abrí nuevamente la aplicación antes de continuar.";
+  warning.innerHTML = `<strong>${message}</strong> Para proteger los datos, Litoral Trace no continuó la renovación automática. Abrí nuevamente la aplicación antes de seguir.`;
   document.body.appendChild(warning);
+}
+
+function installLiveCsrfFetchBridge() {
+  if (
+    typeof window.fetch !== "function"
+    || window.fetch.__litoralTraceLiveCsrf
+  ) {
+    return;
+  }
+
+  const downstreamFetch = window.fetch.bind(window);
+
+  const liveCsrfFetch = (input, init = {}) => {
+    const method = String(
+      init.method || (input instanceof Request ? input.method : "GET"),
+    ).toUpperCase();
+
+    if (SAFE_METHODS.has(method)) {
+      return downstreamFetch(input, init);
+    }
+
+    const rawUrl = input instanceof Request ? input.url : String(input);
+    const requestUrl = new URL(rawUrl, window.location.href);
+
+    if (requestUrl.origin !== window.location.origin) {
+      return downstreamFetch(input, init);
+    }
+
+    // /refresh uses the separate browser-bound token. Every other unsafe API
+    // request must use the current subject/session-bound token from the meta tag,
+    // even if legacy page code cached and supplied an older explicit header.
+    if (requestUrl.pathname === REFRESH_URL) {
+      return downstreamFetch(input, init);
+    }
+
+    const token = readMeta(CSRF_META_NAME);
+    if (!token) {
+      return downstreamFetch(input, init);
+    }
+
+    const headers = new Headers(input instanceof Request ? input.headers : undefined);
+    const initHeaders = new Headers(init.headers || undefined);
+    initHeaders.forEach((value, key) => headers.set(key, value));
+    headers.set(CSRF_HEADER_NAME, token);
+
+    return downstreamFetch(input, {...init, headers});
+  };
+
+  Object.defineProperty(liveCsrfFetch, "__litoralTraceLiveCsrf", {
+    value: true,
+    enumerable: false,
+  });
+  window.fetch = liveCsrfFetch;
+}
+
+async function synchronizeSecurityMeta() {
+  try {
+    const pageResponse = await window.fetch(
+      window.location.href,
+      {
+        method: "GET",
+        credentials: "same-origin",
+        cache: "no-store",
+        headers: {"Accept": "text/html"},
+      },
+    );
+
+    if (!pageResponse.ok) {
+      return false;
+    }
+
+    const securityMeta = extractSecurityMeta(await pageResponse.text());
+    if (!securityMeta.csrfToken || !securityMeta.refreshCsrfToken) {
+      return false;
+    }
+
+    updateRenderedCsrfToken(securityMeta.csrfToken);
+    updateMeta(REFRESH_CSRF_META_NAME, securityMeta.refreshCsrfToken);
+    return true;
+  } catch (_error) {
+    return false;
+  }
+}
+
+async function rotateSession() {
+  const token = readMeta(REFRESH_CSRF_META_NAME);
+  if (!token) {
+    return false;
+  }
+
+  let response;
+  try {
+    response = await window.fetch(
+      REFRESH_URL,
+      {
+        method: "POST",
+        credentials: "same-origin",
+        cache: "no-store",
+        headers: {
+          "Accept": "application/json",
+          "Content-Type": "application/json",
+          [CSRF_HEADER_NAME]: token,
+        },
+        body: "{}",
+      },
+    );
+  } catch (_error) {
+    return false;
+  }
+
+  if (!response.ok) {
+    if (response.status === 401 || response.status === 403) {
+      showSessionWarning();
+    }
+    return false;
+  }
+
+  // Refresh-token rotation changes the session id. Pull only the security meta
+  // from a fresh GET and update the existing DOM in place so form inputs and
+  // scroll position are preserved.
+  const synchronized = await synchronizeSecurityMeta();
+  if (!synchronized) {
+    showSessionWarning("La sesión se renovó, pero la página no pudo sincronizar su protección CSRF.");
+  }
+  return synchronized;
 }
 
 function installSessionRenewal() {
@@ -80,9 +227,36 @@ function installSessionRenewal() {
     return;
   }
 
+  installLiveCsrfFetchBridge();
+
   const intervalMs = rawInterval * 1000;
+  const duplicateSuppressionMs = Math.max(5000, Math.min(30000, Math.floor(intervalMs / 3)));
   let lastRenewalAt = Date.now();
   let inFlight = null;
+
+  const renewInsideCrossTabLock = async () => {
+    const now = Date.now();
+    const sharedRefreshAt = readSharedRefreshAt();
+
+    // Another tab may have just rotated the shared cookies while this tab was
+    // waiting for the Web Lock. Do not rotate again; only rehydrate this tab's
+    // session-bound CSRF token from the newly authenticated GET response.
+    if (sharedRefreshAt && now - sharedRefreshAt < duplicateSuppressionMs) {
+      const synchronized = await synchronizeSecurityMeta();
+      if (synchronized) {
+        lastRenewalAt = Date.now();
+      }
+      return synchronized;
+    }
+
+    const rotated = await rotateSession();
+    if (rotated) {
+      const completedAt = Date.now();
+      lastRenewalAt = completedAt;
+      writeSharedRefreshAt(completedAt);
+    }
+    return rotated;
+  };
 
   const renew = async () => {
     if (inFlight) {
@@ -90,72 +264,20 @@ function installSessionRenewal() {
     }
 
     inFlight = (async () => {
-      const token = readMeta(REFRESH_CSRF_META_NAME);
-      if (!token) {
+      // Rotation-based reuse detection intentionally revokes a session family
+      // when the same refresh token is used twice. Therefore automatic refresh
+      // must be serialized across browser tabs. Web Locks provides an origin-
+      // scoped exclusive lock without storing credentials. On browsers without
+      // Web Locks we fail closed and leave the existing server expiry behavior.
+      if (!navigator.locks?.request) {
         return false;
       }
 
-      let response;
-      try {
-        response = await window.fetch(
-          REFRESH_URL,
-          {
-            method: "POST",
-            credentials: "same-origin",
-            cache: "no-store",
-            headers: {
-              "Accept": "application/json",
-              "Content-Type": "application/json",
-              [CSRF_HEADER_NAME]: token,
-            },
-            body: "{}",
-          },
-        );
-      } catch (_error) {
-        return false;
-      }
-
-      if (!response.ok) {
-        if (response.status === 401 || response.status === 403) {
-          showSessionWarning();
-        }
-        return false;
-      }
-
-      // Refresh-token rotation changes the authenticated session id. Fetch a
-      // fresh server-rendered copy of the current GET page only to obtain the
-      // new signed CSRF tokens, then update the current DOM in place. User
-      // inputs and scroll position are therefore preserved.
-      try {
-        const pageResponse = await window.fetch(
-          window.location.href,
-          {
-            method: "GET",
-            credentials: "same-origin",
-            cache: "no-store",
-            headers: {"Accept": "text/html"},
-          },
-        );
-
-        if (!pageResponse.ok) {
-          showSessionWarning();
-          return false;
-        }
-
-        const securityMeta = extractSecurityMeta(await pageResponse.text());
-        if (!securityMeta.csrfToken || !securityMeta.refreshCsrfToken) {
-          showSessionWarning();
-          return false;
-        }
-
-        updateRenderedCsrfToken(securityMeta.csrfToken);
-        updateMeta(REFRESH_CSRF_META_NAME, securityMeta.refreshCsrfToken);
-        lastRenewalAt = Date.now();
-        return true;
-      } catch (_error) {
-        showSessionWarning();
-        return false;
-      }
+      return navigator.locks.request(
+        REFRESH_LOCK_NAME,
+        {mode: "exclusive"},
+        renewInsideCrossTabLock,
+      );
     })();
 
     try {

--- a/src/litoral_trace/static/src/js/session-renewal.js
+++ b/src/litoral_trace/static/src/js/session-renewal.js
@@ -1,6 +1,7 @@
 const CSRF_META_NAME = "csrf-token";
 const REFRESH_CSRF_META_NAME = "lt-refresh-csrf-token";
 const REFRESH_AFTER_META_NAME = "lt-session-refresh-after";
+const ACCESS_EXPIRES_AT_META_NAME = "lt-session-access-expires-at";
 const CSRF_HEADER_NAME = "X-CSRF-Token";
 const REFRESH_URL = "/api/v1/auth/refresh";
 const REFRESH_LOCK_NAME = "litoral-trace-session-refresh";
@@ -23,6 +24,14 @@ function updateMeta(name, value) {
   }
 }
 
+function readEpochMilliseconds(name) {
+  const raw = Number.parseInt(readMeta(name), 10);
+  if (!Number.isFinite(raw) || raw <= 0) {
+    return null;
+  }
+  return raw * 1000;
+}
+
 function updateRenderedCsrfToken(nextToken) {
   if (!nextToken) {
     return;
@@ -41,6 +50,9 @@ function extractSecurityMeta(htmlText) {
       ?.getAttribute("content")
       ?.trim() || "",
     refreshCsrfToken: parsed.querySelector(`meta[name="${REFRESH_CSRF_META_NAME}"]`)
+      ?.getAttribute("content")
+      ?.trim() || "",
+    accessExpiresAt: parsed.querySelector(`meta[name="${ACCESS_EXPIRES_AT_META_NAME}"]`)
       ?.getAttribute("content")
       ?.trim() || "",
   };
@@ -145,12 +157,17 @@ async function synchronizeSecurityMeta() {
     }
 
     const securityMeta = extractSecurityMeta(await pageResponse.text());
-    if (!securityMeta.csrfToken || !securityMeta.refreshCsrfToken) {
+    if (
+      !securityMeta.csrfToken
+      || !securityMeta.refreshCsrfToken
+      || !securityMeta.accessExpiresAt
+    ) {
       return false;
     }
 
     updateRenderedCsrfToken(securityMeta.csrfToken);
     updateMeta(REFRESH_CSRF_META_NAME, securityMeta.refreshCsrfToken);
+    updateMeta(ACCESS_EXPIRES_AT_META_NAME, securityMeta.accessExpiresAt);
     return true;
   } catch (_error) {
     return false;
@@ -191,7 +208,8 @@ async function rotateSession() {
   }
 
   // Set-Cookie has been applied when fetch resolves. Rehydrate this tab's
-  // session-bound CSRF material without reloading the page or losing inputs.
+  // session-bound CSRF material and the new absolute access expiry without
+  // reloading the page or losing inputs.
   const synchronized = await synchronizeSecurityMeta();
   if (!synchronized) {
     showSessionWarning("La sesión se renovó, pero la página no pudo sincronizar su protección CSRF.");
@@ -202,8 +220,14 @@ async function rotateSession() {
 function installSessionRenewal() {
   const refreshCsrfToken = readMeta(REFRESH_CSRF_META_NAME);
   const rawInterval = Number.parseInt(readMeta(REFRESH_AFTER_META_NAME), 10);
+  const initialExpiryMs = readEpochMilliseconds(ACCESS_EXPIRES_AT_META_NAME);
 
-  if (!refreshCsrfToken || !Number.isFinite(rawInterval) || rawInterval < 15) {
+  if (
+    !refreshCsrfToken
+    || !Number.isFinite(rawInterval)
+    || rawInterval < 15
+    || initialExpiryMs === null
+  ) {
     return;
   }
 
@@ -219,32 +243,62 @@ function installSessionRenewal() {
   installLiveCsrfFetchBridge();
 
   const intervalMs = rawInterval * 1000;
+  const retryDelayMs = Math.max(5000, Math.min(30000, Math.floor(intervalMs / 4)));
   const duplicateSuppressionMs = Math.max(5000, Math.min(30000, Math.floor(intervalMs / 3)));
   const channel = new window.BroadcastChannel(REFRESH_CHANNEL_NAME);
-  let lastRenewalAt = Date.now();
+  let renewalTimer = null;
   let sharedRefreshAt = 0;
   let inFlight = null;
   let peerSyncInFlight = null;
 
-  const rememberSharedRefresh = (value) => {
+  function accessRefreshDueAtMs() {
+    const expiryMs = readEpochMilliseconds(ACCESS_EXPIRES_AT_META_NAME);
+    if (expiryMs === null) {
+      return null;
+    }
+    return expiryMs - intervalMs;
+  }
+
+  function rememberSharedRefresh(value) {
     const timestamp = Number(value);
     if (!Number.isFinite(timestamp) || timestamp <= 0) {
       return false;
     }
     sharedRefreshAt = Math.max(sharedRefreshAt, timestamp);
     return true;
-  };
+  }
 
-  const announceRefresh = (timestamp) => {
+  function announceRefresh(timestamp) {
     rememberSharedRefresh(timestamp);
     channel.postMessage({type: "refreshed", at: timestamp});
-  };
+  }
 
-  const synchronizeFromPeer = async (timestamp) => {
+  function scheduleRenewal({retry = false} = {}) {
+    if (renewalTimer !== null) {
+      window.clearTimeout(renewalTimer);
+      renewalTimer = null;
+    }
+
+    const dueAt = accessRefreshDueAtMs();
+    if (dueAt === null) {
+      showSessionWarning("No fue posible verificar cuándo vence la sesión actual.");
+      return;
+    }
+
+    const minimumDelay = retry ? retryDelayMs : 0;
+    const delay = Math.max(minimumDelay, dueAt - Date.now(), 0);
+
+    renewalTimer = window.setTimeout(async () => {
+      renewalTimer = null;
+      const synchronized = await renew();
+      scheduleRenewal({retry: !synchronized});
+    }, delay);
+  }
+
+  async function synchronizeFromPeer(timestamp) {
     if (!rememberSharedRefresh(timestamp)) {
       return false;
     }
-    lastRenewalAt = Math.max(lastRenewalAt, Number(timestamp));
 
     if (peerSyncInFlight) {
       return peerSyncInFlight;
@@ -255,12 +309,14 @@ function installSessionRenewal() {
       const synchronized = await peerSyncInFlight;
       if (!synchronized) {
         showSessionWarning("Otra pestaña renovó la sesión, pero esta página no pudo sincronizar su protección CSRF.");
+      } else {
+        scheduleRenewal();
       }
       return synchronized;
     } finally {
       peerSyncInFlight = null;
     }
-  };
+  }
 
   channel.addEventListener("message", (event) => {
     const payload = event.data;
@@ -283,32 +339,27 @@ function installSessionRenewal() {
   // refresh or CSRF tokens, tenant IDs, usernames or business data.
   channel.postMessage({type: "state-request"});
 
-  const renewInsideCrossTabLock = async () => {
+  async function renewInsideCrossTabLock() {
     const now = Date.now();
 
     // A peer may have rotated the shared HttpOnly cookies while this tab waited
     // for the Web Lock. If so, never perform a second immediate rotation: just
-    // rehydrate this tab's session-bound CSRF material.
+    // rehydrate this tab's session-bound CSRF and expiry metadata.
     if (sharedRefreshAt && now - sharedRefreshAt < duplicateSuppressionMs) {
-      const synchronized = await synchronizeSecurityMeta();
-      if (synchronized) {
-        lastRenewalAt = Date.now();
-      }
-      return synchronized;
+      return synchronizeSecurityMeta();
     }
 
     const result = await rotateSession();
     if (result.rotated) {
       const completedAt = Date.now();
-      lastRenewalAt = completedAt;
       // Broadcast immediately after the server rotated the HttpOnly cookies so
       // every peer can refresh its session-bound CSRF token before its next POST.
       announceRefresh(completedAt);
     }
     return result.synchronized;
-  };
+  }
 
-  const renew = async () => {
+  async function renew() {
     if (inFlight) {
       return inFlight;
     }
@@ -324,24 +375,36 @@ function installSessionRenewal() {
     } finally {
       inFlight = null;
     }
-  };
+  }
 
-  window.setInterval(() => {
-    void renew();
-  }, intervalMs);
-
-  const renewIfOverdue = () => {
-    if (Date.now() - lastRenewalAt >= intervalMs) {
-      void renew();
+  function renewIfDue() {
+    const dueAt = accessRefreshDueAtMs();
+    if (dueAt === null) {
+      showSessionWarning("No fue posible verificar cuándo vence la sesión actual.");
+      return;
     }
-  };
+
+    if (Date.now() >= dueAt) {
+      void renew().then((synchronized) => {
+        scheduleRenewal({retry: !synchronized});
+      });
+      return;
+    }
+
+    scheduleRenewal();
+  }
+
+  // The deadline is absolute and comes from the verified JWT expiry. A normal
+  // full-page navigation therefore cannot postpone renewal by starting a fresh
+  // interval from page-load time.
+  scheduleRenewal();
 
   document.addEventListener("visibilitychange", () => {
     if (document.visibilityState === "visible") {
-      renewIfOverdue();
+      renewIfDue();
     }
   });
-  window.addEventListener("focus", renewIfOverdue);
+  window.addEventListener("focus", renewIfDue);
 }
 
 if (document.readyState === "loading") {

--- a/src/litoral_trace/static/src/js/session-renewal.js
+++ b/src/litoral_trace/static/src/js/session-renewal.js
@@ -51,7 +51,23 @@ function showSessionWarning() {
   const warning = document.createElement("div");
   warning.dataset.sessionRenewalWarning = "true";
   warning.setAttribute("role", "alert");
-  warning.className = "fixed inset-x-4 top-4 z-[100] mx-auto max-w-2xl rounded-xl border border-amber-300 bg-amber-50 p-4 text-sm text-amber-950 shadow-xl";
+  warning.style.cssText = [
+    "position:fixed",
+    "left:1rem",
+    "right:1rem",
+    "top:1rem",
+    "z-index:100",
+    "max-width:42rem",
+    "margin:0 auto",
+    "border:1px solid #fcd34d",
+    "border-radius:0.75rem",
+    "background:#fffbeb",
+    "padding:1rem",
+    "font-size:0.875rem",
+    "line-height:1.5",
+    "color:#451a03",
+    "box-shadow:0 10px 15px -3px rgb(0 0 0 / 0.1)",
+  ].join(";");
   warning.innerHTML = "<strong>La sesión necesita reautenticación.</strong> Para proteger los datos, Litoral Trace no renovó la sesión automáticamente. Abrí nuevamente la aplicación antes de continuar.";
   document.body.appendChild(warning);
 }

--- a/src/litoral_trace/static/src/js/session-renewal.js
+++ b/src/litoral_trace/static/src/js/session-renewal.js
@@ -5,6 +5,8 @@ const ACCESS_EXPIRES_AT_META_NAME = "lt-session-access-expires-at";
 const SERVER_NOW_META_NAME = "lt-session-server-now";
 const CSRF_HEADER_NAME = "X-CSRF-Token";
 const REFRESH_URL = "/api/v1/auth/refresh";
+const ACCESS_PROBE_URL = "/api/v1/auth/me";
+const SESSION_CLOCK_URL = "/health";
 const REFRESH_LOCK_NAME = "litoral-trace-session-refresh";
 const REFRESH_CHANNEL_NAME = "litoral-trace-session-refresh-events";
 const SAFE_METHODS = new Set(["GET", "HEAD", "OPTIONS", "TRACE"]);
@@ -31,6 +33,10 @@ function readEpochMilliseconds(name) {
     return null;
   }
   return raw * 1000;
+}
+
+function monotonicEpochMilliseconds() {
+  return performance.timeOrigin + performance.now();
 }
 
 function updateRenderedCsrfToken(nextToken) {
@@ -180,6 +186,52 @@ async function synchronizeSecurityMeta() {
   }
 }
 
+async function refreshServerClock() {
+  try {
+    const response = await window.fetch(
+      SESSION_CLOCK_URL,
+      {
+        method: "GET",
+        credentials: "same-origin",
+        cache: "no-store",
+        headers: {"Accept": "application/json"},
+      },
+    );
+
+    if (!response.ok) {
+      return false;
+    }
+
+    const serverDate = response.headers.get("Date");
+    const serverNowMs = Date.parse(serverDate || "");
+    if (!Number.isFinite(serverNowMs) || serverNowMs <= 0) {
+      return false;
+    }
+
+    updateMeta(SERVER_NOW_META_NAME, String(Math.floor(serverNowMs / 1000)));
+    return true;
+  } catch (_error) {
+    return false;
+  }
+}
+
+async function accessSessionIsUsable() {
+  try {
+    const response = await window.fetch(
+      ACCESS_PROBE_URL,
+      {
+        method: "GET",
+        credentials: "same-origin",
+        cache: "no-store",
+        headers: {"Accept": "application/json"},
+      },
+    );
+    return response.ok;
+  } catch (_error) {
+    return false;
+  }
+}
+
 async function rotateSession() {
   const token = readMeta(REFRESH_CSRF_META_NAME);
   if (!token) {
@@ -194,6 +246,7 @@ async function rotateSession() {
         method: "POST",
         credentials: "same-origin",
         cache: "no-store",
+        keepalive: true,
         headers: {
           "Accept": "application/json",
           "Content-Type": "application/json",
@@ -213,9 +266,9 @@ async function rotateSession() {
     return {rotated: false, synchronized: false};
   }
 
-  // Set-Cookie has been applied when fetch resolves. Rehydrate this tab's
-  // session-bound CSRF material and fresh server-relative timing metadata
-  // without reloading the page or losing inputs.
+  // keepalive lets the browser finish the rotation and apply Set-Cookie even if
+  // a navigation starts after the POST reached the server. When this document
+  // survives, rehydrate its session-bound CSRF and timing metadata in place.
   const synchronized = await synchronizeSecurityMeta();
   if (!synchronized) {
     showSessionWarning("La sesión se renovó, pero la página no pudo sincronizar su protección CSRF.");
@@ -255,10 +308,11 @@ function installSessionRenewal() {
   const duplicateSuppressionMs = Math.max(5000, Math.min(30000, Math.floor(intervalMs / 3)));
   const channel = new window.BroadcastChannel(REFRESH_CHANNEL_NAME);
   let renewalTimer = null;
-  let renewalDeadlineMonotonicMs = null;
   let sharedRefreshAt = 0;
   let inFlight = null;
   let peerSyncInFlight = null;
+  let foregroundProbeInFlight = null;
+  let foregroundDueProbe = false;
 
   function serverRelativeRefreshDelayMs() {
     const expiryMs = readEpochMilliseconds(ACCESS_EXPIRES_AT_META_NAME);
@@ -267,8 +321,8 @@ function installSessionRenewal() {
       return null;
     }
 
-    // Both values are emitted by the server from the verified authenticated
-    // response. The workstation wall clock never participates in expiry math.
+    // Both values come from server-controlled responses. The workstation wall
+    // clock never participates in expiry math.
     return Math.max(0, expiryMs - serverNowMs - intervalMs);
   }
 
@@ -291,7 +345,6 @@ function installSessionRenewal() {
       window.clearTimeout(renewalTimer);
     }
 
-    renewalDeadlineMonotonicMs = performance.now() + delay;
     renewalTimer = window.setTimeout(async () => {
       renewalTimer = null;
       const synchronized = await renew();
@@ -348,23 +401,41 @@ function installSessionRenewal() {
   });
 
   // A newly opened tab can ask existing tabs for their latest in-memory
-  // coordination timestamp. Only a timestamp crosses the channel—never access,
-  // refresh or CSRF tokens, tenant IDs, usernames or business data.
+  // coordination timestamp. Only a monotonic timestamp crosses the channel—
+  // never access, refresh or CSRF tokens, tenant IDs, usernames or business data.
   channel.postMessage({type: "state-request"});
 
   async function renewInsideCrossTabLock() {
-    const now = Date.now();
+    const now = monotonicEpochMilliseconds();
 
     // A peer may have rotated the shared HttpOnly cookies while this tab waited
     // for the Web Lock. If so, never perform a second immediate rotation: just
     // rehydrate this tab's session-bound CSRF and timing metadata.
     if (sharedRefreshAt && now - sharedRefreshAt < duplicateSuppressionMs) {
+      foregroundDueProbe = false;
       return synchronizeSecurityMeta();
     }
 
+    // After waking from suspension, multiple tabs can decide that the old access
+    // token is due at the same time. Once the lock is acquired, probe the shared
+    // cookie jar before rotating. If another tab already refreshed, /me succeeds
+    // and the new server metadata moves the deadline forward; if the old access
+    // token is still due/expired, continue with exactly one refresh rotation.
+    if (foregroundDueProbe && await accessSessionIsUsable()) {
+      const synchronized = await synchronizeSecurityMeta();
+      if (synchronized) {
+        const refreshedDelay = serverRelativeRefreshDelayMs();
+        if (refreshedDelay !== null && refreshedDelay > 0) {
+          foregroundDueProbe = false;
+          return true;
+        }
+      }
+    }
+
+    foregroundDueProbe = false;
     const result = await rotateSession();
     if (result.rotated) {
-      const completedAt = Date.now();
+      const completedAt = monotonicEpochMilliseconds();
       // Broadcast immediately after the server rotated the HttpOnly cookies so
       // every peer can refresh its session-bound CSRF token before its next POST.
       announceRefresh(completedAt);
@@ -390,34 +461,71 @@ function installSessionRenewal() {
     }
   }
 
-  function renewIfDue() {
-    if (renewalDeadlineMonotonicMs === null) {
-      scheduleRenewal();
-      return;
+  async function revalidateAfterForeground() {
+    if (foregroundProbeInFlight) {
+      return foregroundProbeInFlight;
     }
 
-    if (performance.now() >= renewalDeadlineMonotonicMs) {
+    foregroundProbeInFlight = (async () => {
+      const clockRefreshed = await refreshServerClock();
+      if (!clockRefreshed) {
+        // If the public server clock cannot be obtained, renewing directly is
+        // safer than trusting a monotonic clock that may have paused in sleep.
+        foregroundDueProbe = true;
+        sharedRefreshAt = 0;
+        const synchronized = await renew();
+        scheduleRenewal({retry: !synchronized});
+        return synchronized;
+      }
+
+      const delay = serverRelativeRefreshDelayMs();
+      if (delay === null) {
+        showSessionWarning("No fue posible verificar cuándo vence la sesión actual.");
+        return false;
+      }
+
+      if (delay > 0) {
+        armRenewalTimer(delay);
+        return true;
+      }
+
       if (renewalTimer !== null) {
         window.clearTimeout(renewalTimer);
         renewalTimer = null;
       }
-      void renew().then((synchronized) => {
-        scheduleRenewal({retry: !synchronized});
-      });
+
+      // The fresh server clock proves the old access token reached its renewal
+      // window. Reset any pre-suspend duplicate marker; the Web Lock plus /me
+      // probe above still prevents two resumed tabs from rotating sequentially.
+      foregroundDueProbe = true;
+      sharedRefreshAt = 0;
+      const synchronized = await renew();
+      scheduleRenewal({retry: !synchronized});
+      return synchronized;
+    })();
+
+    try {
+      return await foregroundProbeInFlight;
+    } finally {
+      foregroundProbeInFlight = null;
     }
   }
 
-  // The delay is based on verified JWT expiry minus server render time. A normal
-  // full-page navigation cannot postpone renewal, and workstation clock skew
-  // cannot make the client refresh too late or spin in an immediate loop.
+  // Initial delay uses verified JWT expiry minus server render time. Normal page
+  // navigation cannot postpone it and workstation clock skew cannot move it.
   scheduleRenewal();
 
+  // performance.now() may pause while a laptop sleeps. On every return to the
+  // foreground, obtain a fresh server Date header before deciding whether the
+  // current access token is still inside its safe renewal window.
   document.addEventListener("visibilitychange", () => {
     if (document.visibilityState === "visible") {
-      renewIfDue();
+      void revalidateAfterForeground();
     }
   });
-  window.addEventListener("focus", renewIfDue);
+  window.addEventListener("focus", () => {
+    void revalidateAfterForeground();
+  });
 }
 
 if (document.readyState === "loading") {

--- a/src/litoral_trace/static/src/js/session-renewal.js
+++ b/src/litoral_trace/static/src/js/session-renewal.js
@@ -4,7 +4,7 @@ const REFRESH_AFTER_META_NAME = "lt-session-refresh-after";
 const CSRF_HEADER_NAME = "X-CSRF-Token";
 const REFRESH_URL = "/api/v1/auth/refresh";
 const REFRESH_LOCK_NAME = "litoral-trace-session-refresh";
-const LAST_REFRESH_KEY = "litoral-trace:last-session-refresh-at";
+const REFRESH_CHANNEL_NAME = "litoral-trace-session-refresh-events";
 const SAFE_METHODS = new Set(["GET", "HEAD", "OPTIONS", "TRACE"]);
 
 function readMeta(name) {
@@ -44,25 +44,6 @@ function extractSecurityMeta(htmlText) {
       ?.getAttribute("content")
       ?.trim() || "",
   };
-}
-
-function readSharedRefreshAt() {
-  try {
-    const value = Number.parseInt(window.localStorage.getItem(LAST_REFRESH_KEY) || "0", 10);
-    return Number.isFinite(value) ? value : 0;
-  } catch (_error) {
-    return 0;
-  }
-}
-
-function writeSharedRefreshAt(value) {
-  try {
-    // This is coordination metadata only. No access token, refresh token, CSRF
-    // token, tenant id or other credential is ever persisted in Web Storage.
-    window.localStorage.setItem(LAST_REFRESH_KEY, String(value));
-  } catch (_error) {
-    // Storage may be disabled. Web Locks still serialize rotations safely.
-  }
 }
 
 function showSessionWarning(message = "La sesión necesita reautenticación.") {
@@ -120,9 +101,9 @@ function installLiveCsrfFetchBridge() {
       return downstreamFetch(input, init);
     }
 
-    // /refresh uses the separate browser-bound token. Every other unsafe API
-    // request must use the current subject/session-bound token from the meta tag,
-    // even if legacy page code cached and supplied an older explicit header.
+    // /refresh uses its dedicated browser-bound token. Every other unsafe API
+    // request uses the current session-bound token from the meta tag, even when
+    // legacy page code supplied a token that was cached before a rotation.
     if (requestUrl.pathname === REFRESH_URL) {
       return downstreamFetch(input, init);
     }
@@ -179,7 +160,7 @@ async function synchronizeSecurityMeta() {
 async function rotateSession() {
   const token = readMeta(REFRESH_CSRF_META_NAME);
   if (!token) {
-    return false;
+    return {rotated: false, synchronized: false};
   }
 
   let response;
@@ -199,24 +180,23 @@ async function rotateSession() {
       },
     );
   } catch (_error) {
-    return false;
+    return {rotated: false, synchronized: false};
   }
 
   if (!response.ok) {
     if (response.status === 401 || response.status === 403) {
       showSessionWarning();
     }
-    return false;
+    return {rotated: false, synchronized: false};
   }
 
-  // Refresh-token rotation changes the session id. Pull only the security meta
-  // from a fresh GET and update the existing DOM in place so form inputs and
-  // scroll position are preserved.
+  // Set-Cookie has been applied when fetch resolves. Rehydrate this tab's
+  // session-bound CSRF material without reloading the page or losing inputs.
   const synchronized = await synchronizeSecurityMeta();
   if (!synchronized) {
     showSessionWarning("La sesión se renovó, pero la página no pudo sincronizar su protección CSRF.");
   }
-  return synchronized;
+  return {rotated: true, synchronized};
 }
 
 function installSessionRenewal() {
@@ -227,20 +207,88 @@ function installSessionRenewal() {
     return;
   }
 
+  // Correct rotation requires both an origin-scoped exclusive lock and an
+  // ephemeral cross-tab notification channel. Without either primitive we fail
+  // closed: the server-side session simply expires normally and the user can
+  // authenticate again. No credential or coordination state is persisted in
+  // localStorage/sessionStorage.
+  if (!navigator.locks?.request || typeof window.BroadcastChannel !== "function") {
+    return;
+  }
+
   installLiveCsrfFetchBridge();
 
   const intervalMs = rawInterval * 1000;
   const duplicateSuppressionMs = Math.max(5000, Math.min(30000, Math.floor(intervalMs / 3)));
+  const channel = new window.BroadcastChannel(REFRESH_CHANNEL_NAME);
   let lastRenewalAt = Date.now();
+  let sharedRefreshAt = 0;
   let inFlight = null;
+  let peerSyncInFlight = null;
+
+  const rememberSharedRefresh = (value) => {
+    const timestamp = Number(value);
+    if (!Number.isFinite(timestamp) || timestamp <= 0) {
+      return false;
+    }
+    sharedRefreshAt = Math.max(sharedRefreshAt, timestamp);
+    return true;
+  };
+
+  const announceRefresh = (timestamp) => {
+    rememberSharedRefresh(timestamp);
+    channel.postMessage({type: "refreshed", at: timestamp});
+  };
+
+  const synchronizeFromPeer = async (timestamp) => {
+    if (!rememberSharedRefresh(timestamp)) {
+      return false;
+    }
+    lastRenewalAt = Math.max(lastRenewalAt, Number(timestamp));
+
+    if (peerSyncInFlight) {
+      return peerSyncInFlight;
+    }
+
+    peerSyncInFlight = synchronizeSecurityMeta();
+    try {
+      const synchronized = await peerSyncInFlight;
+      if (!synchronized) {
+        showSessionWarning("Otra pestaña renovó la sesión, pero esta página no pudo sincronizar su protección CSRF.");
+      }
+      return synchronized;
+    } finally {
+      peerSyncInFlight = null;
+    }
+  };
+
+  channel.addEventListener("message", (event) => {
+    const payload = event.data;
+    if (!payload || typeof payload !== "object") {
+      return;
+    }
+
+    if (payload.type === "refreshed") {
+      void synchronizeFromPeer(payload.at);
+      return;
+    }
+
+    if (payload.type === "state-request" && sharedRefreshAt > 0) {
+      channel.postMessage({type: "refreshed", at: sharedRefreshAt});
+    }
+  });
+
+  // A newly opened tab can ask existing tabs for their latest in-memory
+  // coordination timestamp. Only a timestamp crosses the channel—never access,
+  // refresh or CSRF tokens, tenant IDs, usernames or business data.
+  channel.postMessage({type: "state-request"});
 
   const renewInsideCrossTabLock = async () => {
     const now = Date.now();
-    const sharedRefreshAt = readSharedRefreshAt();
 
-    // Another tab may have just rotated the shared cookies while this tab was
-    // waiting for the Web Lock. Do not rotate again; only rehydrate this tab's
-    // session-bound CSRF token from the newly authenticated GET response.
+    // A peer may have rotated the shared HttpOnly cookies while this tab waited
+    // for the Web Lock. If so, never perform a second immediate rotation: just
+    // rehydrate this tab's session-bound CSRF material.
     if (sharedRefreshAt && now - sharedRefreshAt < duplicateSuppressionMs) {
       const synchronized = await synchronizeSecurityMeta();
       if (synchronized) {
@@ -249,13 +297,15 @@ function installSessionRenewal() {
       return synchronized;
     }
 
-    const rotated = await rotateSession();
-    if (rotated) {
+    const result = await rotateSession();
+    if (result.rotated) {
       const completedAt = Date.now();
       lastRenewalAt = completedAt;
-      writeSharedRefreshAt(completedAt);
+      // Broadcast immediately after the server rotated the HttpOnly cookies so
+      // every peer can refresh its session-bound CSRF token before its next POST.
+      announceRefresh(completedAt);
     }
-    return rotated;
+    return result.synchronized;
   };
 
   const renew = async () => {
@@ -263,22 +313,11 @@ function installSessionRenewal() {
       return inFlight;
     }
 
-    inFlight = (async () => {
-      // Rotation-based reuse detection intentionally revokes a session family
-      // when the same refresh token is used twice. Therefore automatic refresh
-      // must be serialized across browser tabs. Web Locks provides an origin-
-      // scoped exclusive lock without storing credentials. On browsers without
-      // Web Locks we fail closed and leave the existing server expiry behavior.
-      if (!navigator.locks?.request) {
-        return false;
-      }
-
-      return navigator.locks.request(
-        REFRESH_LOCK_NAME,
-        {mode: "exclusive"},
-        renewInsideCrossTabLock,
-      );
-    })();
+    inFlight = navigator.locks.request(
+      REFRESH_LOCK_NAME,
+      {mode: "exclusive"},
+      renewInsideCrossTabLock,
+    );
 
     try {
       return await inFlight;

--- a/src/litoral_trace/static/src/js/session-renewal.js
+++ b/src/litoral_trace/static/src/js/session-renewal.js
@@ -1,0 +1,174 @@
+const CSRF_META_NAME = "csrf-token";
+const REFRESH_CSRF_META_NAME = "lt-refresh-csrf-token";
+const REFRESH_AFTER_META_NAME = "lt-session-refresh-after";
+const CSRF_HEADER_NAME = "X-CSRF-Token";
+const REFRESH_URL = "/api/v1/auth/refresh";
+
+function readMeta(name) {
+  return (
+    document.querySelector(`meta[name="${name}"]`)
+      ?.getAttribute("content")
+      ?.trim()
+    || ""
+  );
+}
+
+function updateMeta(name, value) {
+  const meta = document.querySelector(`meta[name="${name}"]`);
+  if (meta && value) {
+    meta.setAttribute("content", value);
+  }
+}
+
+function updateRenderedCsrfToken(nextToken) {
+  if (!nextToken) {
+    return;
+  }
+
+  updateMeta(CSRF_META_NAME, nextToken);
+  document.querySelectorAll('input[name="csrf_token"]').forEach((input) => {
+    input.value = nextToken;
+  });
+}
+
+function extractSecurityMeta(htmlText) {
+  const parsed = new DOMParser().parseFromString(htmlText, "text/html");
+  return {
+    csrfToken: parsed.querySelector(`meta[name="${CSRF_META_NAME}"]`)
+      ?.getAttribute("content")
+      ?.trim() || "",
+    refreshCsrfToken: parsed.querySelector(`meta[name="${REFRESH_CSRF_META_NAME}"]`)
+      ?.getAttribute("content")
+      ?.trim() || "",
+  };
+}
+
+function showSessionWarning() {
+  if (document.querySelector("[data-session-renewal-warning]")) {
+    return;
+  }
+
+  const warning = document.createElement("div");
+  warning.dataset.sessionRenewalWarning = "true";
+  warning.setAttribute("role", "alert");
+  warning.className = "fixed inset-x-4 top-4 z-[100] mx-auto max-w-2xl rounded-xl border border-amber-300 bg-amber-50 p-4 text-sm text-amber-950 shadow-xl";
+  warning.innerHTML = "<strong>La sesión necesita reautenticación.</strong> Para proteger los datos, Litoral Trace no renovó la sesión automáticamente. Abrí nuevamente la aplicación antes de continuar.";
+  document.body.appendChild(warning);
+}
+
+function installSessionRenewal() {
+  const refreshCsrfToken = readMeta(REFRESH_CSRF_META_NAME);
+  const rawInterval = Number.parseInt(readMeta(REFRESH_AFTER_META_NAME), 10);
+
+  if (!refreshCsrfToken || !Number.isFinite(rawInterval) || rawInterval < 15) {
+    return;
+  }
+
+  const intervalMs = rawInterval * 1000;
+  let lastRenewalAt = Date.now();
+  let inFlight = null;
+
+  const renew = async () => {
+    if (inFlight) {
+      return inFlight;
+    }
+
+    inFlight = (async () => {
+      const token = readMeta(REFRESH_CSRF_META_NAME);
+      if (!token) {
+        return false;
+      }
+
+      let response;
+      try {
+        response = await window.fetch(
+          REFRESH_URL,
+          {
+            method: "POST",
+            credentials: "same-origin",
+            cache: "no-store",
+            headers: {
+              "Accept": "application/json",
+              "Content-Type": "application/json",
+              [CSRF_HEADER_NAME]: token,
+            },
+            body: "{}",
+          },
+        );
+      } catch (_error) {
+        return false;
+      }
+
+      if (!response.ok) {
+        if (response.status === 401 || response.status === 403) {
+          showSessionWarning();
+        }
+        return false;
+      }
+
+      // Refresh-token rotation changes the authenticated session id. Fetch a
+      // fresh server-rendered copy of the current GET page only to obtain the
+      // new signed CSRF tokens, then update the current DOM in place. User
+      // inputs and scroll position are therefore preserved.
+      try {
+        const pageResponse = await window.fetch(
+          window.location.href,
+          {
+            method: "GET",
+            credentials: "same-origin",
+            cache: "no-store",
+            headers: {"Accept": "text/html"},
+          },
+        );
+
+        if (!pageResponse.ok) {
+          showSessionWarning();
+          return false;
+        }
+
+        const securityMeta = extractSecurityMeta(await pageResponse.text());
+        if (!securityMeta.csrfToken || !securityMeta.refreshCsrfToken) {
+          showSessionWarning();
+          return false;
+        }
+
+        updateRenderedCsrfToken(securityMeta.csrfToken);
+        updateMeta(REFRESH_CSRF_META_NAME, securityMeta.refreshCsrfToken);
+        lastRenewalAt = Date.now();
+        return true;
+      } catch (_error) {
+        showSessionWarning();
+        return false;
+      }
+    })();
+
+    try {
+      return await inFlight;
+    } finally {
+      inFlight = null;
+    }
+  };
+
+  window.setInterval(() => {
+    void renew();
+  }, intervalMs);
+
+  const renewIfOverdue = () => {
+    if (Date.now() - lastRenewalAt >= intervalMs) {
+      void renew();
+    }
+  };
+
+  document.addEventListener("visibilitychange", () => {
+    if (document.visibilityState === "visible") {
+      renewIfOverdue();
+    }
+  });
+  window.addEventListener("focus", renewIfOverdue);
+}
+
+if (document.readyState === "loading") {
+  document.addEventListener("DOMContentLoaded", installSessionRenewal, {once: true});
+} else {
+  installSessionRenewal();
+}

--- a/src/litoral_trace/templates/base.html
+++ b/src/litoral_trace/templates/base.html
@@ -16,6 +16,9 @@
     {% if session_access_expires_at_epoch %}
     <meta name="lt-session-access-expires-at" content="{{ session_access_expires_at_epoch }}">
     {% endif %}
+    {% if session_server_now_epoch %}
+    <meta name="lt-session-server-now" content="{{ session_server_now_epoch }}">
+    {% endif %}
 
     <title>{% block title %}Litoral Trace | Trazabilidad de origen y cadena de custodia{% endblock %}</title>
 

--- a/src/litoral_trace/templates/base.html
+++ b/src/litoral_trace/templates/base.html
@@ -13,6 +13,9 @@
     {% if session_refresh_after_seconds %}
     <meta name="lt-session-refresh-after" content="{{ session_refresh_after_seconds }}">
     {% endif %}
+    {% if session_access_expires_at_epoch %}
+    <meta name="lt-session-access-expires-at" content="{{ session_access_expires_at_epoch }}">
+    {% endif %}
 
     <title>{% block title %}Litoral Trace | Trazabilidad de origen y cadena de custodia{% endblock %}</title>
 

--- a/src/litoral_trace/templates/base.html
+++ b/src/litoral_trace/templates/base.html
@@ -33,6 +33,7 @@
     <script src="{{ url_for('static', path='/vendor/leaflet/leaflet.js') }}" defer></script>
     <script type="module" src="{{ url_for('static', path='/src/js/app.js') }}"></script>
     <script type="module" src="{{ url_for('static', path='/src/js/session-renewal.js') }}"></script>
+    <script type="module" src="{{ url_for('static', path='/src/js/evidence-context.js') }}"></script>
     <script type="module" src="{{ url_for('static', path='/src/js/dialog.js') }}"></script>
     <script type="module" src="{{ url_for('static', path='/src/js/mobile-motion.js') }}"></script>
     <script type="module" src="{{ url_for('static', path='/src/js/file-input.js') }}"></script>

--- a/src/litoral_trace/templates/base.html
+++ b/src/litoral_trace/templates/base.html
@@ -35,6 +35,7 @@
     <script type="module" src="{{ url_for('static', path='/src/js/session-renewal.js') }}"></script>
     <script type="module" src="{{ url_for('static', path='/src/js/evidence-context.js') }}"></script>
     <script type="module" src="{{ url_for('static', path='/src/js/datetime-local.js') }}"></script>
+    <script type="module" src="{{ url_for('static', path='/src/js/business-language.js') }}"></script>
     <script type="module" src="{{ url_for('static', path='/src/js/dialog.js') }}"></script>
     <script type="module" src="{{ url_for('static', path='/src/js/mobile-motion.js') }}"></script>
     <script type="module" src="{{ url_for('static', path='/src/js/file-input.js') }}"></script>

--- a/src/litoral_trace/templates/base.html
+++ b/src/litoral_trace/templates/base.html
@@ -7,6 +7,12 @@
     {% if csrf_token %}
     <meta name="csrf-token" content="{{ csrf_token }}">
     {% endif %}
+    {% if refresh_csrf_token %}
+    <meta name="lt-refresh-csrf-token" content="{{ refresh_csrf_token }}">
+    {% endif %}
+    {% if session_refresh_after_seconds %}
+    <meta name="lt-session-refresh-after" content="{{ session_refresh_after_seconds }}">
+    {% endif %}
 
     <title>{% block title %}Litoral Trace | Trazabilidad de origen y cadena de custodia{% endblock %}</title>
 
@@ -26,6 +32,7 @@
     <script src="{{ url_for('static', path='/vendor/htmx/htmx.min.js') }}" defer></script>
     <script src="{{ url_for('static', path='/vendor/leaflet/leaflet.js') }}" defer></script>
     <script type="module" src="{{ url_for('static', path='/src/js/app.js') }}"></script>
+    <script type="module" src="{{ url_for('static', path='/src/js/session-renewal.js') }}"></script>
     <script type="module" src="{{ url_for('static', path='/src/js/dialog.js') }}"></script>
     <script type="module" src="{{ url_for('static', path='/src/js/mobile-motion.js') }}"></script>
     <script type="module" src="{{ url_for('static', path='/src/js/file-input.js') }}"></script>

--- a/src/litoral_trace/templates/base.html
+++ b/src/litoral_trace/templates/base.html
@@ -34,6 +34,7 @@
     <script type="module" src="{{ url_for('static', path='/src/js/app.js') }}"></script>
     <script type="module" src="{{ url_for('static', path='/src/js/session-renewal.js') }}"></script>
     <script type="module" src="{{ url_for('static', path='/src/js/evidence-context.js') }}"></script>
+    <script type="module" src="{{ url_for('static', path='/src/js/datetime-local.js') }}"></script>
     <script type="module" src="{{ url_for('static', path='/src/js/dialog.js') }}"></script>
     <script type="module" src="{{ url_for('static', path='/src/js/mobile-motion.js') }}"></script>
     <script type="module" src="{{ url_for('static', path='/src/js/file-input.js') }}"></script>

--- a/src/litoral_trace/templates/base.html
+++ b/src/litoral_trace/templates/base.html
@@ -38,6 +38,7 @@
     <script src="{{ url_for('static', path='/vendor/htmx/htmx.min.js') }}" defer></script>
     <script src="{{ url_for('static', path='/vendor/leaflet/leaflet.js') }}" defer></script>
     <script type="module" src="{{ url_for('static', path='/src/js/app.js') }}"></script>
+    <script type="module" src="{{ url_for('static', path='/src/js/session-refresh-coordination.js') }}"></script>
     <script type="module" src="{{ url_for('static', path='/src/js/session-renewal.js') }}"></script>
     <script type="module" src="{{ url_for('static', path='/src/js/evidence-context.js') }}"></script>
     <script type="module" src="{{ url_for('static', path='/src/js/datetime-local.js') }}"></script>

--- a/src/litoral_trace/web/context.py
+++ b/src/litoral_trace/web/context.py
@@ -5,6 +5,8 @@ from typing import Any
 
 from fastapi import Request
 
+from litoral_trace.auth.sessions import ACCESS_TOKEN_COOKIE_KEY
+from litoral_trace.auth.tokens import verify_jwt_token
 from litoral_trace.config import get_settings
 from litoral_trace.web.csrf import (
     CSRF_FORM_FIELD,
@@ -20,6 +22,51 @@ def _session_refresh_after_seconds() -> int:
 
     access_seconds = get_settings().jwt.access_token_expire_seconds
     return max(15, min(10 * 60, access_seconds // 2))
+
+
+def _session_access_expires_at_epoch(
+    request: Request,
+    *,
+    user: Any | None,
+) -> int | None:
+    """Return the verified current access-token expiry for this exact session."""
+
+    if user is None:
+        return None
+
+    token = request.cookies.get(ACCESS_TOKEN_COOKIE_KEY)
+    if not token:
+        return None
+
+    payload = verify_jwt_token(
+        token,
+        expected_token_type="access",
+    )
+    if not payload:
+        return None
+
+    try:
+        expires_at = int(payload.get("exp"))
+        organization_id = int(payload.get("org_id"))
+        session_id = int(payload.get("sid"))
+        expected_organization_id = int(getattr(user, "organization_id"))
+        expected_session_id = int(getattr(user, "session_id"))
+    except (TypeError, ValueError):
+        return None
+
+    username = str(payload.get("sub", "")).strip()
+    expected_username = str(getattr(user, "username", "")).strip()
+
+    if (
+        expires_at <= 0
+        or organization_id != expected_organization_id
+        or session_id != expected_session_id
+        or not username
+        or username != expected_username
+    ):
+        return None
+
+    return expires_at
 
 
 def build_template_context(
@@ -61,6 +108,13 @@ def build_template_context(
             _session_refresh_after_seconds()
             if user is not None
             else None
+        ),
+        # Absolute expiry is derived from the verified HttpOnly access JWT and
+        # matched back to the hydrated tenant/session. Rendering only the epoch
+        # prevents full-page navigation from resetting the refresh deadline.
+        "session_access_expires_at_epoch": _session_access_expires_at_epoch(
+            request,
+            user=user,
         ),
         "csrf_header_name": CSRF_HEADER_NAME,
         "csrf_form_field": CSRF_FORM_FIELD,

--- a/src/litoral_trace/web/context.py
+++ b/src/litoral_trace/web/context.py
@@ -1,6 +1,7 @@
 """Secure base context for every server-rendered Litoral Trace template."""
 from __future__ import annotations
 
+import time
 from typing import Any
 
 from fastapi import Request
@@ -49,8 +50,8 @@ def _session_access_expires_at_epoch(
         expires_at = int(payload.get("exp"))
         organization_id = int(payload.get("org_id"))
         session_id = int(payload.get("sid"))
-        expected_organization_id = int(getattr(user, "organization_id"))
-        expected_session_id = int(getattr(user, "session_id"))
+        expected_organization_id = int(getattr(user, "organization_id", None))
+        expected_session_id = int(getattr(user, "session_id", None))
     except (TypeError, ValueError):
         return None
 
@@ -85,6 +86,10 @@ def build_template_context(
         if user is not None
         else None
     )
+    access_expires_at_epoch = _session_access_expires_at_epoch(
+        request,
+        user=user,
+    )
 
     security_context = {
         "user": user,
@@ -110,11 +115,14 @@ def build_template_context(
             else None
         ),
         # Absolute expiry is derived from the verified HttpOnly access JWT and
-        # matched back to the hydrated tenant/session. Rendering only the epoch
-        # prevents full-page navigation from resetting the refresh deadline.
-        "session_access_expires_at_epoch": _session_access_expires_at_epoch(
-            request,
-            user=user,
+        # matched back to the hydrated tenant/session. Pair it with server time
+        # from the same rendered response so browser clock skew never changes
+        # the renewal delay.
+        "session_access_expires_at_epoch": access_expires_at_epoch,
+        "session_server_now_epoch": (
+            int(time.time())
+            if access_expires_at_epoch is not None
+            else None
         ),
         "csrf_header_name": CSRF_HEADER_NAME,
         "csrf_form_field": CSRF_FORM_FIELD,

--- a/src/litoral_trace/web/context.py
+++ b/src/litoral_trace/web/context.py
@@ -5,6 +5,7 @@ from typing import Any
 
 from fastapi import Request
 
+from litoral_trace.config import get_settings
 from litoral_trace.web.csrf import (
     CSRF_FORM_FIELD,
     CSRF_HEADER_NAME,
@@ -12,6 +13,13 @@ from litoral_trace.web.csrf import (
     csrf_subject_from_user,
 )
 from litoral_trace.web.navigation import build_navigation
+
+
+def _session_refresh_after_seconds() -> int:
+    """Refresh well before access expiry without creating excessive rotations."""
+
+    access_seconds = get_settings().jwt.access_token_expire_seconds
+    return max(15, min(10 * 60, access_seconds // 2))
 
 
 def build_template_context(
@@ -36,6 +44,23 @@ def build_template_context(
         "csrf_token": create_csrf_token(
             subject=subject,
             browser_nonce=browser_nonce,
+        ),
+        # Refresh uses a separate browser-bound CSRF token so a suspended tab
+        # can renew safely even after the short-lived access cookie expired.
+        # It carries no tenant/user identity and is still signed + bound to the
+        # HttpOnly browser nonce. The refresh token itself remains HttpOnly.
+        "refresh_csrf_token": (
+            create_csrf_token(
+                subject=None,
+                browser_nonce=browser_nonce,
+            )
+            if user is not None
+            else ""
+        ),
+        "session_refresh_after_seconds": (
+            _session_refresh_after_seconds()
+            if user is not None
+            else None
         ),
         "csrf_header_name": CSRF_HEADER_NAME,
         "csrf_form_field": CSRF_FORM_FIELD,

--- a/src/litoral_trace/web/csrf.py
+++ b/src/litoral_trace/web/csrf.py
@@ -201,15 +201,22 @@ def get_or_create_csrf_browser_nonce(
     return create_csrf_browser_nonce(), True
 
 
-def _csrf_browser_cookie_max_age_seconds(settings: Any) -> int:
-    """Keep the browser CSRF binding usable for the full refresh-session TTL."""
+def refresh_csrf_max_age_seconds(
+    settings: Any | None = None,
+) -> int:
+    """Return the browser/refresh CSRF lifetime aligned to refresh-session TTL."""
 
+    resolved_settings = settings or get_settings()
     try:
-        refresh_days = int(settings.jwt.refresh_token_expire_days)
+        refresh_days = int(
+            resolved_settings.jwt.refresh_token_expire_days
+        )
     except (AttributeError, TypeError, ValueError):
         refresh_days = 0
 
-    refresh_seconds = max(0, refresh_days) * 24 * 60 * 60
+    refresh_seconds = (
+        max(0, refresh_days) * 24 * 60 * 60
+    )
     return max(
         CSRF_BROWSER_COOKIE_MAX_AGE_SECONDS,
         refresh_seconds,
@@ -235,7 +242,7 @@ def set_csrf_browser_cookie(
         httponly=True,
         samesite="lax",
         secure=settings.is_production,
-        max_age=_csrf_browser_cookie_max_age_seconds(settings),
+        max_age=refresh_csrf_max_age_seconds(settings),
         path="/",
     )
 

--- a/src/litoral_trace/web/csrf.py
+++ b/src/litoral_trace/web/csrf.py
@@ -201,6 +201,21 @@ def get_or_create_csrf_browser_nonce(
     return create_csrf_browser_nonce(), True
 
 
+def _csrf_browser_cookie_max_age_seconds(settings: Any) -> int:
+    """Keep the browser CSRF binding usable for the full refresh-session TTL."""
+
+    try:
+        refresh_days = int(settings.jwt.refresh_token_expire_days)
+    except (AttributeError, TypeError, ValueError):
+        refresh_days = 0
+
+    refresh_seconds = max(0, refresh_days) * 24 * 60 * 60
+    return max(
+        CSRF_BROWSER_COOKIE_MAX_AGE_SECONDS,
+        refresh_seconds,
+    )
+
+
 def set_csrf_browser_cookie(
     response: Response,
     browser_nonce: str,
@@ -220,7 +235,7 @@ def set_csrf_browser_cookie(
         httponly=True,
         samesite="lax",
         secure=settings.is_production,
-        max_age=CSRF_BROWSER_COOKIE_MAX_AGE_SECONDS,
+        max_age=_csrf_browser_cookie_max_age_seconds(settings),
         path="/",
     )
 

--- a/src/litoral_trace/web/eudr_dds_candidate.py
+++ b/src/litoral_trace/web/eudr_dds_candidate.py
@@ -140,7 +140,7 @@ def _view_payload(conformance) -> dict[str, Any]:
                 "risk_conclusion": candidate.risk_conclusion,
                 "risk_assessment_reference": candidate.risk_assessment_reference or "",
                 "risk_assessed_at": (
-                    candidate.risk_assessed_at.isoformat(timespec="minutes")
+                    candidate.risk_assessed_at.strftime("%Y-%m-%dT%H:%M")
                     if candidate.risk_assessed_at
                     else ""
                 ),
@@ -248,8 +248,7 @@ async def render_eudr_acceptance_candidate(
 )
 async def update_eudr_acceptance_candidate(request: Request):
     user, denied = get_html_route_user(
-        request,
-        required_permission=Permission.TRACEABILITY_EVIDENCE,
+        request, required_permission=Permission.TRACEABILITY_EVIDENCE,
     )
     if denied is not None:
         return denied

--- a/src/litoral_trace/web/middleware.py
+++ b/src/litoral_trace/web/middleware.py
@@ -1,8 +1,6 @@
 """Pure-ASGI CSRF enforcement for unsafe API requests authenticated by cookies."""
 from __future__ import annotations
 
-from typing import Any
-
 from starlette.requests import Request
 from starlette.responses import JSONResponse
 from starlette.types import (
@@ -16,9 +14,7 @@ from litoral_trace.auth.sessions import (
     ACCESS_TOKEN_COOKIE_KEY,
     REFRESH_TOKEN_COOKIE_KEY,
 )
-from litoral_trace.auth.tokens import (
-    verify_jwt_token,
-)
+from litoral_trace.auth.tokens import verify_jwt_token
 from litoral_trace.web.csrf import (
     CSRF_HEADER_NAME,
     csrf_subject_from_access_payload,
@@ -107,6 +103,22 @@ def validate_cookie_csrf_request(
     if not csrf_token or browser_nonce is None:
         return "csrf_missing"
 
+    # Session renewal deliberately accepts a dedicated token bound only to the
+    # HttpOnly browser nonce. This keeps refresh possible after a suspended tab
+    # outlives the short access JWT, without exposing or weakening the refresh
+    # cookie. The signed token still has a bounded lifetime and same-origin UI
+    # code must possess it.
+    if (
+        refresh_token
+        and path == "/api/v1/auth/refresh"
+        and verify_csrf_browser_binding(
+            csrf_token,
+            browser_nonce=browser_nonce,
+            secret_key=secret_key,
+        )
+    ):
+        return None
+
     if access_token:
         payload = verify_jwt_token(
             access_token,
@@ -173,10 +185,8 @@ class CookieApiCsrfMiddleware:
 
         request = Request(scope)
 
-        error_code = (
-            validate_cookie_csrf_request(
-                request
-            )
+        error_code = validate_cookie_csrf_request(
+            request
         )
 
         if error_code is None:

--- a/src/litoral_trace/web/middleware.py
+++ b/src/litoral_trace/web/middleware.py
@@ -104,21 +104,21 @@ def validate_cookie_csrf_request(
     if not csrf_token or browser_nonce is None:
         return "csrf_missing"
 
-    # Session renewal deliberately accepts a dedicated token bound only to the
-    # HttpOnly browser nonce. Its verification window matches the refresh-session
-    # TTL so a legitimately suspended tab can still renew after the one-hour
-    # regular form-CSRF window, without weakening CSRF on any other API endpoint.
-    if (
-        refresh_token
-        and path == "/api/v1/auth/refresh"
-        and verify_csrf_browser_binding(
+    # Session renewal accepts only the dedicated anonymous-subject CSRF token,
+    # signed and bound to the HttpOnly browser nonce. Its verification window
+    # matches the refresh-session TTL so a legitimately suspended tab can renew
+    # after the one-hour regular form-CSRF window. A normal session-bound CSRF
+    # token is deliberately not interchangeable with this refresh capability.
+    if refresh_token and path == "/api/v1/auth/refresh":
+        if verify_csrf_token(
             csrf_token,
+            subject=None,
             browser_nonce=browser_nonce,
             max_age_seconds=refresh_csrf_max_age_seconds(),
             secret_key=secret_key,
-        )
-    ):
-        return None
+        ):
+            return None
+        return "csrf_invalid"
 
     if access_token:
         payload = verify_jwt_token(

--- a/src/litoral_trace/web/middleware.py
+++ b/src/litoral_trace/web/middleware.py
@@ -19,6 +19,7 @@ from litoral_trace.web.csrf import (
     CSRF_HEADER_NAME,
     csrf_subject_from_access_payload,
     get_csrf_browser_nonce,
+    refresh_csrf_max_age_seconds,
     verify_csrf_browser_binding,
     verify_csrf_token,
 )
@@ -104,16 +105,16 @@ def validate_cookie_csrf_request(
         return "csrf_missing"
 
     # Session renewal deliberately accepts a dedicated token bound only to the
-    # HttpOnly browser nonce. This keeps refresh possible after a suspended tab
-    # outlives the short access JWT, without exposing or weakening the refresh
-    # cookie. The signed token still has a bounded lifetime and same-origin UI
-    # code must possess it.
+    # HttpOnly browser nonce. Its verification window matches the refresh-session
+    # TTL so a legitimately suspended tab can still renew after the one-hour
+    # regular form-CSRF window, without weakening CSRF on any other API endpoint.
     if (
         refresh_token
         and path == "/api/v1/auth/refresh"
         and verify_csrf_browser_binding(
             csrf_token,
             browser_nonce=browser_nonce,
+            max_age_seconds=refresh_csrf_max_age_seconds(),
             secret_key=secret_key,
         )
     ):

--- a/src/litoral_trace/web/runtime.py
+++ b/src/litoral_trace/web/runtime.py
@@ -208,7 +208,12 @@ def render_web_template(
     )
     response.headers["Pragma"] = "no-cache"
 
-    if created:
+    # Authenticated renders are also the synchronization heartbeat used by the
+    # browser session-renewal layer. Re-issuing the same HttpOnly nonce only
+    # slides its Max-Age; it does not expose or rotate the binding. This keeps
+    # the 8-hour browser binding alive while an authenticated application tab is
+    # actively renewing, without extending anonymous cookies unnecessarily.
+    if created or user is not None:
         set_csrf_browser_cookie(
             response,
             browser_nonce,

--- a/src/litoral_trace/web/runtime.py
+++ b/src/litoral_trace/web/runtime.py
@@ -132,8 +132,13 @@ def get_authenticated_html_user(
             exc.status_code
             == status.HTTP_401_UNAUTHORIZED
         ):
+            # An invalid/expired short access JWT does not prove the long-lived
+            # refresh session is invalid. Do not erase refresh or browser-CSRF
+            # cookies here: an in-flight keepalive refresh may be completing
+            # during this navigation, and explicit logout/revocation remains the
+            # authority that clears the full browser session.
             return None, redirect_to_login(
-                clear_cookies=True
+                clear_cookies=False
             )
 
         if (
@@ -209,10 +214,9 @@ def render_web_template(
     response.headers["Pragma"] = "no-cache"
 
     # Authenticated renders are also the synchronization heartbeat used by the
-    # browser session-renewal layer. Re-issuing the same HttpOnly nonce only
-    # slides its Max-Age; it does not expose or rotate the binding. This keeps
-    # the 8-hour browser binding alive while an authenticated application tab is
-    # actively renewing, without extending anonymous cookies unnecessarily.
+    # browser session-renewal layer. Re-issuing the same HttpOnly nonce slides
+    # its Max-Age without exposing or rotating the binding; its lifetime is
+    # aligned to the refresh-session TTL and refreshed during active use.
     if created or user is not None:
         set_csrf_browser_cookie(
             response,

--- a/src/litoral_trace/web/shipment_phytosanitary_case.py
+++ b/src/litoral_trace/web/shipment_phytosanitary_case.py
@@ -95,7 +95,7 @@ def _view_payload(readiness) -> dict[str, Any]:
                 "certification_mode": case.certification_mode,
                 "requirements_reference": case.requirements_reference or "",
                 "requirements_checked_at": (
-                    case.requirements_checked_at.isoformat(timespec="minutes")
+                    case.requirements_checked_at.strftime("%Y-%m-%dT%H:%M")
                     if case.requirements_checked_at
                     else ""
                 ),

--- a/src/litoral_trace/web/traceability_evidence.py
+++ b/src/litoral_trace/web/traceability_evidence.py
@@ -186,7 +186,8 @@ def _present_workspace(
     subjects = service.list_subjects(organization_id=user.organization_id)
     subject_views = tuple(_present_subject(subject) for subject in subjects)
     valid_keys = {subject["key"] for subject in subject_views}
-    selected_key = selected_key if selected_key in valid_keys else (subject_views[0]["key"] if subject_views else None)
+    requested_key = str(selected_key or "").strip()
+    selected_key = requested_key if requested_key in valid_keys else None
     selected_type, selected_reference = _parse_subject_key(selected_key)
 
     evidence = service.list_evidence(

--- a/tests/test_frontend_p2feb_unittest.py
+++ b/tests/test_frontend_p2feb_unittest.py
@@ -288,19 +288,15 @@ def test_bearer_api_mutation_does_not_gain_browser_csrf_requirement():
     )
 
 
-def test_refresh_cookie_mutation_accepts_browser_binding_without_access_cookie():
-    subject = CsrfSubject(
-        username="user",
-        organization_id=7,
-        session_id=11,
-    )
-
+def test_refresh_cookie_mutation_accepts_dedicated_browser_binding_without_access_cookie():
     browser_nonce = (
         "e" * 43
     )
 
+    # Refresh has its own anonymous-subject capability. A normal session-bound
+    # CSRF token is intentionally not interchangeable with this token.
     csrf_token = create_csrf_token(
-        subject=subject,
+        subject=None,
         browser_nonce=browser_nonce,
         nonce="n" * 24,
         secret_key=_TEST_SECRET,

--- a/tests/test_pre_pilot_hardening_unittest.py
+++ b/tests/test_pre_pilot_hardening_unittest.py
@@ -238,6 +238,7 @@ def test_base_loads_pre_pilot_hardening_layers() -> None:
     assert "lt-refresh-csrf-token" in base
     assert "lt-session-refresh-after" in base
     assert "lt-session-access-expires-at" in base
+    assert "lt-session-server-now" in base
     assert "/src/js/session-renewal.js" in base
     assert "/src/js/evidence-context.js" in base
     assert "/src/js/datetime-local.js" in base
@@ -254,14 +255,16 @@ def test_session_renewal_preserves_forms_and_rotates_rendered_csrf() -> None:
     assert "window.sessionStorage" not in source
 
 
-def test_session_renewal_uses_verified_absolute_expiry_not_page_load_interval() -> None:
+def test_session_renewal_uses_verified_server_relative_expiry_not_client_clock() -> None:
     source = (STATIC_JS / "session-renewal.js").read_text(encoding="utf-8")
     assert 'ACCESS_EXPIRES_AT_META_NAME = "lt-session-access-expires-at"' in source
+    assert 'SERVER_NOW_META_NAME = "lt-session-server-now"' in source
     assert "readEpochMilliseconds(ACCESS_EXPIRES_AT_META_NAME)" in source
-    assert "return expiryMs - intervalMs" in source
-    assert "scheduleRenewal" in source
+    assert "readEpochMilliseconds(SERVER_NOW_META_NAME)" in source
+    assert "return Math.max(0, expiryMs - serverNowMs - intervalMs)" in source
+    assert "renewalDeadlineMonotonicMs = performance.now() + delay" in source
+    assert "performance.now() >= renewalDeadlineMonotonicMs" in source
     assert "window.setTimeout" in source
-    assert "Date.now() >= dueAt" in source
     assert "window.setInterval" not in source
 
 

--- a/tests/test_pre_pilot_hardening_unittest.py
+++ b/tests/test_pre_pilot_hardening_unittest.py
@@ -122,13 +122,13 @@ def test_datetime_local_guard_handles_timestamptz_rendering_without_timezone_shi
 def test_business_language_layer_translates_internal_codes_without_mutating_values() -> None:
     source = (STATIC_JS / "business-language.js").read_text(encoding="utf-8")
     required_pairs = (
-        ('"CONFORMANCE_READY", "Preparado para conformidad"',),
-        ('"POSTED", "Contabilizado"',),
-        ('"DISPATCHED", "Despachado"',),
-        ('"RISK_CONCLUSION", "Conclusión de riesgo"',),
-        ('"RISK_ASSESSED_AT", "Fecha de evaluación de riesgo"',),
+        '"CONFORMANCE_READY", "Preparado para conformidad"',
+        '"POSTED", "Contabilizado"',
+        '"DISPATCHED", "Despachado"',
+        '"RISK_CONCLUSION", "Conclusión de riesgo"',
+        '"RISK_ASSESSED_AT", "Fecha de evaluación de riesgo"',
     )
-    for (pair,) in required_pairs:
+    for pair in required_pairs:
         assert pair in source
     assert "node.nodeValue = translated" in source
     assert ".value =" not in source

--- a/tests/test_pre_pilot_hardening_unittest.py
+++ b/tests/test_pre_pilot_hardening_unittest.py
@@ -1,9 +1,20 @@
 from __future__ import annotations
 
+from datetime import datetime, timezone
 from pathlib import Path
+from types import SimpleNamespace
+from uuid import uuid4
 
 from starlette.requests import Request
 
+from litoral_trace.auth.sessions import (
+    ACCESS_TOKEN_COOKIE_KEY,
+    REFRESH_TOKEN_COOKIE_KEY,
+)
+from litoral_trace.services.traceability_evidence import EvidenceSubjectChoice
+from litoral_trace.web import eudr_dds_candidate as eudr_web
+from litoral_trace.web import shipment_phytosanitary_case as phytosanitary_web
+from litoral_trace.web import traceability_evidence as evidence_web
 from litoral_trace.web.csrf import (
     CSRF_BROWSER_COOKIE_KEY,
     CSRF_HEADER_NAME,
@@ -11,10 +22,6 @@ from litoral_trace.web.csrf import (
     create_csrf_token,
 )
 from litoral_trace.web.middleware import validate_cookie_csrf_request
-from litoral_trace.auth.sessions import (
-    ACCESS_TOKEN_COOKIE_KEY,
-    REFRESH_TOKEN_COOKIE_KEY,
-)
 
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -129,6 +136,46 @@ def test_evidence_context_never_silently_enables_default_subject_mutations() -> 
     assert "button.disabled = true" in source
     assert "target.searchParams.set(SHIPMENT_PARAM, code)" in source
     assert "return option?.value" in source
+    assert "selectorContainsSubject" in source
+    assert "params.delete(SUBJECT_PARAM)" in source
+    assert "data-evidence-placeholder" in source
+
+
+def test_evidence_workspace_fails_closed_for_missing_or_invalid_subject(monkeypatch) -> None:
+    subject = EvidenceSubjectChoice(
+        subject_type="SOURCE_LOTE",
+        reference="RODAL-DEMO-001",
+        label="RODAL-DEMO-001",
+        secondary="PROV-001 · Pino",
+        status="ACTIVE",
+    )
+
+    class FakeService:
+        def list_subjects(self, *, organization_id: int):
+            assert organization_id == 1
+            return (subject,)
+
+        def list_evidence(self, **kwargs):
+            raise AssertionError("No debe consultar evidencia sin un subject confirmado")
+
+        def coverage(self, *, organization_id: int):
+            assert organization_id == 1
+            return SimpleNamespace(
+                subjects_with_evidence=0,
+                total_subjects=1,
+                percentage=0,
+                by_subject_type={},
+            )
+
+    monkeypatch.setattr(evidence_web, "_service", lambda: FakeService())
+    monkeypatch.setattr(evidence_web, "has_permission", lambda *_args, **_kwargs: False)
+    user = SimpleNamespace(organization_id=1)
+
+    for requested in (None, "", "SHIPMENT|stale-or-cross-context"):
+        view = evidence_web._present_workspace(user=user, selected_key=requested)
+        assert view["selected_key"] is None
+        assert view["selected_subject"] is None
+        assert view["evidence"] == ()
 
 
 def test_datetime_local_guard_handles_timestamptz_rendering_without_timezone_shift() -> None:
@@ -137,6 +184,84 @@ def test_datetime_local_guard_handles_timestamptz_rendering_without_timezone_shi
     assert "\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}" in source
     assert 'getAttribute("value")' in source
     assert "getTimezoneOffset" not in source
+
+
+def test_phytosanitary_datetime_round_trip_renders_valid_datetime_local() -> None:
+    persisted = datetime(2026, 8, 26, 17, 42, tzinfo=timezone.utc)
+    case = SimpleNamespace(
+        certification_mode="PAPER",
+        requirements_reference="SENASA-REF",
+        requirements_checked_at=persisted,
+        cert_pov_reference="CERT-POV-1",
+        certificate_number="PHYTO-1",
+        ephyto_reference=None,
+        notes=None,
+    )
+    readiness = SimpleNamespace(
+        shipment_code="EXP-001",
+        shipment_public_id=uuid4(),
+        state="READY",
+        ready=True,
+        certification_mode="PAPER",
+        requirements=(),
+        missing=(),
+        evidence_types=(),
+        phytosanitary_case=case,
+    )
+
+    rendered = phytosanitary_web._view_payload(readiness)["case"]["requirements_checked_at"]
+    assert rendered == "2026-08-26T17:42"
+    assert "+00:00" not in rendered
+    assert not rendered.endswith("Z")
+
+
+def test_eudr_risk_datetime_round_trip_renders_valid_datetime_local() -> None:
+    persisted = datetime(2026, 8, 26, 18, 7, tzinfo=timezone.utc)
+    candidate = SimpleNamespace(
+        activity_type="EXPORT",
+        commodity_profile="WOOD",
+        operator_name="Operador UE",
+        operator_address="Dirección",
+        operator_country_code="DE",
+        operator_eori="EORI1",
+        hs_code="4407",
+        trade_name="Madera aserrada",
+        product_description="Producto",
+        common_species_name="Pino",
+        scientific_species_name="Pinus elliottii",
+        net_mass_kg="1000",
+        production_country_code="AR",
+        production_date_from=None,
+        production_date_to=None,
+        relies_on_previous_dds=False,
+        previous_dds_reference=None,
+        previous_dds_verification=None,
+        risk_conclusion="NO_OR_NEGLIGIBLE_RISK",
+        risk_assessment_reference="RISK-1",
+        risk_assessed_at=persisted,
+        spec_profile="EUDR_V3",
+        spec_fingerprint_sha256="abc",
+        notes=None,
+    )
+    conformance = SimpleNamespace(
+        shipment_code="EXP-001",
+        shipment_public_id=uuid4(),
+        state="CONFORMANCE_READY",
+        ready=True,
+        missing=(),
+        lineage_complete=True,
+        requirements=(),
+        plots=(),
+        payload_sha256="payload",
+        target_environment="ACCEPTANCE",
+        legal_effect="NON_LEGAL_ACCEPTANCE",
+        candidate=candidate,
+    )
+
+    rendered = eudr_web._view_payload(conformance)["candidate"]["risk_assessed_at"]
+    assert rendered == "2026-08-26T18:07"
+    assert "+00:00" not in rendered
+    assert not rendered.endswith("Z")
 
 
 def test_business_language_layer_translates_internal_codes_without_mutating_values() -> None:

--- a/tests/test_pre_pilot_hardening_unittest.py
+++ b/tests/test_pre_pilot_hardening_unittest.py
@@ -1,0 +1,134 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from starlette.requests import Request
+
+from litoral_trace.web.csrf import (
+    CSRF_BROWSER_COOKIE_KEY,
+    CSRF_HEADER_NAME,
+    create_csrf_browser_nonce,
+    create_csrf_token,
+)
+from litoral_trace.web.middleware import validate_cookie_csrf_request
+from litoral_trace.auth.sessions import (
+    ACCESS_TOKEN_COOKIE_KEY,
+    REFRESH_TOKEN_COOKIE_KEY,
+)
+
+
+ROOT = Path(__file__).resolve().parents[1]
+STATIC_JS = ROOT / "src" / "litoral_trace" / "static" / "src" / "js"
+TEMPLATES = ROOT / "src" / "litoral_trace" / "templates"
+SECRET = "pre-pilot-test-secret-key-with-at-least-32-chars"
+
+
+def _request(*, browser_nonce: str, csrf_token: str, access_token: str = "expired") -> Request:
+    cookies = "; ".join(
+        (
+            f"{ACCESS_TOKEN_COOKIE_KEY}={access_token}",
+            f"{REFRESH_TOKEN_COOKIE_KEY}=refresh-cookie-value",
+            f"{CSRF_BROWSER_COOKIE_KEY}={browser_nonce}",
+        )
+    )
+    scope = {
+        "type": "http",
+        "http_version": "1.1",
+        "method": "POST",
+        "scheme": "https",
+        "path": "/api/v1/auth/refresh",
+        "raw_path": b"/api/v1/auth/refresh",
+        "query_string": b"",
+        "headers": [
+            (b"cookie", cookies.encode("utf-8")),
+            (CSRF_HEADER_NAME.lower().encode("ascii"), csrf_token.encode("utf-8")),
+        ],
+        "client": ("127.0.0.1", 12345),
+        "server": ("testserver", 443),
+        "root_path": "",
+    }
+    return Request(scope)
+
+
+def test_refresh_accepts_browser_bound_csrf_after_access_token_is_unusable() -> None:
+    browser_nonce = create_csrf_browser_nonce()
+    refresh_csrf = create_csrf_token(
+        subject=None,
+        browser_nonce=browser_nonce,
+        secret_key=SECRET,
+    )
+
+    assert (
+        validate_cookie_csrf_request(
+            _request(browser_nonce=browser_nonce, csrf_token=refresh_csrf),
+            secret_key=SECRET,
+        )
+        is None
+    )
+
+
+def test_refresh_rejects_browser_token_bound_to_another_browser() -> None:
+    browser_nonce = create_csrf_browser_nonce()
+    other_nonce = create_csrf_browser_nonce()
+    refresh_csrf = create_csrf_token(
+        subject=None,
+        browser_nonce=other_nonce,
+        secret_key=SECRET,
+    )
+
+    assert validate_cookie_csrf_request(
+        _request(browser_nonce=browser_nonce, csrf_token=refresh_csrf),
+        secret_key=SECRET,
+    ) == "csrf_invalid"
+
+
+def test_base_loads_pre_pilot_hardening_layers() -> None:
+    base = (TEMPLATES / "base.html").read_text(encoding="utf-8")
+    assert "lt-refresh-csrf-token" in base
+    assert "lt-session-refresh-after" in base
+    assert "/src/js/session-renewal.js" in base
+    assert "/src/js/evidence-context.js" in base
+    assert "/src/js/datetime-local.js" in base
+    assert "/src/js/business-language.js" in base
+
+
+def test_session_renewal_preserves_forms_and_rotates_rendered_csrf() -> None:
+    source = (STATIC_JS / "session-renewal.js").read_text(encoding="utf-8")
+    assert 'input[name="csrf_token"]' in source
+    assert "window.location.href" in source
+    assert "DOMParser" in source
+    assert "credentials: \"same-origin\"" in source
+    assert "localStorage" not in source
+    assert "sessionStorage" not in source
+
+
+def test_evidence_context_never_silently_enables_default_subject_mutations() -> None:
+    source = (STATIC_JS / "evidence-context.js").read_text(encoding="utf-8")
+    assert "SHIPMENT|" in source
+    assert "Confirmá el eslabón antes de vincular" in source
+    assert 'form[action="/evidence/link"]' in source
+    assert 'form[action="/evidence/upload-link"]' in source
+    assert "button.disabled = true" in source
+
+
+def test_datetime_local_guard_handles_timestamptz_rendering_without_timezone_shift() -> None:
+    source = (STATIC_JS / "datetime-local.js").read_text(encoding="utf-8")
+    assert 'input[type="datetime-local"]' in source
+    assert "\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}" in source
+    assert "getAttribute(\"value\")" in source
+    assert "getTimezoneOffset" not in source
+
+
+def test_business_language_layer_translates_internal_codes_without_mutating_values() -> None:
+    source = (STATIC_JS / "business-language.js").read_text(encoding="utf-8")
+    required_pairs = (
+        ('"CONFORMANCE_READY", "Preparado para conformidad"',),
+        ('"POSTED", "Contabilizado"',),
+        ('"DISPATCHED", "Despachado"',),
+        ('"RISK_CONCLUSION", "Conclusión de riesgo"',),
+        ('"RISK_ASSESSED_AT", "Fecha de evaluación de riesgo"',),
+    )
+    for (pair,) in required_pairs:
+        assert pair in source
+    assert "node.nodeValue = translated" in source
+    assert ".value =" not in source

--- a/tests/test_pre_pilot_hardening_unittest.py
+++ b/tests/test_pre_pilot_hardening_unittest.py
@@ -66,6 +66,28 @@ def _request(
     return Request(scope)
 
 
+def _template_request(access_token: str) -> Request:
+    scope = {
+        "type": "http",
+        "http_version": "1.1",
+        "method": "GET",
+        "scheme": "https",
+        "path": "/dashboard",
+        "raw_path": b"/dashboard",
+        "query_string": b"",
+        "headers": [
+            (
+                b"cookie",
+                f"{ACCESS_TOKEN_COOKIE_KEY}={access_token}".encode("utf-8"),
+            )
+        ],
+        "client": ("127.0.0.1", 12345),
+        "server": ("testserver", 443),
+        "root_path": "",
+    }
+    return Request(scope)
+
+
 def test_refresh_accepts_browser_bound_csrf_after_access_token_is_unusable() -> None:
     browser_nonce = create_csrf_browser_nonce()
     refresh_csrf = create_csrf_token(
@@ -170,10 +192,52 @@ def test_session_refresh_cadence_precedes_short_and_default_access_expiry(monkey
     assert context_web._session_refresh_after_seconds() < 30 * 60
 
 
+def test_access_expiry_metadata_is_bound_to_exact_hydrated_session(monkeypatch) -> None:
+    user = SimpleNamespace(
+        username="operator",
+        organization_id=17,
+        session_id=42,
+    )
+    request = _template_request("opaque-access-token")
+
+    valid_payload = {
+        "sub": "operator",
+        "org_id": 17,
+        "sid": 42,
+        "exp": 2_000_000_000,
+    }
+    monkeypatch.setattr(
+        context_web,
+        "verify_jwt_token",
+        lambda *_args, **_kwargs: valid_payload,
+    )
+    assert context_web._session_access_expires_at_epoch(
+        request,
+        user=user,
+    ) == 2_000_000_000
+
+    for mismatched_payload in (
+        {**valid_payload, "sub": "other"},
+        {**valid_payload, "org_id": 18},
+        {**valid_payload, "sid": 43},
+        {**valid_payload, "exp": 0},
+    ):
+        monkeypatch.setattr(
+            context_web,
+            "verify_jwt_token",
+            lambda *_args, payload=mismatched_payload, **_kwargs: payload,
+        )
+        assert context_web._session_access_expires_at_epoch(
+            request,
+            user=user,
+        ) is None
+
+
 def test_base_loads_pre_pilot_hardening_layers() -> None:
     base = (TEMPLATES / "base.html").read_text(encoding="utf-8")
     assert "lt-refresh-csrf-token" in base
     assert "lt-session-refresh-after" in base
+    assert "lt-session-access-expires-at" in base
     assert "/src/js/session-renewal.js" in base
     assert "/src/js/evidence-context.js" in base
     assert "/src/js/datetime-local.js" in base
@@ -188,6 +252,17 @@ def test_session_renewal_preserves_forms_and_rotates_rendered_csrf() -> None:
     assert 'credentials: "same-origin"' in source
     assert "window.localStorage" not in source
     assert "window.sessionStorage" not in source
+
+
+def test_session_renewal_uses_verified_absolute_expiry_not_page_load_interval() -> None:
+    source = (STATIC_JS / "session-renewal.js").read_text(encoding="utf-8")
+    assert 'ACCESS_EXPIRES_AT_META_NAME = "lt-session-access-expires-at"' in source
+    assert "readEpochMilliseconds(ACCESS_EXPIRES_AT_META_NAME)" in source
+    assert "return expiryMs - intervalMs" in source
+    assert "scheduleRenewal" in source
+    assert "window.setTimeout" in source
+    assert "Date.now() >= dueAt" in source
+    assert "window.setInterval" not in source
 
 
 def test_session_renewal_serializes_tabs_and_rehydrates_peer_csrf() -> None:

--- a/tests/test_pre_pilot_hardening_unittest.py
+++ b/tests/test_pre_pilot_hardening_unittest.py
@@ -97,9 +97,27 @@ def test_session_renewal_preserves_forms_and_rotates_rendered_csrf() -> None:
     assert 'input[name="csrf_token"]' in source
     assert "window.location.href" in source
     assert "DOMParser" in source
-    assert "credentials: \"same-origin\"" in source
-    assert "localStorage" not in source
-    assert "sessionStorage" not in source
+    assert 'credentials: "same-origin"' in source
+    assert "window.localStorage" not in source
+    assert "window.sessionStorage" not in source
+
+
+def test_session_renewal_serializes_tabs_and_rehydrates_peer_csrf() -> None:
+    source = (STATIC_JS / "session-renewal.js").read_text(encoding="utf-8")
+    assert "navigator.locks.request" in source
+    assert "BroadcastChannel" in source
+    assert 'type: "refreshed"' in source
+    assert "synchronizeFromPeer" in source
+    assert "synchronizeSecurityMeta" in source
+    assert "announceRefresh(completedAt)" in source
+
+
+def test_live_csrf_bridge_overrides_stale_page_headers_after_rotation() -> None:
+    source = (STATIC_JS / "session-renewal.js").read_text(encoding="utf-8")
+    assert "installLiveCsrfFetchBridge" in source
+    assert "headers.set(CSRF_HEADER_NAME, token)" in source
+    assert "requestUrl.pathname === REFRESH_URL" in source
+    assert "readMeta(CSRF_META_NAME)" in source
 
 
 def test_evidence_context_never_silently_enables_default_subject_mutations() -> None:
@@ -109,13 +127,15 @@ def test_evidence_context_never_silently_enables_default_subject_mutations() -> 
     assert 'form[action="/evidence/link"]' in source
     assert 'form[action="/evidence/upload-link"]' in source
     assert "button.disabled = true" in source
+    assert "target.searchParams.set(SHIPMENT_PARAM, code)" in source
+    assert "return option?.value" in source
 
 
 def test_datetime_local_guard_handles_timestamptz_rendering_without_timezone_shift() -> None:
     source = (STATIC_JS / "datetime-local.js").read_text(encoding="utf-8")
     assert 'input[type="datetime-local"]' in source
     assert "\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}" in source
-    assert "getAttribute(\"value\")" in source
+    assert 'getAttribute("value")' in source
     assert "getTimezoneOffset" not in source
 
 
@@ -132,3 +152,6 @@ def test_business_language_layer_translates_internal_codes_without_mutating_valu
         assert pair in source
     assert "node.nodeValue = translated" in source
     assert ".value =" not in source
+    assert "replaceAll" not in source
+    assert "trimmed.endsWith(suffix)" in source
+    assert "PRESENTATION_LABELS.get(trimmed)" in source

--- a/tests/test_pre_pilot_hardening_unittest.py
+++ b/tests/test_pre_pilot_hardening_unittest.py
@@ -5,13 +5,16 @@ from pathlib import Path
 from types import SimpleNamespace
 from uuid import uuid4
 
+from fastapi import Response
 from starlette.requests import Request
 
+from litoral_trace.api.auth import _set_auth_cookies
 from litoral_trace.auth.sessions import (
     ACCESS_TOKEN_COOKIE_KEY,
     REFRESH_TOKEN_COOKIE_KEY,
 )
 from litoral_trace.services.traceability_evidence import EvidenceSubjectChoice
+from litoral_trace.web import context as context_web
 from litoral_trace.web import eudr_dds_candidate as eudr_web
 from litoral_trace.web import shipment_phytosanitary_case as phytosanitary_web
 from litoral_trace.web import traceability_evidence as evidence_web
@@ -87,6 +90,60 @@ def test_refresh_rejects_browser_token_bound_to_another_browser() -> None:
         _request(browser_nonce=browser_nonce, csrf_token=refresh_csrf),
         secret_key=SECRET,
     ) == "csrf_invalid"
+
+
+def test_production_auth_cookies_are_http_only_secure_lax_and_ttl_bounded() -> None:
+    response = Response()
+    settings = SimpleNamespace(
+        is_production=True,
+        jwt=SimpleNamespace(
+            access_token_expire_seconds=30 * 60,
+            refresh_token_expire_days=30,
+        ),
+    )
+
+    _set_auth_cookies(
+        response=response,
+        access_token="access-token",
+        refresh_token="refresh-token",
+        settings=settings,
+    )
+
+    headers = response.headers.getlist("set-cookie")
+    access_header = next(
+        header for header in headers
+        if header.startswith(f"{ACCESS_TOKEN_COOKIE_KEY}=")
+    )
+    refresh_header = next(
+        header for header in headers
+        if header.startswith(f"{REFRESH_TOKEN_COOKIE_KEY}=")
+    )
+
+    for header in (access_header, refresh_header):
+        lowered = header.lower()
+        assert "httponly" in lowered
+        assert "secure" in lowered
+        assert "samesite=lax" in lowered
+        assert "path=/" in lowered
+
+    assert "max-age=1800" in access_header.lower()
+    assert "max-age=2592000" in refresh_header.lower()
+
+
+def test_session_refresh_cadence_precedes_short_and_default_access_expiry(monkeypatch) -> None:
+    short_settings = SimpleNamespace(
+        jwt=SimpleNamespace(access_token_expire_seconds=4 * 60)
+    )
+    monkeypatch.setattr(context_web, "get_settings", lambda: short_settings)
+    assert context_web._session_refresh_after_seconds() == 2 * 60
+    assert context_web._session_refresh_after_seconds() < 4 * 60
+
+    default_settings = SimpleNamespace(
+        jwt=SimpleNamespace(access_token_expire_seconds=30 * 60)
+    )
+    monkeypatch.setattr(context_web, "get_settings", lambda: default_settings)
+    assert context_web._session_refresh_after_seconds() == 10 * 60
+    assert context_web._session_refresh_after_seconds() < 30 * 60
 
 
 def test_base_loads_pre_pilot_hardening_layers() -> None:
@@ -268,6 +325,7 @@ def test_business_language_layer_translates_internal_codes_without_mutating_valu
     source = (STATIC_JS / "business-language.js").read_text(encoding="utf-8")
     required_pairs = (
         '"CONFORMANCE_READY", "Preparado para conformidad"',
+        '"DDS_CANDIDATE", "Candidato DDS configurado"',
         '"POSTED", "Contabilizado"',
         '"DISPATCHED", "Despachado"',
         '"RISK_CONCLUSION", "Conclusión de riesgo"',

--- a/tests/test_pre_pilot_hardening_unittest.py
+++ b/tests/test_pre_pilot_hardening_unittest.py
@@ -23,6 +23,8 @@ from litoral_trace.web.csrf import (
     CSRF_HEADER_NAME,
     create_csrf_browser_nonce,
     create_csrf_token,
+    refresh_csrf_max_age_seconds,
+    verify_csrf_browser_binding,
 )
 from litoral_trace.web.middleware import validate_cookie_csrf_request
 
@@ -30,6 +32,7 @@ from litoral_trace.web.middleware import validate_cookie_csrf_request
 ROOT = Path(__file__).resolve().parents[1]
 STATIC_JS = ROOT / "src" / "litoral_trace" / "static" / "src" / "js"
 TEMPLATES = ROOT / "src" / "litoral_trace" / "templates"
+WEB = ROOT / "src" / "litoral_trace" / "web"
 SECRET = "pre-pilot-test-secret-key-with-at-least-32-chars"
 
 
@@ -136,6 +139,44 @@ def test_browser_only_refresh_csrf_is_rejected_on_other_unsafe_api_paths() -> No
         ),
         secret_key=SECRET,
     ) == "csrf_invalid"
+
+
+def test_refresh_csrf_window_matches_refresh_session_ttl() -> None:
+    settings = SimpleNamespace(
+        jwt=SimpleNamespace(refresh_token_expire_days=30)
+    )
+    max_age = refresh_csrf_max_age_seconds(settings)
+    assert max_age == 30 * 24 * 60 * 60
+
+    browser_nonce = create_csrf_browser_nonce()
+    issued_at = 1_000_000
+    refresh_csrf = create_csrf_token(
+        subject=None,
+        browser_nonce=browser_nonce,
+        now_epoch=issued_at,
+        secret_key=SECRET,
+    )
+
+    # The regular one-hour form-CSRF policy remains short-lived.
+    assert not verify_csrf_browser_binding(
+        refresh_csrf,
+        browser_nonce=browser_nonce,
+        now_epoch=issued_at + (2 * 60 * 60),
+        secret_key=SECRET,
+    )
+    # Only refresh explicitly opts into the refresh-session-sized window.
+    assert verify_csrf_browser_binding(
+        refresh_csrf,
+        browser_nonce=browser_nonce,
+        now_epoch=issued_at + (2 * 60 * 60),
+        max_age_seconds=max_age,
+        secret_key=SECRET,
+    )
+
+    csrf_source = (WEB / "csrf.py").read_text(encoding="utf-8")
+    middleware_source = (WEB / "middleware.py").read_text(encoding="utf-8")
+    assert "max_age=refresh_csrf_max_age_seconds(settings)" in csrf_source
+    assert "max_age_seconds=refresh_csrf_max_age_seconds()" in middleware_source
 
 
 def test_production_auth_cookies_are_http_only_secure_lax_and_ttl_bounded() -> None:
@@ -262,10 +303,29 @@ def test_session_renewal_uses_verified_server_relative_expiry_not_client_clock()
     assert "readEpochMilliseconds(ACCESS_EXPIRES_AT_META_NAME)" in source
     assert "readEpochMilliseconds(SERVER_NOW_META_NAME)" in source
     assert "return Math.max(0, expiryMs - serverNowMs - intervalMs)" in source
-    assert "renewalDeadlineMonotonicMs = performance.now() + delay" in source
-    assert "performance.now() >= renewalDeadlineMonotonicMs" in source
+    assert 'SESSION_CLOCK_URL = "/health"' in source
+    assert 'response.headers.get("Date")' in source
+    assert "Date.now()" not in source
     assert "window.setTimeout" in source
     assert "window.setInterval" not in source
+
+
+def test_session_renewal_revalidates_server_time_after_suspend() -> None:
+    source = (STATIC_JS / "session-renewal.js").read_text(encoding="utf-8")
+    assert "revalidateAfterForeground" in source
+    assert "refreshServerClock" in source
+    assert 'document.visibilityState === "visible"' in source
+    assert "foregroundDueProbe = true" in source
+    assert 'ACCESS_PROBE_URL = "/api/v1/auth/me"' in source
+    assert "accessSessionIsUsable" in source
+
+
+def test_session_rotation_survives_navigation_unload() -> None:
+    source = (STATIC_JS / "session-renewal.js").read_text(encoding="utf-8")
+    assert 'REFRESH_URL = "/api/v1/auth/refresh"' in source
+    assert "keepalive: true" in source
+    assert 'body: "{}"' in source
+    assert 'credentials: "same-origin"' in source
 
 
 def test_session_renewal_serializes_tabs_and_rehydrates_peer_csrf() -> None:
@@ -276,6 +336,7 @@ def test_session_renewal_serializes_tabs_and_rehydrates_peer_csrf() -> None:
     assert "synchronizeFromPeer" in source
     assert "synchronizeSecurityMeta" in source
     assert "announceRefresh(completedAt)" in source
+    assert "performance.timeOrigin + performance.now()" in source
 
 
 def test_live_csrf_bridge_overrides_stale_page_headers_after_rotation() -> None:

--- a/tests/test_pre_pilot_hardening_unittest.py
+++ b/tests/test_pre_pilot_hardening_unittest.py
@@ -33,7 +33,13 @@ TEMPLATES = ROOT / "src" / "litoral_trace" / "templates"
 SECRET = "pre-pilot-test-secret-key-with-at-least-32-chars"
 
 
-def _request(*, browser_nonce: str, csrf_token: str, access_token: str = "expired") -> Request:
+def _request(
+    *,
+    browser_nonce: str,
+    csrf_token: str,
+    access_token: str = "expired",
+    path: str = "/api/v1/auth/refresh",
+) -> Request:
     cookies = "; ".join(
         (
             f"{ACCESS_TOKEN_COOKIE_KEY}={access_token}",
@@ -46,8 +52,8 @@ def _request(*, browser_nonce: str, csrf_token: str, access_token: str = "expire
         "http_version": "1.1",
         "method": "POST",
         "scheme": "https",
-        "path": "/api/v1/auth/refresh",
-        "raw_path": b"/api/v1/auth/refresh",
+        "path": path,
+        "raw_path": path.encode("utf-8"),
         "query_string": b"",
         "headers": [
             (b"cookie", cookies.encode("utf-8")),
@@ -88,6 +94,24 @@ def test_refresh_rejects_browser_token_bound_to_another_browser() -> None:
 
     assert validate_cookie_csrf_request(
         _request(browser_nonce=browser_nonce, csrf_token=refresh_csrf),
+        secret_key=SECRET,
+    ) == "csrf_invalid"
+
+
+def test_browser_only_refresh_csrf_is_rejected_on_other_unsafe_api_paths() -> None:
+    browser_nonce = create_csrf_browser_nonce()
+    refresh_csrf = create_csrf_token(
+        subject=None,
+        browser_nonce=browser_nonce,
+        secret_key=SECRET,
+    )
+
+    assert validate_cookie_csrf_request(
+        _request(
+            browser_nonce=browser_nonce,
+            csrf_token=refresh_csrf,
+            path="/api/v1/satellite/jobs",
+        ),
         secret_key=SECRET,
     ) == "csrf_invalid"
 

--- a/tests/test_pre_pilot_session_refresh_security_unittest.py
+++ b/tests/test_pre_pilot_session_refresh_security_unittest.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import time
 
+from fastapi import HTTPException, status
 from starlette.requests import Request
 
 from litoral_trace.auth.sessions import (
@@ -9,6 +10,7 @@ from litoral_trace.auth.sessions import (
     REFRESH_TOKEN_COOKIE_KEY,
 )
 from litoral_trace.web import middleware as middleware_web
+from litoral_trace.web import runtime as runtime_web
 from litoral_trace.web.csrf import (
     CSRF_BROWSER_COOKIE_KEY,
     CSRF_HEADER_NAME,
@@ -41,6 +43,29 @@ def _refresh_request(*, browser_nonce: str, csrf_token: str) -> Request:
             (b"cookie", cookies.encode("utf-8")),
             (CSRF_HEADER_NAME.lower().encode("ascii"), csrf_token.encode("utf-8")),
         ],
+        "client": ("127.0.0.1", 12345),
+        "server": ("testserver", 443),
+        "root_path": "",
+    }
+    return Request(scope)
+
+
+def _html_request() -> Request:
+    cookies = "; ".join(
+        (
+            f"{ACCESS_TOKEN_COOKIE_KEY}=expired-access-token",
+            f"{REFRESH_TOKEN_COOKIE_KEY}=still-valid-refresh-token",
+        )
+    )
+    scope = {
+        "type": "http",
+        "http_version": "1.1",
+        "method": "GET",
+        "scheme": "https",
+        "path": "/dashboard",
+        "raw_path": b"/dashboard",
+        "query_string": b"",
+        "headers": [(b"cookie", cookies.encode("utf-8"))],
         "client": ("127.0.0.1", 12345),
         "server": ("testserver", 443),
         "root_path": "",
@@ -96,3 +121,27 @@ def test_regular_session_csrf_cannot_be_reused_as_refresh_capability(monkeypatch
         ),
         secret_key=SECRET,
     ) == "csrf_invalid"
+
+
+def test_expired_html_access_does_not_erase_recoverable_refresh_cookie(monkeypatch) -> None:
+    def reject_access(*_args, **_kwargs):
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="expired",
+        )
+
+    monkeypatch.setattr(
+        runtime_web,
+        "get_current_tenant_user",
+        reject_access,
+    )
+
+    user, response = runtime_web.get_authenticated_html_user(
+        _html_request()
+    )
+
+    assert user is None
+    assert response is not None
+    assert response.status_code == status.HTTP_303_SEE_OTHER
+    assert response.headers.get("location") == "/login"
+    assert response.headers.getlist("set-cookie") == []

--- a/tests/test_pre_pilot_session_refresh_security_unittest.py
+++ b/tests/test_pre_pilot_session_refresh_security_unittest.py
@@ -1,0 +1,98 @@
+from __future__ import annotations
+
+import time
+
+from starlette.requests import Request
+
+from litoral_trace.auth.sessions import (
+    ACCESS_TOKEN_COOKIE_KEY,
+    REFRESH_TOKEN_COOKIE_KEY,
+)
+from litoral_trace.web import middleware as middleware_web
+from litoral_trace.web.csrf import (
+    CSRF_BROWSER_COOKIE_KEY,
+    CSRF_HEADER_NAME,
+    CsrfSubject,
+    create_csrf_browser_nonce,
+    create_csrf_token,
+)
+
+
+SECRET = "pre-pilot-refresh-security-secret-at-least-32-chars"
+
+
+def _refresh_request(*, browser_nonce: str, csrf_token: str) -> Request:
+    cookies = "; ".join(
+        (
+            f"{ACCESS_TOKEN_COOKIE_KEY}=expired-access-token",
+            f"{REFRESH_TOKEN_COOKIE_KEY}=refresh-cookie-value",
+            f"{CSRF_BROWSER_COOKIE_KEY}={browser_nonce}",
+        )
+    )
+    scope = {
+        "type": "http",
+        "http_version": "1.1",
+        "method": "POST",
+        "scheme": "https",
+        "path": "/api/v1/auth/refresh",
+        "raw_path": b"/api/v1/auth/refresh",
+        "query_string": b"",
+        "headers": [
+            (b"cookie", cookies.encode("utf-8")),
+            (CSRF_HEADER_NAME.lower().encode("ascii"), csrf_token.encode("utf-8")),
+        ],
+        "client": ("127.0.0.1", 12345),
+        "server": ("testserver", 443),
+        "root_path": "",
+    }
+    return Request(scope)
+
+
+def test_suspended_tab_refresh_csrf_can_outlive_regular_one_hour_window(monkeypatch) -> None:
+    browser_nonce = create_csrf_browser_nonce()
+    issued_at = int(time.time()) - (2 * 60 * 60)
+    refresh_csrf = create_csrf_token(
+        subject=None,
+        browser_nonce=browser_nonce,
+        now_epoch=issued_at,
+        secret_key=SECRET,
+    )
+    monkeypatch.setattr(
+        middleware_web,
+        "refresh_csrf_max_age_seconds",
+        lambda: 30 * 24 * 60 * 60,
+    )
+
+    assert middleware_web.validate_cookie_csrf_request(
+        _refresh_request(
+            browser_nonce=browser_nonce,
+            csrf_token=refresh_csrf,
+        ),
+        secret_key=SECRET,
+    ) is None
+
+
+def test_regular_session_csrf_cannot_be_reused_as_refresh_capability(monkeypatch) -> None:
+    browser_nonce = create_csrf_browser_nonce()
+    regular_session_csrf = create_csrf_token(
+        subject=CsrfSubject(
+            username="operator",
+            organization_id=17,
+            session_id=42,
+        ),
+        browser_nonce=browser_nonce,
+        secret_key=SECRET,
+    )
+    monkeypatch.setattr(
+        middleware_web,
+        "refresh_csrf_max_age_seconds",
+        lambda: 30 * 24 * 60 * 60,
+    )
+
+    assert middleware_web.validate_cookie_csrf_request(
+        _refresh_request(
+            browser_nonce=browser_nonce,
+            csrf_token=regular_session_csrf,
+        ),
+        secret_key=SECRET,
+    ) == "csrf_invalid"

--- a/tests/test_refresh_navigation_logout_hardening_unittest.py
+++ b/tests/test_refresh_navigation_logout_hardening_unittest.py
@@ -1,0 +1,176 @@
+from __future__ import annotations
+
+import asyncio
+from http.cookies import SimpleCookie
+from pathlib import Path
+
+import pytest
+from fastapi import Response
+from sqlalchemy import delete, select
+
+from litoral_trace.api.auth import (
+    LoginRequest,
+    LogoutRequest,
+    login_b2b,
+    logout_b2b_session,
+    refresh_b2b_session,
+)
+from litoral_trace.auth.sessions import (
+    REFRESH_TOKEN_COOKIE_KEY,
+)
+from litoral_trace.db.engine import get_db_session
+from litoral_trace.db.init_db import get_non_production_superadmin_seed
+from litoral_trace.db.models import User, UserSession
+
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+COORDINATION_JS = (
+    ROOT_DIR
+    / "src"
+    / "litoral_trace"
+    / "static"
+    / "src"
+    / "js"
+    / "session-refresh-coordination.js"
+)
+SESSIONS_PY = (
+    ROOT_DIR
+    / "src"
+    / "litoral_trace"
+    / "auth"
+    / "sessions.py"
+)
+
+
+@pytest.fixture(autouse=True)
+def cleanup_user_sessions():
+    db_session = get_db_session()
+    db_session.execute(delete(UserSession))
+    admin_user = db_session.execute(
+        select(User).where(User.username == "admin")
+    ).scalar_one()
+    admin_user.last_login_at = None
+    db_session.commit()
+    db_session.close()
+
+    yield
+
+    db_session = get_db_session()
+    db_session.execute(delete(UserSession))
+    admin_user = db_session.execute(
+        select(User).where(User.username == "admin")
+    ).scalar_one()
+    admin_user.last_login_at = None
+    db_session.commit()
+    db_session.close()
+
+
+def _extract_cookies(response: Response) -> dict[str, str]:
+    parsed_cookie = SimpleCookie()
+    for set_cookie_header in response.headers.getlist("set-cookie"):
+        parsed_cookie.load(set_cookie_header)
+    return {
+        cookie_name: morsel.value
+        for cookie_name, morsel in parsed_cookie.items()
+    }
+
+
+def _all_sessions() -> list[UserSession]:
+    db_session = get_db_session()
+    try:
+        return db_session.execute(
+            select(UserSession).order_by(UserSession.id)
+        ).scalars().all()
+    finally:
+        db_session.close()
+
+
+def test_logout_with_rotated_parent_revokes_active_successor_family():
+    login_response = Response()
+    username, password = get_non_production_superadmin_seed()
+
+    asyncio.run(
+        login_b2b(
+            LoginRequest(
+                username=username,
+                password=password,
+            ),
+            login_response,
+        )
+    )
+    login_cookies = _extract_cookies(login_response)
+    parent_refresh_token = login_cookies[REFRESH_TOKEN_COOKIE_KEY]
+
+    refresh_response = Response()
+    asyncio.run(
+        refresh_b2b_session(
+            refresh_response,
+            refresh_token_cookie=parent_refresh_token,
+        )
+    )
+
+    sessions_after_refresh = _all_sessions()
+    assert len(sessions_after_refresh) == 2
+    assert sum(
+        session.revoked_at is None
+        for session in sessions_after_refresh
+    ) == 1
+
+    # This models the race where logout was sent with the parent refresh cookie
+    # while a keepalive refresh was already in flight and committed first.
+    logout_response = Response()
+    asyncio.run(
+        logout_b2b_session(
+            logout_response,
+            payload=LogoutRequest(
+                refresh_token=parent_refresh_token,
+            ),
+        )
+    )
+
+    sessions_after_logout = _all_sessions()
+    assert len(sessions_after_logout) == 2
+    assert all(
+        session.revoked_at is not None
+        for session in sessions_after_logout
+    )
+
+
+def test_cross_document_marker_has_no_expiring_lease_and_ambiguous_fail_closed():
+    source = COORDINATION_JS.read_text(encoding="utf-8")
+
+    assert "COORDINATION_MAX_AGE_SECONDS" not in source
+    assert "COORDINATION_WAIT_SECONDS" in source
+    assert "Refresh outcome ambiguous" in source
+    assert "return ambiguousRefreshResponse();" in source
+    assert "response.status >= 500" in source
+
+    mark_function = source.split(
+        "function markRefreshInFlight()",
+        1,
+    )[1].split(
+        "function clearRefreshInFlight()",
+        1,
+    )[0]
+    assert "Max-Age=" not in mark_function
+    assert "SameSite=Strict" in mark_function
+
+    request_block = source.split(
+        "markRefreshInFlight();",
+        1,
+    )[1]
+    assert "finally" not in request_block
+    assert "catch (_error)" in request_block
+
+
+def test_session_revocation_is_family_scoped_and_row_locked():
+    source = SESSIONS_PY.read_text(encoding="utf-8")
+    revoke_source = source.split(
+        "def revoke_session(",
+        1,
+    )[1]
+
+    assert "for_update=True" in revoke_source
+    assert "_revoke_family(" in revoke_source
+    assert "family_id=session_record.family_id" in revoke_source
+    assert "organization_id=session_record.organization_id" in revoke_source

--- a/tests/test_refresh_navigation_logout_hardening_unittest.py
+++ b/tests/test_refresh_navigation_logout_hardening_unittest.py
@@ -16,6 +16,7 @@ from litoral_trace.api.auth import (
     refresh_b2b_session,
 )
 from litoral_trace.auth.sessions import (
+    ACCESS_TOKEN_COOKIE_KEY,
     REFRESH_TOKEN_COOKIE_KEY,
 )
 from litoral_trace.db.engine import get_db_session
@@ -85,7 +86,7 @@ def _all_sessions() -> list[UserSession]:
         db_session.close()
 
 
-def test_logout_with_rotated_parent_revokes_active_successor_family():
+def _login_and_rotate() -> tuple[dict[str, str], str]:
     login_response = Response()
     username, password = get_non_production_superadmin_seed()
 
@@ -108,6 +109,11 @@ def test_logout_with_rotated_parent_revokes_active_successor_family():
             refresh_token_cookie=parent_refresh_token,
         )
     )
+    return login_cookies, parent_refresh_token
+
+
+def test_logout_with_rotated_parent_refresh_revokes_active_successor_family():
+    _, parent_refresh_token = _login_and_rotate()
 
     sessions_after_refresh = _all_sessions()
     assert len(sessions_after_refresh) == 2
@@ -116,8 +122,8 @@ def test_logout_with_rotated_parent_revokes_active_successor_family():
         for session in sessions_after_refresh
     ) == 1
 
-    # This models the race where logout was sent with the parent refresh cookie
-    # while a keepalive refresh was already in flight and committed first.
+    # Models logout carrying the parent refresh cookie after a keepalive refresh
+    # committed first. The active descendant must still be revoked.
     logout_response = Response()
     asyncio.run(
         logout_b2b_session(
@@ -125,6 +131,34 @@ def test_logout_with_rotated_parent_revokes_active_successor_family():
             payload=LogoutRequest(
                 refresh_token=parent_refresh_token,
             ),
+        )
+    )
+
+    sessions_after_logout = _all_sessions()
+    assert len(sessions_after_logout) == 2
+    assert all(
+        session.revoked_at is not None
+        for session in sessions_after_logout
+    )
+
+
+def test_logout_with_ancestor_access_token_revokes_active_successor_family():
+    login_cookies, _ = _login_and_rotate()
+
+    sessions_after_refresh = _all_sessions()
+    assert len(sessions_after_refresh) == 2
+    assert sum(
+        session.revoked_at is None
+        for session in sessions_after_refresh
+    ) == 1
+
+    # Models a page whose still-cryptographically-valid access JWT references an
+    # ancestor while another client already rotated to a descendant.
+    logout_response = Response()
+    asyncio.run(
+        logout_b2b_session(
+            logout_response,
+            session_jwt=login_cookies[ACCESS_TOKEN_COOKIE_KEY],
         )
     )
 
@@ -163,14 +197,30 @@ def test_cross_document_marker_has_no_expiring_lease_and_ambiguous_fail_closed()
     assert "catch (_error)" in request_block
 
 
-def test_session_revocation_is_family_scoped_and_row_locked():
+def test_refresh_and_logout_share_family_lock_before_row_lock():
     source = SESSIONS_PY.read_text(encoding="utf-8")
-    revoke_source = source.split(
-        "def revoke_session(",
-        1,
-    )[1]
 
-    assert "for_update=True" in revoke_source
-    assert "_revoke_family(" in revoke_source
-    assert "family_id=session_record.family_id" in revoke_source
-    assert "organization_id=session_record.organization_id" in revoke_source
+    assert "pg_advisory_xact_lock" in source
+    assert "_lookup_session_bootstrap_without_retained_row_lock" in source
+
+    rotation = source.split(
+        "def rotate_refresh_session(",
+        1,
+    )[1].split(
+        "\ndef revoke_session(",
+        1,
+    )[0]
+    rotation_family_lock = rotation.index("_acquire_refresh_family_lock(")
+    rotation_row_lock = rotation.index("current_session = _get_session_by_id(")
+    assert rotation_family_lock < rotation_row_lock
+    assert "for_update=True" in rotation[rotation_row_lock:]
+
+    revocation = source.split("def revoke_session(", 1)[1]
+    revocation_family_lock = revocation.index("_acquire_refresh_family_lock(")
+    revocation_row_lock = revocation.index("session_record = _get_session_by_id(")
+    family_revoke = revocation.index("_revoke_family(")
+
+    assert revocation_family_lock < revocation_row_lock < family_revoke
+    assert "for_update=True" in revocation[revocation_row_lock:family_revoke]
+    assert "family_id=family_id" in revocation[family_revoke:]
+    assert "organization_id=family_organization_id" in revocation[family_revoke:]

--- a/tests/test_refresh_rotation_cross_document_unittest.py
+++ b/tests/test_refresh_rotation_cross_document_unittest.py
@@ -64,7 +64,7 @@ def test_cross_document_coordinator_wraps_refresh_before_session_renewal() -> No
     assert base.index(coordinator) < base.index(renewal)
 
 
-def test_refresh_rotation_relocks_parent_after_tenant_context() -> None:
+def test_refresh_rotation_family_lock_precedes_parent_row_lock() -> None:
     source = SESSIONS.read_text(encoding="utf-8")
     start = source.index("def rotate_refresh_session(")
     end = source.index("\ndef revoke_session(", start)
@@ -73,24 +73,47 @@ def test_refresh_rotation_relocks_parent_after_tenant_context() -> None:
     tenant_context = rotation.index(
         "set_tenant_db_context(db_session, session_lookup.organization_id)"
     )
+    family_reference = rotation.index("family_reference = _get_session_family_reference(")
+    family_lock = rotation.index("_acquire_refresh_family_lock(")
     parent_lookup = rotation.index("current_session = _get_session_by_id(")
     row_lock = rotation.index("for_update=True", parent_lookup)
     reuse_check = rotation.index("if current_session.revoked_at is not None:")
 
-    assert tenant_context < parent_lookup < row_lock < reuse_check
+    assert (
+        tenant_context
+        < family_reference
+        < family_lock
+        < parent_lookup
+        < row_lock
+        < reuse_check
+    )
 
 
-def test_logout_revocation_relocks_parent_and_revokes_whole_family() -> None:
+def test_logout_family_lock_precedes_row_lock_and_revokes_whole_family() -> None:
     source = SESSIONS.read_text(encoding="utf-8")
     revocation = source.split("def revoke_session(", 1)[1]
 
-    tenant_context = revocation.index(
-        "set_tenant_db_context(db_session, session_lookup.organization_id)"
-    )
+    family_reference = revocation.index("family_reference = _get_session_family_reference(")
+    family_lock = revocation.index("_acquire_refresh_family_lock(")
     parent_lookup = revocation.index("session_record = _get_session_by_id(")
     row_lock = revocation.index("for_update=True", parent_lookup)
     family_revoke = revocation.index("_revoke_family(")
 
-    assert tenant_context < parent_lookup < row_lock < family_revoke
-    assert "family_id=session_record.family_id" in revocation
-    assert "organization_id=session_record.organization_id" in revocation
+    assert family_reference < family_lock < parent_lookup < row_lock < family_revoke
+    assert "family_id=family_id" in revocation[family_revoke:]
+    assert "organization_id=family_organization_id" in revocation[family_revoke:]
+
+
+def test_postgres_bootstrap_row_lock_is_released_before_family_lock_transaction() -> None:
+    source = SESSIONS.read_text(encoding="utf-8")
+    helper = source.split(
+        "def _lookup_session_bootstrap_without_retained_row_lock(",
+        1,
+    )[1].split(
+        "\ndef _family_advisory_lock_key(",
+        1,
+    )[0]
+
+    assert "with Session(bind=engine) as bootstrap_session:" in helper
+    assert "bootstrap_session.rollback()" in helper
+    assert "lookup_session_bootstrap_by_token_hash(" in helper

--- a/tests/test_refresh_rotation_cross_document_unittest.py
+++ b/tests/test_refresh_rotation_cross_document_unittest.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+COORDINATOR = (
+    ROOT
+    / "src"
+    / "litoral_trace"
+    / "static"
+    / "src"
+    / "js"
+    / "session-refresh-coordination.js"
+)
+BASE_TEMPLATE = ROOT / "src" / "litoral_trace" / "templates" / "base.html"
+SESSIONS = ROOT / "src" / "litoral_trace" / "auth" / "sessions.py"
+
+
+def test_cross_document_refresh_lease_is_short_lived_and_non_sensitive() -> None:
+    source = COORDINATOR.read_text(encoding="utf-8")
+
+    assert 'COORDINATION_COOKIE_NAME = "lt_refresh_inflight"' in source
+    assert "COORDINATION_MAX_AGE_SECONDS = 15" in source
+    assert '"SameSite=Strict"' in source
+    assert 'window.location.protocol === "https:" ? "; Secure" : ""' in source
+    assert "`${COORDINATION_COOKIE_NAME}=1`" in source
+    assert "Max-Age=${COORDINATION_MAX_AGE_SECONDS}" in source
+    assert "waitForOutstandingRefresh" in source
+    assert "refreshedCookieJarHasFutureRenewalWindow" in source
+    assert 'status: 425' in source
+    assert "markRefreshInFlight();" in source
+    assert "clearRefreshInFlight();" in source
+    assert "window.localStorage" not in source
+    assert "window.sessionStorage" not in source
+    assert "localStorage" not in source
+    assert "sessionStorage" not in source
+
+
+def test_cross_document_coordinator_wraps_refresh_before_session_renewal() -> None:
+    base = BASE_TEMPLATE.read_text(encoding="utf-8")
+
+    coordinator = "/src/js/session-refresh-coordination.js"
+    renewal = "/src/js/session-renewal.js"
+
+    assert coordinator in base
+    assert renewal in base
+    assert base.index(coordinator) < base.index(renewal)
+
+
+def test_refresh_rotation_relocks_parent_after_tenant_context() -> None:
+    source = SESSIONS.read_text(encoding="utf-8")
+    start = source.index("def rotate_refresh_session(")
+    end = source.index("\ndef revoke_session(", start)
+    rotation = source[start:end]
+
+    tenant_context = rotation.index(
+        "set_tenant_db_context(db_session, session_lookup.organization_id)"
+    )
+    parent_lookup = rotation.index("current_session = _get_session_by_id(")
+    row_lock = rotation.index("for_update=True", parent_lookup)
+    reuse_check = rotation.index("if current_session.revoked_at is not None:")
+
+    assert tenant_context < parent_lookup < row_lock < reuse_check

--- a/tests/test_refresh_rotation_cross_document_unittest.py
+++ b/tests/test_refresh_rotation_cross_document_unittest.py
@@ -17,20 +17,36 @@ BASE_TEMPLATE = ROOT / "src" / "litoral_trace" / "templates" / "base.html"
 SESSIONS = ROOT / "src" / "litoral_trace" / "auth" / "sessions.py"
 
 
-def test_cross_document_refresh_lease_is_short_lived_and_non_sensitive() -> None:
+def test_cross_document_refresh_marker_is_non_sensitive_and_does_not_expire_into_replay() -> None:
     source = COORDINATOR.read_text(encoding="utf-8")
 
     assert 'COORDINATION_COOKIE_NAME = "lt_refresh_inflight"' in source
-    assert "COORDINATION_MAX_AGE_SECONDS = 15" in source
+    assert "COORDINATION_MAX_AGE_SECONDS" not in source
+    assert "COORDINATION_WAIT_SECONDS" in source
     assert '"SameSite=Strict"' in source
     assert 'window.location.protocol === "https:" ? "; Secure" : ""' in source
     assert "`${COORDINATION_COOKIE_NAME}=1`" in source
-    assert "Max-Age=${COORDINATION_MAX_AGE_SECONDS}" in source
-    assert "waitForOutstandingRefresh" in source
+
+    marker_function = source.split(
+        "function markRefreshInFlight()",
+        1,
+    )[1].split(
+        "function clearRefreshInFlight()",
+        1,
+    )[0]
+    assert "Max-Age=" not in marker_function
+
+    assert "waitForOutstandingRefresh(rawFetch)" in source
     assert "refreshedCookieJarHasFutureRenewalWindow" in source
-    assert 'status: 425' in source
+    assert 'return "ambiguous";' in source
+    assert "Refresh outcome ambiguous" in source
+    assert "response.status >= 500" in source
     assert "markRefreshInFlight();" in source
-    assert "clearRefreshInFlight();" in source
+
+    sent_request = source.split("markRefreshInFlight();", 1)[1]
+    assert "catch (_error)" in sent_request
+    assert "finally" not in sent_request
+
     assert "window.localStorage" not in source
     assert "window.sessionStorage" not in source
     assert "localStorage" not in source
@@ -62,3 +78,19 @@ def test_refresh_rotation_relocks_parent_after_tenant_context() -> None:
     reuse_check = rotation.index("if current_session.revoked_at is not None:")
 
     assert tenant_context < parent_lookup < row_lock < reuse_check
+
+
+def test_logout_revocation_relocks_parent_and_revokes_whole_family() -> None:
+    source = SESSIONS.read_text(encoding="utf-8")
+    revocation = source.split("def revoke_session(", 1)[1]
+
+    tenant_context = revocation.index(
+        "set_tenant_db_context(db_session, session_lookup.organization_id)"
+    )
+    parent_lookup = revocation.index("session_record = _get_session_by_id(")
+    row_lock = revocation.index("for_update=True", parent_lookup)
+    family_revoke = revocation.index("_revoke_family(")
+
+    assert tenant_context < parent_lookup < row_lock < family_revoke
+    assert "family_id=session_record.family_id" in revocation
+    assert "organization_id=session_record.organization_id" in revocation


### PR DESCRIPTION
## Objetivo
Cerrar los hallazgos P1/P2 detectados durante la prueba manual punta a punta antes de entrevistas, demos y piloto pago.

Closes #128
Closes #129
Closes #131
Closes #133

## Cambios

### #128 — renovación segura de sesión web
- token CSRF dedicado y browser-bound para `/api/v1/auth/refresh`;
- refresh token continúa HttpOnly y rotando en servidor;
- renovación calculada desde expiración real del access token y tiempo relativo del servidor, tolerante a clock skew y suspensión del equipo;
- `keepalive` para sobrevivir navegación/unload;
- coordinación cross-document sin lease fijo que pueda vencer mientras el refresh siga activo;
- resultado de transporte ambiguo falla cerrado y no entra en retry ordinario;
- sincronización de CSRF y metadata tras rotación sin guardar credenciales en `localStorage`/`sessionStorage`;
- refresh y logout serializados en PostgreSQL por familia mediante `pg_advisory_xact_lock` antes de los row locks tenant-scoped;
- logout revoca la familia completa y prevalece frente a refresh concurrentes, incluso entre ancestros y descendientes del mismo linaje.

### #129 — contexto de Evidencias fail-closed
- `shipment_code` se conserva sólo como contexto de navegación;
- `/evidence` lo resuelve contra opciones tenant-scoped emitidas por servidor y reutiliza el `SHIPMENT|<public UUID>` real;
- nunca fabrica UUIDs ni resuelve objetos fuera del tenant;
- si no puede demostrar contexto seguro, los formularios de mutación quedan bloqueados hasta selección explícita.

### #131 — datetime-local
- normaliza visualmente `timestamptz` ISO con `Z`/offset para `datetime-local`;
- no aplica conversiones silenciosas de zona horaria en el browser.

### #133 — lenguaje comercial
- traducción central de enums/códigos visibles a español empresarial;
- sólo traduce tokens completos/segmentos controlados, no substrings dentro de identificadores, archivos, notas o referencias;
- no modifica values, atributos, enums backend, API ni lógica de negocio;
- conserva siglas oficiales como EUDR, DDS, EORI, HS/CN, CERT-POV, ePhyto, SENASA, ARCA, SIM, SHA-256 y GeoJSON.

## Seguridad
- tenant isolation/RLS se mantiene sin bypasses nuevos;
- la excepción CSRF de refresh exige token firmado + browser nonce HttpOnly + refresh cookie;
- los demás endpoints mutables conservan CSRF normal;
- la serialización familiar usa una transacción bootstrap corta pre-tenant para liberar el `FOR UPDATE`, luego tenant context + advisory lock de familia + revalidación org/family/token + row lock;
- Evidence falla cerrado cuando no puede demostrar el contexto;
- ningún token de acceso/refresh se persiste en storage del browser.

## Tests / CI
Head final: `5cbbe504ac6fe593a223167e8c22c25f66229373`.

CI #590 / run `33041726125`: `python-tests` SUCCESS, incluyendo syntax gate, Alembic canonical head y suite pytest completa.

Se agregaron regresiones para:
- refresh browser-bound con access JWT no utilizable;
- nonce CSRF inválido;
- expiración/clock skew/suspend-resume;
- navegación con refresh keepalive;
- coordinación cross-document;
- resultado ambiguo fail-closed;
- logout vs refresh concurrente;
- ancestro vs descendiente de una misma familia;
- revocación de familia completa;
- bloqueo de mutaciones de Evidencias sin subject seguro;
- datetime-local;
- traducciones sin mutar datos auditables.

Revisión final de Codex sobre `5cbbe504ac`: **Didn't find any major issues**. Todos los threads P1/P2 quedaron respondidos y resueltos.

Los jobs pesados (`frontend-build`, `production-build`, `postgres-integration-gates`) siguen manual-only por la política de presupuesto y deben ejecutarse sobre este SHA exacto antes del merge.

## Fuera de alcance
- extracción/OCR/autofill de PDFs (#130), post-piloto;
- expansión de taxonomía industrial (#132), post-piloto.