### PR TITLE
Fix UptimeRobot HEAD health probe

### DIFF
--- a/src/litoral_trace/web/us_lacey_unified_app.py
+++ b/src/litoral_trace/web/us_lacey_unified_app.py
@@ -11,7 +11,7 @@ landing -> sample -> signup -> verification -> login -> billing -> operations.
 """
 from __future__ import annotations
 
-from fastapi import Request
+from fastapi import Request, Response
 
 from litoral_trace.us_lacey.portal_auth import US_LACEY_SESSION_COOKIE
 from litoral_trace.web.lacey_gtm import render_lacey_landing, router as lacey_router
@@ -21,6 +21,19 @@ from litoral_trace.web.us_lacey_free_app import app
 # Public marketing/sample routes are additive and do not shadow the certified
 # portal endpoints (/signup, /login, /billing, /operations, /ready, ...).
 app.include_router(lacey_router)
+
+
+@app.head("/health", include_in_schema=False)
+def health_head() -> Response:
+    """Lightweight HEAD liveness probe for external uptime monitors.
+
+    The portal's canonical GET /health contract remains owned by the certified
+    portal app. UptimeRobot uses HEAD for HTTP monitors by default, so accepting
+    HEAD here prevents a healthy service from being reported as HTTP 405/DOWN.
+    """
+    response = Response(status_code=200)
+    response.headers["Cache-Control"] = "no-store, max-age=0"
+    return response
 
 
 @app.middleware("http")

--- a/tests/test_us_lacey_uptime_health.py
+++ b/tests/test_us_lacey_uptime_health.py
@@ -1,0 +1,17 @@
+"""Regression coverage for external U.S. Lacey uptime probes."""
+from fastapi.testclient import TestClient
+
+from litoral_trace.web.us_lacey_unified_app import app
+
+
+def test_us_lacey_health_accepts_get_and_head() -> None:
+    client = TestClient(app)
+
+    get_response = client.get("/health")
+    assert get_response.status_code == 200
+    assert get_response.json() == {"status": "healthy", "service": "us-lacey-pilot"}
+
+    head_response = client.head("/health")
+    assert head_response.status_code == 200
+    assert head_response.content == b""
+    assert head_response.headers["cache-control"] == "no-store, max-age=0"


### PR DESCRIPTION
## Summary
- accept `HEAD /health` on the unified U.S. Lacey service
- preserve the existing canonical `GET /health` JSON contract
- add regression coverage for GET + HEAD

## Why
UptimeRobot HTTP monitors use HEAD by default. The deployed FastAPI service accepted GET only, so the monitor reported `405 Method Not Allowed` even while the service was healthy.

This PR intentionally contains no billing or Lemon Squeezy changes.