### PR TITLE
U.S. Lacey: English-only portal shell

### DIFF
--- a/src/litoral_trace/templates/us_lacey/base.html
+++ b/src/litoral_trace/templates/us_lacey/base.html
@@ -1,27 +1,83 @@
-{% extends "public/base_public.html" %}
+{% extends "base.html" %}
 {% from "components/ui.html" import button, badge, status_badge, alert, page_header, empty_state %}
 
+{% block html_open %}<html lang="en" class="h-full bg-slate-50">{% endblock %}
 {% block title %}{% block lacey_title %}U.S. Lacey{% endblock %} | Litoral Trace{% endblock %}
 
-{% block content %}
-<section class="bg-slate-50 px-4 py-8 sm:px-6 lg:px-8">
-  <div class="mx-auto max-w-6xl">
-    <div class="mb-6 flex flex-wrap items-center justify-between gap-3 border-b border-slate-200 pb-4">
-      <p class="text-xs font-bold uppercase tracking-[0.14em] text-emerald-700">Litoral Trace · U.S. Lacey private beta</p>
-      {% if authenticated %}
-      <nav class="flex flex-wrap items-center gap-2" aria-label="U.S. Lacey workspace">
-        {{ button("Operations", "/operations", "ghost", "fa-briefcase") }}
-        {{ button("Billing", "/billing", "ghost", "fa-receipt") }}
-        <form method="post" action="/logout" class="inline">{{ button("Sign out", variant="secondary", icon="fa-right-from-bracket", button_type="submit") }}</form>
+{% block shell %}
+<a href="#main-content" class="sr-only focus:not-sr-only focus:fixed focus:left-4 focus:top-4 focus:z-[70] focus:rounded-lg focus:bg-white focus:px-4 focus:py-2 focus:text-sm focus:font-semibold focus:text-slate-950 focus:shadow-lg">
+  Skip to main content
+</a>
+
+<div class="min-h-full bg-white text-slate-900">
+  <header class="sticky top-0 z-50 border-b border-slate-200/80 bg-white/95 backdrop-blur-xl">
+    <div class="mx-auto flex min-h-[4.5rem] max-w-7xl flex-wrap items-center gap-4 px-4 py-3 sm:px-6 lg:px-8">
+      <a href="/" class="flex shrink-0 items-center gap-3" aria-label="Litoral Trace U.S. Lacey workspace home">
+        <span class="flex h-10 w-10 items-center justify-center rounded-xl bg-emerald-600 text-white shadow-sm shadow-emerald-900/20" aria-hidden="true">
+          <i class="fa-solid fa-tree"></i>
+        </span>
+        <span class="min-w-0">
+          <span class="block text-base font-bold tracking-tight text-slate-950">Litoral Trace</span>
+          <span class="block text-[10px] font-bold uppercase tracking-[0.14em] text-emerald-700">U.S. Lacey Act workspace</span>
+        </span>
+      </a>
+
+      <nav class="ml-auto flex flex-wrap items-center justify-end gap-2" aria-label="U.S. Lacey portal navigation">
+        {% if authenticated %}
+          {{ button("Operations", "/operations", "ghost", "fa-briefcase") }}
+          {{ button("Billing", "/billing", "ghost", "fa-receipt") }}
+          {{ button("Private Beta Terms", "/legal/private-beta", "ghost", "fa-scale-balanced") }}
+          <form method="post" action="/logout" class="inline">{{ button("Sign out", variant="secondary", icon="fa-right-from-bracket", button_type="submit") }}</form>
+        {% else %}
+          {{ button("Terms", "/legal/terms", "ghost") }}
+          {{ button("Privacy", "/legal/privacy", "ghost") }}
+          {{ button("Private Beta", "/legal/private-beta", "ghost") }}
+          {{ button("Sign in", "/login", "secondary") }}
+          {{ button("Create account", "/signup", "primary") }}
+        {% endif %}
       </nav>
-      {% else %}
-      <nav class="flex flex-wrap items-center gap-2" aria-label="U.S. Lacey account">
-        {{ button("Sign in", "/login", "ghost") }}
-        {{ button("Create account", "/signup", "primary") }}
-      </nav>
-      {% endif %}
     </div>
-    <div class="lt-page">{% block lacey_content %}{% endblock %}</div>
-  </div>
-</section>
+  </header>
+
+  <main id="main-content" tabindex="-1">
+    <section class="bg-slate-50 px-4 py-8 sm:px-6 lg:px-8">
+      <div class="mx-auto max-w-6xl">
+        <div class="mb-6 flex flex-wrap items-center justify-between gap-3 border-b border-slate-200 pb-4">
+          <p class="text-xs font-bold uppercase tracking-[0.14em] text-emerald-700">Litoral Trace · U.S. Lacey Private Beta</p>
+          {% if authenticated %}
+          <p class="text-xs font-semibold uppercase tracking-wide text-slate-500">PPQ 505 preparation · Human review required</p>
+          {% else %}
+          <p class="text-xs font-semibold uppercase tracking-wide text-slate-500">Document preparation · Evidence management</p>
+          {% endif %}
+        </div>
+        <div class="lt-page">{% block lacey_content %}{% endblock %}</div>
+      </div>
+    </section>
+  </main>
+
+  <footer class="border-t border-slate-800 bg-slate-950 text-slate-400">
+    <div class="mx-auto grid max-w-7xl gap-8 px-4 py-10 sm:px-6 md:grid-cols-2 lg:px-8">
+      <div>
+        <div class="flex items-center gap-3">
+          <span class="flex h-9 w-9 items-center justify-center rounded-lg bg-emerald-600 text-white" aria-hidden="true"><i class="fa-solid fa-tree"></i></span>
+          <div>
+            <p class="font-bold text-white">Litoral Trace</p>
+            <p class="text-[10px] font-bold uppercase tracking-[0.14em] text-emerald-400">U.S. Lacey Act workspace</p>
+          </div>
+        </div>
+        <p class="mt-4 max-w-xl text-sm leading-6 text-slate-400">Document preparation, evidence management and human review for U.S. Lacey Act and PPQ 505 workflows.</p>
+        <p class="mt-3 max-w-xl text-xs leading-5 text-slate-500">Preparation work product only. Not filed. No ACE/LAWGS submission. Litoral Trace does not provide legal advice or make an automatic legal-compliance determination.</p>
+      </div>
+      <div class="md:text-right">
+        <p class="text-sm font-semibold text-slate-200">U.S. Lacey Private Beta · Human-reviewed preparation</p>
+        <div class="mt-5 flex flex-wrap gap-4 md:justify-end">
+          <a href="/legal/terms" class="text-xs font-semibold text-slate-400 hover:text-white">Terms</a>
+          <a href="/legal/privacy" class="text-xs font-semibold text-slate-400 hover:text-white">Privacy</a>
+          <a href="/legal/private-beta" class="text-xs font-semibold text-slate-400 hover:text-white">Private Beta Terms</a>
+          <a href="mailto:comercial@litoraltrace.com" class="text-xs font-semibold text-emerald-400 hover:text-emerald-300">comercial@litoraltrace.com</a>
+        </div>
+      </div>
+    </div>
+  </footer>
+</div>
 {% endblock %}

--- a/tests/test_us_lacey_english_shell.py
+++ b/tests/test_us_lacey_english_shell.py
@@ -1,0 +1,36 @@
+from pathlib import Path
+
+
+US_LACEY_TEMPLATE_DIR = Path("src/litoral_trace/templates/us_lacey")
+
+
+def test_us_lacey_shell_is_english_and_isolated_from_regional_public_layout():
+    text = (US_LACEY_TEMPLATE_DIR / "base.html").read_text(encoding="utf-8")
+
+    assert '{% extends "base.html" %}' in text
+    assert 'lang="en"' in text
+    assert "U.S. Lacey Act workspace" in text
+    assert "PPQ 505 preparation" in text
+    assert "Human review required" in text
+    assert "public/base_public.html" not in text
+
+
+def test_us_lacey_templates_do_not_contain_regional_spanish_navigation_copy():
+    banned = {
+        "Trazabilidad de origen",
+        "Plataforma",
+        "Debida diligencia",
+        "Contexto regional",
+        "Auditabilidad",
+        "Acceso de clientes",
+        "Solicitar demostración",
+        "Solicitar demo",
+        "Ir al contenido principal",
+        "Navegación pública",
+        "Argentina · Cadenas forestales · Comercio exterior",
+    }
+
+    for template in sorted(US_LACEY_TEMPLATE_DIR.glob("*.html")):
+        text = template.read_text(encoding="utf-8")
+        for phrase in banned:
+            assert phrase not in text, f"{template} contains regional Spanish copy: {phrase!r}"

--- a/tests/test_us_lacey_ui_parity.py
+++ b/tests/test_us_lacey_ui_parity.py
@@ -20,13 +20,23 @@ def test_us_lacey_views_delegate_html_to_shared_jinja_templates() -> None:
         assert "background:#" not in source
 
 
-def test_us_lacey_templates_inherit_the_canonical_public_shell() -> None:
+def test_us_lacey_templates_use_shared_design_system_with_an_isolated_english_shell() -> None:
     base = (TEMPLATES / "base.html").read_text(encoding="utf-8")
-    assert '{% extends "public/base_public.html" %}' in base
+    assert '{% extends "base.html" %}' in base
+    assert '{% extends "public/base_public.html" %}' not in base
     assert '{% from "components/ui.html" import' in base
+    assert 'lang="en"' in base
+    assert "U.S. Lacey Act workspace" in base
+    assert "PPQ 505 preparation" in base
+    assert "Trazabilidad de origen" not in base
+    assert "Debida diligencia" not in base
+
     for path in TEMPLATES.glob("*.html"):
         if path.name != "base.html":
             assert '{% extends "us_lacey/base.html" %}' in path.read_text(encoding="utf-8")
+
+    # Public marketing/demo pages remain on the canonical public shell; only the
+    # private U.S. customer portal is isolated from its regional navigation copy.
     for path in PUBLIC_LACEY_TEMPLATES:
         assert '{% extends "public/base_public.html" %}' in path.read_text(encoding="utf-8")
 


### PR DESCRIPTION
Isolates the U.S. Lacey portal from the Argentina/regional public shell.

Changes:
- U.S. Lacey templates now inherit directly from the neutral base template;
- `<html lang="en">`, skip link, header, navigation and footer are English-only;
- visible chrome is specific to U.S. Lacey Act / PPQ 505 / human-reviewed preparation;
- removes inherited Argentina/EUDR navigation and footer copy from every U.S. Lacey screen;
- adds a regression test that rejects the known Spanish regional labels from `templates/us_lacey`.

No PPQ 505 business logic, authentication logic, billing logic or database schema changes.

Related follow-up tracked in #142: configure the customer-facing custom domain `lacey.litoraltrace.com` before pilot GO.