### PR TITLE
Finalize U.S. Lacey custom-domain cutover

### DIFF
--- a/.github/workflows/us-lacey-render-live-gate.yml
+++ b/.github/workflows/us-lacey-render-live-gate.yml
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 12
     env:
-      ORIGIN: https://litoral-trace-us-lacey-pilot-free.onrender.com
+      ORIGIN: https://lacey.litoraltrace.com
     steps:
       - name: Wake service and verify health
         shell: bash
@@ -219,7 +219,7 @@ jobs:
           assert body.get('status') == 'ready', body
           assert body.get('service') == 'us-lacey-pilot', body
           assert body.get('environment') == 'production', body
-          assert body.get('hostname') == 'litoral-trace-us-lacey-pilot-free.onrender.com', body
+          assert body.get('hostname') == 'lacey.litoraltrace.com', body
           print('render_ready=PASS')
           PY
           elif [ "$code" = "503" ]; then

--- a/deploy/render-us-lacey-pilot-free.yaml
+++ b/deploy/render-us-lacey-pilot-free.yaml
@@ -30,10 +30,9 @@ services:
         value: src
       - key: US_LACEY_ENVIRONMENT
         value: production
-      # Transitional Render origin. Replace with lacey.litoraltrace.com only
-      # after the custom domain has been moved to this unified service.
+      # Canonical public origin after the custom-domain cutover.
       - key: US_LACEY_APP_HOSTNAME
-        value: litoral-trace-us-lacey-pilot-free.onrender.com
+        value: lacey.litoraltrace.com
       - key: US_LACEY_SESSION_TTL_HOURS
         value: "12"
       - key: US_LACEY_STORAGE_BUCKET
@@ -82,13 +81,13 @@ services:
         sync: false
       - key: US_LACEY_BETA_TERMS_VERSION
         sync: false
-      # Legal pages are served by the same free Render service during the beta.
+      # Legal pages live on the same canonical U.S. Lacey origin.
       - key: US_LACEY_TERMS_URL
-        value: https://litoral-trace-us-lacey-pilot-free.onrender.com/legal/terms
+        value: https://lacey.litoraltrace.com/legal/terms
       - key: US_LACEY_PRIVACY_URL
-        value: https://litoral-trace-us-lacey-pilot-free.onrender.com/legal/privacy
+        value: https://lacey.litoraltrace.com/legal/privacy
       - key: US_LACEY_BETA_TERMS_URL
-        value: https://litoral-trace-us-lacey-pilot-free.onrender.com/legal/private-beta
+        value: https://lacey.litoraltrace.com/legal/private-beta
       - key: US_LACEY_SUPPORT_EMAIL
         value: comercial@litoraltrace.com
 


### PR DESCRIPTION
## DO NOT MERGE UNTIL MANUAL DOMAIN CUTOVER IS COMPLETE

This PR is intentionally prepared in advance so the remaining manual work is limited to moving `lacey.litoraltrace.com` from the legacy Render service to `litoral-trace-us-lacey-pilot-free` and updating the Namecheap CNAME.

## Current verified state
- `https://litoral-trace-us-lacey-pilot-free.onrender.com` has passed the persistent external live gate;
- unified landing, demo, signup/login, legacy aliases, auth guard, worker, S3 roundtrip, `/ready` and legal pages are green;
- the old service must remain available by its Render hostname for rollback.

## Manual cutover checkpoint
1. In Render, open the legacy U.S. Lacey beta service and locate `lacey.litoraltrace.com` under Custom Domains.
2. Move that custom domain to the `litoral-trace-us-lacey-pilot-free` service. If Render does not allow the same domain on both services, remove it from the legacy service first, then immediately add it to `litoral-trace-us-lacey-pilot-free`.
3. In Namecheap > Advanced DNS, edit the existing CNAME record with host `lacey` so its value is exactly `litoral-trace-us-lacey-pilot-free.onrender.com` (no `https://`, no path). Keep the lowest practical/automatic TTL.
4. Return to the new Render service and wait until the custom domain/TLS status is verified/issued.
5. Open `https://lacey.litoraltrace.com` and confirm the unified landing appears, including `Stop manually preparing Lacey spreadsheets.`
6. Do **not** delete the legacy Render service; keep its `onrender.com` hostname available as rollback.
7. Then report the cutover as complete. The remaining GitHub/deploy verification is automated from this PR.

## After the manual cutover, this PR will
- set `US_LACEY_APP_HOSTNAME=lacey.litoraltrace.com`;
- move legal URLs to the canonical custom domain;
- make the persistent live Render gate test `https://lacey.litoraltrace.com` directly;
- require `/ready` to report the canonical hostname;
- re-check landing, demo, legacy aliases, auth guard, worker, S3 roundtrip and legal pages on the final domain.

## Automated completion after the checkpoint
Once DNS/custom-domain routing is confirmed, re-sync this draft with the latest `feature/us-lacey-pilot-platform`, run CI, mark it ready, squash-merge with the exact head SHA, wait for Render auto-deploy, and require the custom-domain live gate to pass before declaring the cutover complete.

## Safety
Do not merge this PR before DNS/custom-domain routing is live. Until then, the deployed service should keep its current `onrender.com` public origin to avoid generating links/forms toward a domain that is still routed to the legacy service.