### PR TITLE
Gate B: prove live worker and S3 readiness

### DIFF
--- a/.github/workflows/us-lacey-neon-live-gate.yml
+++ b/.github/workflows/us-lacey-neon-live-gate.yml
@@ -163,8 +163,8 @@ jobs:
                   tables = [
                       'us_lacey_ppq_shipments',
                       'us_lacey_ppq_plant_lines',
-                      'us_lacey_ppq_plant_declarations',
-                      'us_lacey_ppq_operation_fields',
+                      'us_lacey_plant_declarations',
+                      'us_lacey_field_candidates',
                   ]
                   rows = conn.execute(text("""
                       select c.relname, c.relrowsecurity, c.relforcerowsecurity

--- a/.github/workflows/us-lacey-neon-live-gate.yml
+++ b/.github/workflows/us-lacey-neon-live-gate.yml
@@ -96,11 +96,7 @@ jobs:
           if url.drivername in {"postgresql", "postgres", "postgresql+psycopg2"}:
               url = url.set(drivername="postgresql+psycopg")
 
-          engine = create_engine(
-              url,
-              pool_pre_ping=True,
-              hide_parameters=True,
-          )
+          engine = create_engine(url, pool_pre_ping=True, hide_parameters=True)
           with engine.connect() as conn:
               db = conn.execute(text("select current_database()" )).scalar_one()
               user = conn.execute(text("select current_user" )).scalar_one()
@@ -134,11 +130,7 @@ jobs:
           if url.drivername in {"postgresql", "postgres", "postgresql+psycopg2"}:
               url = url.set(drivername="postgresql+psycopg")
 
-          engine = create_engine(
-              url,
-              pool_pre_ping=True,
-              hide_parameters=True,
-          )
+          engine = create_engine(url, pool_pre_ping=True, hide_parameters=True)
           with engine.connect() as conn:
               version = conn.execute(text("select version_num from alembic_version" )).scalar_one()
               print(f"alembic_version_after={version}")
@@ -189,6 +181,51 @@ jobs:
                       if policy_counts.get(table) != 4:
                           raise SystemExit(f"Expected 4 tenant policies on {table}; got {policy_counts.get(table)}")
                   print("ppq_rls_force_policies=PASS")
+
+                  table_privs = ('SELECT', 'INSERT', 'UPDATE', 'DELETE')
+                  for table in tables:
+                      qualified = f'public.{table}'
+                      for privilege in table_privs:
+                          runtime_has = conn.execute(
+                              text("select has_table_privilege('litoral_trace_app', :obj, :priv)"),
+                              {'obj': qualified, 'priv': privilege},
+                          ).scalar_one()
+                          worker_has = conn.execute(
+                              text("select has_table_privilege('litoral_trace_us_lacey_worker', :obj, :priv)"),
+                              {'obj': qualified, 'priv': privilege},
+                          ).scalar_one()
+                          public_has = conn.execute(
+                              text("select has_table_privilege('public', :obj, :priv)"),
+                              {'obj': qualified, 'priv': privilege},
+                          ).scalar_one()
+                          if not runtime_has:
+                              raise SystemExit(f"Runtime missing {privilege} on {table}")
+                          if worker_has:
+                              raise SystemExit(f"Worker unexpectedly has {privilege} on {table}")
+                          if public_has:
+                              raise SystemExit(f"PUBLIC unexpectedly has {privilege} on {table}")
+
+                      sequence = f'public.{table}_id_seq'
+                      for privilege in ('USAGE', 'SELECT'):
+                          runtime_has = conn.execute(
+                              text("select has_sequence_privilege('litoral_trace_app', :obj, :priv)"),
+                              {'obj': sequence, 'priv': privilege},
+                          ).scalar_one()
+                          worker_has = conn.execute(
+                              text("select has_sequence_privilege('litoral_trace_us_lacey_worker', :obj, :priv)"),
+                              {'obj': sequence, 'priv': privilege},
+                          ).scalar_one()
+                          public_has = conn.execute(
+                              text("select has_sequence_privilege('public', :obj, :priv)"),
+                              {'obj': sequence, 'priv': privilege},
+                          ).scalar_one()
+                          if not runtime_has:
+                              raise SystemExit(f"Runtime missing sequence {privilege} on {table}")
+                          if worker_has:
+                              raise SystemExit(f"Worker unexpectedly has sequence {privilege} on {table}")
+                          if public_has:
+                              raise SystemExit(f"PUBLIC unexpectedly has sequence {privilege} on {table}")
+                  print("ppq_effective_privileges=PASS")
               else:
                   print("ppq_040_checks=NOT_APPLICABLE_BEFORE_MIGRATION")
           engine.dispose()

--- a/.github/workflows/us-lacey-neon-live-gate.yml
+++ b/.github/workflows/us-lacey-neon-live-gate.yml
@@ -1,0 +1,168 @@
+name: US Lacey Neon Live Gate
+
+on:
+  workflow_dispatch:
+    inputs:
+      mode:
+        description: "inspect = read-only; migrate = Alembic upgrade to canonical head"
+        required: true
+        default: inspect
+        type: choice
+        options:
+          - inspect
+          - migrate
+
+permissions:
+  contents: read
+
+concurrency:
+  group: us-lacey-neon-live-gate
+  cancel-in-progress: false
+
+jobs:
+  neon-live-gate:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    env:
+      ENVIRONMENT: production
+      MIGRATION_DATABASE_URL: ${{ secrets.US_LACEY_NEON_MIGRATION_DATABASE_URL }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: pip
+          cache-dependency-path: requirements.txt
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -r requirements.txt alembic
+
+      - name: Require migration connection secret
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [ -z "${MIGRATION_DATABASE_URL:-}" ]; then
+            echo "Missing GitHub secret US_LACEY_NEON_MIGRATION_DATABASE_URL"
+            exit 1
+          fi
+          echo "Migration connection secret is configured (value not printed)."
+
+      - name: Verify repository canonical head
+        shell: bash
+        run: |
+          set -euo pipefail
+          python -m alembic heads | tee /tmp/alembic-heads.txt
+          test "$(grep -c '(head)' /tmp/alembic-heads.txt)" -eq 1
+          grep -F "040_us_lacey_ppq505 (head)" /tmp/alembic-heads.txt
+
+      - name: Inspect persistent Neon before changes
+        shell: bash
+        run: |
+          set -euo pipefail
+          python -m alembic current | tee /tmp/alembic-current-before.txt
+          python - <<'PY'
+          import os
+          from sqlalchemy import create_engine, text
+
+          engine = create_engine(
+              os.environ["MIGRATION_DATABASE_URL"],
+              pool_pre_ping=True,
+              hide_parameters=True,
+          )
+          with engine.connect() as conn:
+              db = conn.execute(text("select current_database()" )).scalar_one()
+              user = conn.execute(text("select current_user" )).scalar_one()
+              version = conn.execute(text("select version_num from alembic_version" )).scalar_one()
+              print(f"database={db}")
+              print(f"role={user}")
+              print(f"alembic_version={version}")
+              if user in {"litoral_trace_app", "litoral_trace_us_lacey_worker"}:
+                  raise SystemExit("Refusing migration gate with runtime/worker role")
+          engine.dispose()
+          PY
+
+      - name: Migrate persistent Neon to canonical head
+        if: ${{ inputs.mode == 'migrate' }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          python -m alembic upgrade head
+
+      - name: Verify persistent Neon after inspection or migration
+        shell: bash
+        run: |
+          set -euo pipefail
+          python -m alembic current | tee /tmp/alembic-current-after.txt
+          python - <<'PY'
+          import os
+          from sqlalchemy import create_engine, text
+
+          engine = create_engine(
+              os.environ["MIGRATION_DATABASE_URL"],
+              pool_pre_ping=True,
+              hide_parameters=True,
+          )
+          with engine.connect() as conn:
+              version = conn.execute(text("select version_num from alembic_version" )).scalar_one()
+              print(f"alembic_version_after={version}")
+
+              roles = {
+                  row.rolname: (row.rolsuper, row.rolbypassrls)
+                  for row in conn.execute(text("""
+                      select rolname, rolsuper, rolbypassrls
+                      from pg_roles
+                      where rolname in ('litoral_trace_app', 'litoral_trace_us_lacey_worker')
+                  """))
+              }
+              expected_roles = {'litoral_trace_app', 'litoral_trace_us_lacey_worker'}
+              if set(roles) != expected_roles:
+                  raise SystemExit(f"Expected runtime/worker roles; found {sorted(roles)}")
+              for role, (superuser, bypassrls) in roles.items():
+                  if superuser or bypassrls:
+                      raise SystemExit(f"Unsafe role attributes for {role}")
+              print("runtime_worker_roles=NOSUPERUSER,NOBYPASSRLS")
+
+              if version == '040_us_lacey_ppq505':
+                  tables = [
+                      'us_lacey_ppq_shipments',
+                      'us_lacey_ppq_plant_lines',
+                      'us_lacey_ppq_plant_declarations',
+                      'us_lacey_ppq_operation_fields',
+                  ]
+                  rows = conn.execute(text("""
+                      select c.relname, c.relrowsecurity, c.relforcerowsecurity
+                      from pg_class c
+                      join pg_namespace n on n.oid = c.relnamespace
+                      where n.nspname = 'public' and c.relname = any(:tables)
+                  """), {'tables': tables}).all()
+                  shape = {name: (rls, force) for name, rls, force in rows}
+                  if set(shape) != set(tables):
+                      raise SystemExit(f"Missing PPQ tables: {sorted(set(tables) - set(shape))}")
+                  for table, (rls, force) in shape.items():
+                      if not rls or not force:
+                          raise SystemExit(f"RLS/FORCE RLS not enabled on {table}")
+
+                  policy_counts = dict(conn.execute(text("""
+                      select tablename, count(*)::int
+                      from pg_policies
+                      where schemaname = 'public' and tablename = any(:tables)
+                      group by tablename
+                  """), {'tables': tables}).all())
+                  for table in tables:
+                      if policy_counts.get(table) != 4:
+                          raise SystemExit(f"Expected 4 tenant policies on {table}; got {policy_counts.get(table)}")
+                  print("ppq_rls_force_policies=PASS")
+              else:
+                  print("ppq_040_checks=NOT_APPLICABLE_BEFORE_MIGRATION")
+          engine.dispose()
+          PY
+
+      - name: Require canonical 040 after migrate mode
+        if: ${{ inputs.mode == 'migrate' }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          grep -F "040_us_lacey_ppq505" /tmp/alembic-current-after.txt

--- a/.github/workflows/us-lacey-neon-live-gate.yml
+++ b/.github/workflows/us-lacey-neon-live-gate.yml
@@ -1,6 +1,12 @@
 name: US Lacey Neon Live Gate
 
 on:
+  push:
+    branches:
+      - wip/us-lacey-live-readiness
+    paths:
+      - ".github/workflows/us-lacey-neon-live-gate.yml"
+      - ".github/us-lacey-*.trigger"
   workflow_dispatch:
     inputs:
       mode:
@@ -28,6 +34,24 @@ jobs:
       MIGRATION_DATABASE_URL: ${{ secrets.US_LACEY_NEON_MIGRATION_DATABASE_URL }}
     steps:
       - uses: actions/checkout@v4
+
+      - name: Resolve safe mode
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            MODE="${{ inputs.mode }}"
+          elif [ -f ".github/us-lacey-migrate-040.trigger" ]; then
+            MODE="migrate"
+          else
+            MODE="inspect"
+          fi
+          if [ "$MODE" != "inspect" ] && [ "$MODE" != "migrate" ]; then
+            echo "Invalid mode: $MODE"
+            exit 1
+          fi
+          echo "US_LACEY_NEON_MODE=$MODE" >> "$GITHUB_ENV"
+          echo "Resolved mode: $MODE"
 
       - uses: actions/setup-python@v5
         with:
@@ -85,7 +109,7 @@ jobs:
           PY
 
       - name: Migrate persistent Neon to canonical head
-        if: ${{ inputs.mode == 'migrate' }}
+        if: ${{ env.US_LACEY_NEON_MODE == 'migrate' }}
         shell: bash
         run: |
           set -euo pipefail
@@ -161,7 +185,7 @@ jobs:
           PY
 
       - name: Require canonical 040 after migrate mode
-        if: ${{ inputs.mode == 'migrate' }}
+        if: ${{ env.US_LACEY_NEON_MODE == 'migrate' }}
         shell: bash
         run: |
           set -euo pipefail

--- a/.github/workflows/us-lacey-neon-live-gate.yml
+++ b/.github/workflows/us-lacey-neon-live-gate.yml
@@ -90,9 +90,14 @@ jobs:
           python - <<'PY'
           import os
           from sqlalchemy import create_engine, text
+          from sqlalchemy.engine import make_url
+
+          url = make_url(os.environ["MIGRATION_DATABASE_URL"])
+          if url.drivername in {"postgresql", "postgres", "postgresql+psycopg2"}:
+              url = url.set(drivername="postgresql+psycopg")
 
           engine = create_engine(
-              os.environ["MIGRATION_DATABASE_URL"],
+              url,
               pool_pre_ping=True,
               hide_parameters=True,
           )
@@ -123,9 +128,14 @@ jobs:
           python - <<'PY'
           import os
           from sqlalchemy import create_engine, text
+          from sqlalchemy.engine import make_url
+
+          url = make_url(os.environ["MIGRATION_DATABASE_URL"])
+          if url.drivername in {"postgresql", "postgres", "postgresql+psycopg2"}:
+              url = url.set(drivername="postgresql+psycopg")
 
           engine = create_engine(
-              os.environ["MIGRATION_DATABASE_URL"],
+              url,
               pool_pre_ping=True,
               hide_parameters=True,
           )

--- a/.github/workflows/us-lacey-render-live-gate.yml
+++ b/.github/workflows/us-lacey-render-live-gate.yml
@@ -1,0 +1,79 @@
+name: US Lacey Render Live Gate
+
+on:
+  push:
+    branches:
+      - wip/us-lacey-live-readiness
+    paths:
+      - .github/workflows/us-lacey-render-live-gate.yml
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  render-live-gate:
+    runs-on: ubuntu-latest
+    timeout-minutes: 8
+    env:
+      ORIGIN: https://litoral-trace-us-lacey-pilot-free.onrender.com
+    steps:
+      - name: Wake service and verify health
+        shell: bash
+        run: |
+          set -euo pipefail
+          for attempt in $(seq 1 18); do
+            code="$(curl -sS -o /tmp/health.json -w '%{http_code}' --max-time 20 "$ORIGIN/health" || true)"
+            if [ "$code" = "200" ]; then
+              break
+            fi
+            echo "health attempt $attempt returned HTTP ${code:-network-error}; waiting for free-tier wake-up"
+            sleep 5
+          done
+          test "${code:-}" = "200"
+          python - <<'PY'
+          import json
+          from pathlib import Path
+          body = json.loads(Path('/tmp/health.json').read_text())
+          assert body.get('status') == 'healthy', body
+          assert body.get('service') == 'us-lacey-pilot', body
+          print('render_health=PASS')
+          PY
+
+      - name: Verify readiness contract
+        shell: bash
+        run: |
+          set -euo pipefail
+          code="$(curl -sS -o /tmp/ready.json -w '%{http_code}' --max-time 20 "$ORIGIN/ready")"
+          echo "render_ready_http=$code"
+          if [ "$code" = "200" ]; then
+            python - <<'PY'
+          import json
+          from pathlib import Path
+          body = json.loads(Path('/tmp/ready.json').read_text())
+          assert body.get('status') == 'ready', body
+          assert body.get('service') == 'us-lacey-pilot', body
+          assert body.get('environment') == 'production', body
+          assert body.get('hostname') == 'litoral-trace-us-lacey-pilot-free.onrender.com', body
+          print('render_ready=PASS')
+          PY
+          elif [ "$code" = "503" ]; then
+            echo "render_ready=FAIL_CLOSED_503"
+            cat /tmp/ready.json
+            exit 1
+          else
+            echo "Unexpected /ready HTTP $code"
+            cat /tmp/ready.json
+            exit 1
+          fi
+
+      - name: Verify legal pages
+        shell: bash
+        run: |
+          set -euo pipefail
+          for path in /legal/terms /legal/privacy /legal/private-beta; do
+            code="$(curl -sS -o /tmp/legal.html -w '%{http_code}' --max-time 20 "$ORIGIN$path")"
+            test "$code" = "200"
+            grep -qi '<html' /tmp/legal.html
+            echo "legal_page_${path##*/}=PASS"
+          done

--- a/src/litoral_trace/us_lacey/live_readiness.py
+++ b/src/litoral_trace/us_lacey/live_readiness.py
@@ -1,0 +1,85 @@
+"""Coarse live-readiness probes for the isolated U.S. Lacey pilot.
+
+These probes deliberately return only ready/not-ready state. They must never
+expose connection strings, bucket names, object keys, credentials, or provider
+error details to HTTP clients.
+"""
+from __future__ import annotations
+
+import logging
+from uuid import uuid4
+
+from litoral_trace.us_lacey.storage import (
+    build_us_lacey_storage_settings,
+    get_us_lacey_storage_client,
+)
+
+_LOG = logging.getLogger("litoral_trace.us_lacey.live_readiness")
+
+
+def probe_storage_roundtrip() -> str:
+    """Write, read, verify, and remove one tiny object in the U.S. prefix."""
+    payload = b"us-lacey-live-readiness"
+    storage = None
+    object_key: str | None = None
+    version_id: str | None = None
+    wrote_object = False
+    roundtrip_ok = False
+    cleanup_ok = True
+
+    try:
+        settings = build_us_lacey_storage_settings()
+        storage = get_us_lacey_storage_client()
+        object_key = (
+            f"{settings.normalized_key_prefix}/healthchecks/"
+            f"{uuid4().hex}.txt"
+        )
+        write = storage.put_object(
+            key=object_key,
+            body=payload,
+            content_type="text/plain",
+            content_length=len(payload),
+            metadata={"purpose": "live-readiness"},
+        )
+        wrote_object = True
+        version_id = write.version_id
+
+        head = storage.head_object(key=object_key, version_id=version_id)
+        if head.size_bytes != len(payload):
+            raise RuntimeError("storage readiness size mismatch")
+
+        with storage.get_object_stream(key=object_key, version_id=version_id) as stream:
+            if stream.read() != payload:
+                raise RuntimeError("storage readiness payload mismatch")
+
+        roundtrip_ok = True
+    except Exception:
+        _LOG.exception("us_lacey_storage_roundtrip_failed")
+    finally:
+        if wrote_object and storage is not None and object_key is not None:
+            try:
+                storage.delete_object(key=object_key, version_id=version_id)
+            except Exception:
+                cleanup_ok = False
+                _LOG.exception("us_lacey_storage_roundtrip_cleanup_failed")
+
+    if roundtrip_ok and cleanup_ok:
+        _LOG.info("us_lacey_storage_roundtrip_ready")
+        return "ready"
+    return "not_ready"
+
+
+def live_runtime_status(*, worker_thread, storage_roundtrip: str) -> dict[str, str]:
+    """Return a secret-free status document for the deployed free-tier workload."""
+    inline_worker = (
+        "ready"
+        if worker_thread is not None and worker_thread.is_alive()
+        else "not_ready"
+    )
+    storage = "ready" if storage_roundtrip == "ready" else "not_ready"
+    overall = "ready" if inline_worker == "ready" and storage == "ready" else "not_ready"
+    return {
+        "status": overall,
+        "inline_worker": inline_worker,
+        "storage_roundtrip": storage,
+    }

--- a/src/litoral_trace/us_lacey/live_readiness.py
+++ b/src/litoral_trace/us_lacey/live_readiness.py
@@ -69,13 +69,9 @@ def probe_storage_roundtrip() -> str:
     return "not_ready"
 
 
-def live_runtime_status(*, worker_thread, storage_roundtrip: str) -> dict[str, str]:
+def live_runtime_status(*, worker_ready: bool, storage_roundtrip: str) -> dict[str, str]:
     """Return a secret-free status document for the deployed free-tier workload."""
-    inline_worker = (
-        "ready"
-        if worker_thread is not None and worker_thread.is_alive()
-        else "not_ready"
-    )
+    inline_worker = "ready" if worker_ready else "not_ready"
     storage = "ready" if storage_roundtrip == "ready" else "not_ready"
     overall = "ready" if inline_worker == "ready" and storage == "ready" else "not_ready"
     return {

--- a/src/litoral_trace/web/us_lacey_free_app.py
+++ b/src/litoral_trace/web/us_lacey_free_app.py
@@ -63,6 +63,10 @@ def _int_env(name: str, default: int, *, minimum: int, maximum: int) -> int:
     return value
 
 
+def _record_worker_success() -> None:
+    app.state.us_lacey_inline_worker_last_success_monotonic = time.monotonic()
+
+
 def _inline_worker_loop(stop_event: threading.Event) -> None:
     poll_seconds = _float_env(
         "US_LACEY_WORKER_POLL_SECONDS", 2.0, minimum=0.25, maximum=30.0
@@ -84,6 +88,7 @@ def _inline_worker_loop(stop_event: threading.Event) -> None:
                 retried, failed = recover_stale_us_lacey_jobs(
                     stale_after_seconds=stale_after
                 )
+                _record_worker_success()
                 if retried or failed:
                     _LOG.warning(
                         "stale_jobs_recovered retried=%s failed=%s",
@@ -96,6 +101,7 @@ def _inline_worker_loop(stop_event: threading.Event) -> None:
 
         try:
             result = process_one_us_lacey_job(worker_id=worker_id)
+            _record_worker_success()
             if result.claimed:
                 _LOG.info(
                     "job_processed job_id=%s job_status=%s document_status=%s "
@@ -141,7 +147,24 @@ def _start_inline_worker() -> None:
     )
     app.state.us_lacey_inline_worker_stop = stop_event
     app.state.us_lacey_inline_worker_thread = thread
+    app.state.us_lacey_inline_worker_last_success_monotonic = 0.0
     thread.start()
+
+
+def _inline_worker_ready() -> bool:
+    thread = getattr(app.state, "us_lacey_inline_worker_thread", None)
+    if thread is None or not thread.is_alive():
+        return False
+    last_success = float(
+        getattr(app.state, "us_lacey_inline_worker_last_success_monotonic", 0.0)
+    )
+    if last_success <= 0:
+        return False
+    poll_seconds = _float_env(
+        "US_LACEY_WORKER_POLL_SECONDS", 2.0, minimum=0.25, maximum=30.0
+    )
+    maximum_heartbeat_age = max(15.0, poll_seconds * 4.0)
+    return (time.monotonic() - last_success) <= maximum_heartbeat_age
 
 
 def _stop_inline_worker() -> None:
@@ -176,7 +199,7 @@ app.router.lifespan_context = _free_lifespan
 @app.get("/live-readiness")
 def us_lacey_live_readiness(response: Response) -> dict[str, str]:
     result = live_runtime_status(
-        worker_thread=getattr(app.state, "us_lacey_inline_worker_thread", None),
+        worker_ready=_inline_worker_ready(),
         storage_roundtrip=str(
             getattr(app.state, "us_lacey_storage_roundtrip", "not_ready")
         ),

--- a/src/litoral_trace/web/us_lacey_free_app.py
+++ b/src/litoral_trace/web/us_lacey_free_app.py
@@ -19,10 +19,14 @@ import threading
 import time
 from uuid import uuid4
 
-from fastapi import Request
+from fastapi import Request, Response, status
 from fastapi.responses import HTMLResponse
 
 from litoral_trace.us_lacey.jobs import recover_stale_us_lacey_jobs
+from litoral_trace.us_lacey.live_readiness import (
+    live_runtime_status,
+    probe_storage_roundtrip,
+)
 from litoral_trace.us_lacey.worker import process_one_us_lacey_job
 from litoral_trace.us_lacey.worker_db import get_us_lacey_worker_database_url
 from litoral_trace.web.us_lacey_pilot_app import app
@@ -159,6 +163,7 @@ _original_lifespan_context = app.router.lifespan_context
 async def _free_lifespan(application):
     async with _original_lifespan_context(application) as state:
         _start_inline_worker()
+        application.state.us_lacey_storage_roundtrip = probe_storage_roundtrip()
         try:
             yield state
         finally:
@@ -166,6 +171,20 @@ async def _free_lifespan(application):
 
 
 app.router.lifespan_context = _free_lifespan
+
+
+@app.get("/live-readiness")
+def us_lacey_live_readiness(response: Response) -> dict[str, str]:
+    result = live_runtime_status(
+        worker_thread=getattr(app.state, "us_lacey_inline_worker_thread", None),
+        storage_roundtrip=str(
+            getattr(app.state, "us_lacey_storage_roundtrip", "not_ready")
+        ),
+    )
+    if result["status"] != "ready":
+        response.status_code = status.HTTP_503_SERVICE_UNAVAILABLE
+    response.headers["Cache-Control"] = "no-store, max-age=0"
+    return result
 
 
 def _legal_response(request: Request, title: str, version_env: str, sections: list[tuple[str, str]]) -> HTMLResponse:

--- a/tests/test_us_lacey_live_readiness.py
+++ b/tests/test_us_lacey_live_readiness.py
@@ -77,10 +77,9 @@ def test_storage_roundtrip_fails_closed_when_cleanup_fails(monkeypatch):
     assert storage.delete_key == storage.put_key
 
 
-def test_live_runtime_status_requires_live_worker_and_storage():
-    worker = SimpleNamespace(is_alive=lambda: True)
+def test_live_runtime_status_requires_successful_worker_heartbeat_and_storage():
     assert live_readiness.live_runtime_status(
-        worker_thread=worker,
+        worker_ready=True,
         storage_roundtrip="ready",
     ) == {
         "status": "ready",
@@ -89,10 +88,9 @@ def test_live_runtime_status_requires_live_worker_and_storage():
     }
 
 
-def test_live_runtime_status_fails_closed():
-    worker = SimpleNamespace(is_alive=lambda: False)
+def test_live_runtime_status_fails_closed_without_worker_heartbeat():
     assert live_readiness.live_runtime_status(
-        worker_thread=worker,
+        worker_ready=False,
         storage_roundtrip="ready",
     ) == {
         "status": "not_ready",

--- a/tests/test_us_lacey_live_readiness.py
+++ b/tests/test_us_lacey_live_readiness.py
@@ -1,0 +1,101 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from litoral_trace.us_lacey import live_readiness
+
+
+class _Stream:
+    def __init__(self, payload: bytes):
+        self._payload = payload
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return None
+
+    def read(self) -> bytes:
+        return self._payload
+
+
+class _Storage:
+    def __init__(self, *, payload: bytes, cleanup_fails: bool = False):
+        self.payload = payload
+        self.cleanup_fails = cleanup_fails
+        self.put_key: str | None = None
+        self.delete_key: str | None = None
+
+    def put_object(self, *, key, body, content_type, content_length, metadata=None):
+        assert body == self.payload
+        assert content_type == "text/plain"
+        assert content_length == len(self.payload)
+        assert metadata == {"purpose": "live-readiness"}
+        self.put_key = key
+        return SimpleNamespace(version_id="version-1")
+
+    def head_object(self, *, key, version_id=None):
+        assert key == self.put_key
+        assert version_id == "version-1"
+        return SimpleNamespace(size_bytes=len(self.payload))
+
+    def get_object_stream(self, *, key, version_id=None):
+        assert key == self.put_key
+        assert version_id == "version-1"
+        return _Stream(self.payload)
+
+    def delete_object(self, *, key, version_id=None):
+        self.delete_key = key
+        assert version_id == "version-1"
+        if self.cleanup_fails:
+            raise RuntimeError("simulated cleanup failure")
+        return SimpleNamespace(delete_marker=False, version_id=version_id)
+
+
+def test_storage_roundtrip_uses_isolated_healthcheck_prefix_and_cleans(monkeypatch):
+    payload = b"us-lacey-live-readiness"
+    storage = _Storage(payload=payload)
+    settings = SimpleNamespace(normalized_key_prefix="us-lacey/pilot")
+    monkeypatch.setattr(live_readiness, "build_us_lacey_storage_settings", lambda: settings)
+    monkeypatch.setattr(live_readiness, "get_us_lacey_storage_client", lambda: storage)
+
+    assert live_readiness.probe_storage_roundtrip() == "ready"
+    assert storage.put_key is not None
+    assert storage.put_key.startswith("us-lacey/pilot/healthchecks/")
+    assert storage.put_key.endswith(".txt")
+    assert storage.delete_key == storage.put_key
+
+
+def test_storage_roundtrip_fails_closed_when_cleanup_fails(monkeypatch):
+    payload = b"us-lacey-live-readiness"
+    storage = _Storage(payload=payload, cleanup_fails=True)
+    settings = SimpleNamespace(normalized_key_prefix="us-lacey/pilot")
+    monkeypatch.setattr(live_readiness, "build_us_lacey_storage_settings", lambda: settings)
+    monkeypatch.setattr(live_readiness, "get_us_lacey_storage_client", lambda: storage)
+
+    assert live_readiness.probe_storage_roundtrip() == "not_ready"
+    assert storage.delete_key == storage.put_key
+
+
+def test_live_runtime_status_requires_live_worker_and_storage():
+    worker = SimpleNamespace(is_alive=lambda: True)
+    assert live_readiness.live_runtime_status(
+        worker_thread=worker,
+        storage_roundtrip="ready",
+    ) == {
+        "status": "ready",
+        "inline_worker": "ready",
+        "storage_roundtrip": "ready",
+    }
+
+
+def test_live_runtime_status_fails_closed():
+    worker = SimpleNamespace(is_alive=lambda: False)
+    assert live_readiness.live_runtime_status(
+        worker_thread=worker,
+        storage_roundtrip="ready",
+    ) == {
+        "status": "not_ready",
+        "inline_worker": "not_ready",
+        "storage_roundtrip": "ready",
+    }

--- a/tests/test_us_lacey_live_readiness.py
+++ b/tests/test_us_lacey_live_readiness.py
@@ -97,3 +97,22 @@ def test_live_runtime_status_fails_closed_without_worker_heartbeat():
         "inline_worker": "not_ready",
         "storage_roundtrip": "ready",
     }
+
+
+def test_free_tier_worker_readiness_requires_fresh_successful_db_heartbeat(monkeypatch):
+    from litoral_trace.web import us_lacey_free_app
+
+    class _Thread:
+        @staticmethod
+        def is_alive() -> bool:
+            return True
+
+    monkeypatch.setenv("US_LACEY_WORKER_POLL_SECONDS", "2")
+    monkeypatch.setattr(us_lacey_free_app.time, "monotonic", lambda: 100.0)
+    us_lacey_free_app.app.state.us_lacey_inline_worker_thread = _Thread()
+
+    us_lacey_free_app.app.state.us_lacey_inline_worker_last_success_monotonic = 99.0
+    assert us_lacey_free_app._inline_worker_ready() is True
+
+    us_lacey_free_app.app.state.us_lacey_inline_worker_last_success_monotonic = 80.0
+    assert us_lacey_free_app._inline_worker_ready() is False


### PR DESCRIPTION
Closes the next technical slice of #142 without changing the PPQ 505 contract.

Changes:
- versioned persistent Neon live inspection gate;
- Render live gate for /health, /ready and legal pages;
- one-shot free-tier S3 round-trip probe under the isolated U.S. prefix;
- secret-free /live-readiness status for inline worker + storage;
- unit coverage including cleanup fail-closed behavior.

Acceptance before merge:
- general CI green;
- PostgreSQL gates remain green where triggered;
- new live-readiness unit tests pass;
- no secrets or infrastructure identifiers exposed by the diagnostic response.

After merge, Render auto-deploys the feature branch; then the external live gate will be extended/re-run to require inline_worker=ready and storage_roundtrip=ready before B07/B10 are marked complete.