### PR TITLE
Finalize U.S. Lacey custom-domain cutover

### DIFF
--- a/.github/workflows/us-lacey-render-live-gate.yml
+++ b/.github/workflows/us-lacey-render-live-gate.yml
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 12
     env:
-      ORIGIN: https://litoral-trace-us-lacey-pilot-free.onrender.com
+      ORIGIN: https://lacey.litoraltrace.com
     steps:
       - name: Wake service and verify health
         shell: bash
@@ -219,7 +219,7 @@ jobs:
           assert body.get('status') == 'ready', body
           assert body.get('service') == 'us-lacey-pilot', body
           assert body.get('environment') == 'production', body
-          assert body.get('hostname') == 'litoral-trace-us-lacey-pilot-free.onrender.com', body
+          assert body.get('hostname') == 'lacey.litoraltrace.com', body
           print('render_ready=PASS')
           PY
           elif [ "$code" = "503" ]; then

--- a/deploy/render-us-lacey-pilot-free.yaml
+++ b/deploy/render-us-lacey-pilot-free.yaml
@@ -30,10 +30,9 @@ services:
         value: src
       - key: US_LACEY_ENVIRONMENT
         value: production
-      # Transitional Render origin. Replace with lacey.litoraltrace.com only
-      # after the custom domain has been moved to this unified service.
+      # Canonical public origin after the custom-domain cutover.
       - key: US_LACEY_APP_HOSTNAME
-        value: litoral-trace-us-lacey-pilot-free.onrender.com
+        value: lacey.litoraltrace.com
       - key: US_LACEY_SESSION_TTL_HOURS
         value: "12"
       - key: US_LACEY_STORAGE_BUCKET
@@ -82,13 +81,13 @@ services:
         sync: false
       - key: US_LACEY_BETA_TERMS_VERSION
         sync: false
-      # Legal pages are served by the same free Render service during the beta.
+      # Legal pages live on the same canonical U.S. Lacey origin.
       - key: US_LACEY_TERMS_URL
-        value: https://litoral-trace-us-lacey-pilot-free.onrender.com/legal/terms
+        value: https://lacey.litoraltrace.com/legal/terms
       - key: US_LACEY_PRIVACY_URL
-        value: https://litoral-trace-us-lacey-pilot-free.onrender.com/legal/privacy
+        value: https://lacey.litoraltrace.com/legal/privacy
       - key: US_LACEY_BETA_TERMS_URL
-        value: https://litoral-trace-us-lacey-pilot-free.onrender.com/legal/private-beta
+        value: https://lacey.litoraltrace.com/legal/private-beta
       - key: US_LACEY_SUPPORT_EMAIL
         value: comercial@litoraltrace.com
 


### PR DESCRIPTION
## Cutover checkpoint completed
`lacey.litoraltrace.com` has already been moved from the legacy Render beta service to `litoral-trace-us-lacey-pilot-free`, the custom domain is verified by Render, HTTPS is serving the unified application, and the regenerated responsive CSS has been independently verified on the live custom domain.

## This PR finalizes configuration
- set `US_LACEY_APP_HOSTNAME=lacey.litoraltrace.com`;
- move Terms / Privacy / Private Beta URLs to the canonical domain;
- make the persistent Render live gate test `https://lacey.litoraltrace.com`;
- require `/ready` to report the canonical hostname.

## Safety / scope
Only the Render Blueprint public-origin settings and live-gate expected origin/hostname change. Auth, PostgreSQL/RLS, worker, S3, PPQ 505, pricing and legal content remain unchanged. The legacy Render service remains available on its `onrender.com` hostname as temporary rollback.