### PR TITLE
Fix PostgreSQL backup workflow runner context

### DIFF
--- a/.github/workflows/postgres-logical-backup.yml
+++ b/.github/workflows/postgres-logical-backup.yml
@@ -29,7 +29,6 @@ jobs:
       BACKUP_S3_REGION: ${{ vars.BACKUP_S3_REGION }}
       BACKUP_S3_SSE: ${{ vars.BACKUP_S3_SSE }}
       BACKUP_RELEASE_COMMIT: ${{ vars.BACKUP_RELEASE_COMMIT }}
-      BACKUP_WORKDIR: ${{ runner.temp }}/litoral-trace-postgres-backup
     steps:
       - name: Checkout
         # actions/checkout@v4
@@ -81,6 +80,11 @@ jobs:
           if [ "$missing" -ne 0 ]; then
             exit 1
           fi
+
+      - name: Initialize backup workdir
+        shell: bash
+        run: |
+          echo "BACKUP_WORKDIR=$RUNNER_TEMP/litoral-trace-postgres-backup" >> "$GITHUB_ENV"
 
       - name: Create logical backup
         shell: bash

--- a/tests/test_postgres_logical_backup_workflow_p27a3_unittest.py
+++ b/tests/test_postgres_logical_backup_workflow_p27a3_unittest.py
@@ -126,7 +126,14 @@ def test_p27a3c2_validates_required_config_without_printing_values():
 def test_p27a3c2_uses_private_runner_temp_workspace_and_umask():
     workflow = _workflow_text()
 
-    assert "BACKUP_WORKDIR: ${{ runner.temp }}/litoral-trace-postgres-backup" in workflow
+    # `runner` is not an allowed context in jobs.<job_id>.env. Initialize the
+    # private path after the runner exists and persist it through GITHUB_ENV.
+    assert "BACKUP_WORKDIR: ${{ runner.temp }}" not in workflow
+    assert "Initialize backup workdir" in workflow
+    assert (
+        'echo "BACKUP_WORKDIR=$RUNNER_TEMP/litoral-trace-postgres-backup" '
+        '>> "$GITHUB_ENV"'
+    ) in workflow
     assert 'mkdir -p "$BACKUP_WORKDIR"' in workflow
     assert "umask 077" in workflow
     assert "backups/postgres" not in workflow


### PR DESCRIPTION
## Goal
Remove an invalid GitHub Actions context reference that causes the logical-backup workflow to fail validation before any job is created.

## Root cause
`BACKUP_WORKDIR: ${{ runner.temp }}/...` was defined in `jobs.<job_id>.env`. GitHub does not make the `runner` context available at that workflow key, so pushes surface an immediate failed workflow run with zero jobs.

## Fix
- initialize `BACKUP_WORKDIR` from `$RUNNER_TEMP` in a runner step and persist it through `$GITHUB_ENV`;
- keep the backup commands, OIDC permissions, S3 namespace, PostgreSQL client version and cleanup semantics unchanged;
- update the contract test so it rejects the invalid job-level runner context and requires runner-time initialization.

This branch does not activate or execute production backups; the workflow remains schedule/workflow_dispatch only and still documents that operational activation requires the default branch.