### PR TITLE
feat(us-lacey): certify Lemon Squeezy billing on 041

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,7 +71,7 @@ jobs:
             echo "Expected exactly one Alembic head."
             exit 1
           fi
-          grep -Fx "040_us_lacey_ppq505 (head)" alembic-heads.txt
+          grep -Fx "041_us_lacey_lemon (head)" alembic-heads.txt
 
       - name: Run pytest suite
         run: python -m pytest -q -rs

--- a/.github/workflows/us-lacey-postgres-gate.yml
+++ b/.github/workflows/us-lacey-postgres-gate.yml
@@ -436,6 +436,11 @@ jobs:
 
           runtime = create_engine(os.environ["DATABASE_URL"], pool_pre_ping=True)
           migrator = create_engine(os.environ["MIGRATION_DATABASE_URL"], pool_pre_ping=True)
+          audit = create_engine(
+              "postgresql+psycopg://postgres:us_lacey_root_password_2026@127.0.0.1:5432/litoral_trace_us_lacey_ci",
+              pool_pre_ping=True,
+              hide_parameters=True,
+          )
           verification_hash = "b" * 64
           payload_hash = "c" * 64
           fake_bcrypt_hash = "$2b$12$" + ("y" * 53)
@@ -503,7 +508,19 @@ jobs:
               assert second["payment_status"] == "VERIFIED"
               assert second["subscription_status"] == "ACTIVE"
               assert second["account_status"] == "ACTIVE"
+
+          # FORCE RLS must hide the append-only ledger even from its table owner
+          # because no policy is granted to the migration role.
           with migrator.connect() as connection:
+              visible_to_migrator = connection.execute(text("""
+                  SELECT count(*) FROM public.us_lacey_payment_events
+                  WHERE provider_order_id = 'gate-lemon-order-1'
+              """)).scalar_one()
+              assert visible_to_migrator == 0
+
+          # The ephemeral CI superuser is used only as an external auditor so the
+          # gate can prove the hidden ledger row exists without weakening RLS.
+          with audit.connect() as connection:
               event = connection.execute(text("""
                   SELECT provider, provider_order_id, payload_sha256, amount_cents,
                          currency, store_id, variant_id, test_mode
@@ -531,6 +548,7 @@ jobs:
               assert count == 1
           runtime.dispose()
           migrator.dispose()
+          audit.dispose()
           PY
       - name: Prove Lemon fail-closed parsing contracts
         run: python -m pytest -q -rs tests/test_us_lacey_lemon_squeezy.py

--- a/.github/workflows/us-lacey-postgres-gate.yml
+++ b/.github/workflows/us-lacey-postgres-gate.yml
@@ -10,10 +10,12 @@ on:
       - "alembic/versions/038_us_lacey_pilot_activation.py"
       - "alembic/versions/039_fix_us_lacey_pilot_activation.py"
       - "alembic/versions/040_establish_us_lacey_ppq505_contract.py"
+      - "alembic/versions/041_add_us_lacey_lemon_squeezy_billing.py"
       - "src/litoral_trace/us_lacey/**"
       - "src/litoral_trace/web/us_lacey_*"
       - "src/litoral_trace/db/models/us_lacey.py"
       - "src/litoral_trace/db/models/us_lacey_commercial.py"
+      - "src/litoral_trace/db/models/us_lacey_payment_event.py"
       - "src/litoral_trace/db/models/reconciliation_issue.py"
       - "src/litoral_trace/db/models/__init__.py"
       - "src/litoral_trace/db/tenant.py"
@@ -126,7 +128,7 @@ jobs:
           PY
       - name: Migrate through pre-Assurance baseline
         run: python -m alembic upgrade 029_add_smart_import_profiles
-      - name: Migrate through US Lacey self-service head
+      - name: Migrate through US Lacey Lemon head
         run: python -m alembic upgrade head
       - name: Bind dedicated worker login to queue capability
         shell: bash
@@ -152,7 +154,7 @@ jobs:
         run: |
           set -euo pipefail
           python -m alembic current | tee /tmp/alembic-current.txt
-          grep -F "040_us_lacey_ppq505" /tmp/alembic-current.txt
+          grep -F "041_us_lacey_lemon" /tmp/alembic-current.txt
           python - <<'PY'
           import os
           from sqlalchemy import create_engine, text
@@ -170,6 +172,7 @@ jobs:
               "us_lacey_ppq_plant_lines": 4,
               "us_lacey_plant_declarations": 4,
               "us_lacey_field_candidates": 4,
+              "us_lacey_payment_events": 1,
           }
           ppq_tables = (
               "us_lacey_ppq_shipments",
@@ -187,6 +190,17 @@ jobs:
               "ck_us_lacey_field_candidates_confidence",
               "ck_us_lacey_field_candidates_validation",
               "ck_us_lacey_field_candidates_decision",
+          }
+          expected_lemon_constraints = {
+              "ck_us_lacey_payment_events_provider",
+              "ck_us_lacey_payment_events_name",
+              "ck_us_lacey_payment_events_payload_sha256",
+              "ck_us_lacey_payment_events_amount_positive",
+              "ck_us_lacey_payment_events_currency_usd",
+              "ck_us_lacey_payment_events_store_positive",
+              "ck_us_lacey_payment_events_variant_positive",
+              "uq_us_lacey_payment_events_provider_order",
+              "fk_us_lacey_payment_events_payment_tenant",
           }
           engine = create_engine(os.environ["MIGRATION_DATABASE_URL"], pool_pre_ping=True)
           with engine.connect() as connection:
@@ -271,6 +285,59 @@ jobs:
                   FROM pg_constraint
                   WHERE conname = ANY(:names) AND contype = 'c'
               """), {"names": sorted(expected_check_constraints)}).scalars().all()
+              lemon_constraints = connection.execute(text("""
+                  SELECT conname
+                  FROM pg_constraint
+                  WHERE conname = ANY(:names)
+              """), {"names": sorted(expected_lemon_constraints)}).scalars().all()
+              payment_provider_constraint = connection.execute(text("""
+                  SELECT pg_get_constraintdef(oid)
+                  FROM pg_constraint
+                  WHERE conname = 'ck_us_lacey_payments_provider'
+                    AND conrelid = 'public.us_lacey_payments'::regclass
+                    AND contype = 'c'
+              """)).scalar_one()
+              lemon_privileges = connection.execute(text("""
+                  SELECT
+                      has_table_privilege('litoral_trace_platform_definer', c.oid, 'SELECT') AS platform_select,
+                      has_table_privilege('litoral_trace_platform_definer', c.oid, 'INSERT') AS platform_insert,
+                      has_table_privilege('litoral_trace_platform_definer', c.oid, 'UPDATE') AS platform_update,
+                      has_table_privilege('litoral_trace_platform_definer', c.oid, 'DELETE') AS platform_delete,
+                      has_table_privilege('litoral_trace_app', c.oid, 'SELECT') AS runtime_select,
+                      has_table_privilege('litoral_trace_us_lacey_worker', c.oid, 'SELECT') AS worker_select,
+                      EXISTS (
+                          SELECT 1
+                          FROM aclexplode(coalesce(c.relacl, acldefault('r', c.relowner))) AS acl
+                          WHERE acl.grantee = 0
+                            AND acl.privilege_type IN ('SELECT', 'INSERT', 'UPDATE', 'DELETE')
+                      ) AS public_privilege
+                  FROM pg_class c
+                  JOIN pg_namespace n ON n.oid = c.relnamespace
+                  WHERE n.nspname = 'public' AND c.relname = 'us_lacey_payment_events'
+              """)).mappings().one()
+              lemon_sequence_privileges = connection.execute(text("""
+                  SELECT
+                      has_sequence_privilege('litoral_trace_platform_definer', c.oid, 'USAGE') AS platform_usage,
+                      has_sequence_privilege('litoral_trace_platform_definer', c.oid, 'SELECT') AS platform_select,
+                      has_sequence_privilege('litoral_trace_app', c.oid, 'USAGE') AS runtime_usage,
+                      has_sequence_privilege('litoral_trace_us_lacey_worker', c.oid, 'USAGE') AS worker_usage,
+                      EXISTS (
+                          SELECT 1
+                          FROM aclexplode(coalesce(c.relacl, acldefault('S', c.relowner))) AS acl
+                          WHERE acl.grantee = 0
+                      ) AS public_privilege
+                  FROM pg_class c
+                  JOIN pg_namespace n ON n.oid = c.relnamespace
+                  WHERE n.nspname = 'public'
+                    AND c.relname = 'us_lacey_payment_events_id_seq'
+              """)).mappings().one()
+              runtime_apply_execute = connection.execute(text("""
+                  SELECT has_function_privilege(
+                      'litoral_trace_app',
+                      'public.us_lacey_apply_lemon_order(integer,uuid,text,text,text,integer,text,integer,integer,boolean)',
+                      'EXECUTE'
+                  )
+              """)).scalar_one()
           by_table = {row["relname"]: row for row in rows}
           assert set(by_table) == set(expected_policy_counts)
           assert all(row["relrowsecurity"] is True for row in by_table.values())
@@ -296,6 +363,25 @@ jobs:
               for row in ppq_privileges
           )
           assert set(check_constraints) == expected_check_constraints
+          assert set(lemon_constraints) == expected_lemon_constraints
+          assert "LEMON_SQUEEZY" in payment_provider_constraint
+          assert lemon_privileges == {
+              "platform_select": True,
+              "platform_insert": True,
+              "platform_update": False,
+              "platform_delete": False,
+              "runtime_select": False,
+              "worker_select": False,
+              "public_privilege": False,
+          }
+          assert lemon_sequence_privileges == {
+              "platform_usage": True,
+              "platform_select": True,
+              "runtime_usage": False,
+              "worker_usage": False,
+              "public_privilege": False,
+          }
+          assert runtime_apply_execute is True
           engine.dispose()
           PY
       - name: Prove self-registration and email transition
@@ -326,7 +412,7 @@ jobs:
                   "verification_hash": verification_hash,
                   "price_cents": 10000,
                   "monthly_limit": 25,
-                  "provider": "WISE",
+                  "provider": "MANUAL_BANK_TRANSFER",
                   "terms_version": "gate-terms-v1",
                   "privacy_version": "gate-privacy-v1",
                   "beta_version": "gate-beta-v1",
@@ -340,6 +426,114 @@ jobs:
               assert verified["account_status"] == "PAYMENT_PENDING"
           engine.dispose()
           PY
+      - name: Prove Lemon registration activation and idempotency
+        shell: bash
+        run: |
+          set -euo pipefail
+          python - <<'PY'
+          import os
+          from sqlalchemy import create_engine, text
+
+          runtime = create_engine(os.environ["DATABASE_URL"], pool_pre_ping=True)
+          migrator = create_engine(os.environ["MIGRATION_DATABASE_URL"], pool_pre_ping=True)
+          verification_hash = "b" * 64
+          payload_hash = "c" * 64
+          fake_bcrypt_hash = "$2b$12$" + ("y" * 53)
+          values = {
+              "legal_name": "US Lacey Lemon Gate LLC",
+              "business_type": "IMPORTER",
+              "admin_name": "Lemon Gate Admin",
+              "email": "lemon-gate@example.com",
+              "password_hash": fake_bcrypt_hash,
+              "verification_hash": verification_hash,
+              "price_cents": 19900,
+              "monthly_limit": 25,
+              "provider": "LEMON_SQUEEZY",
+              "terms_version": "gate-terms-v1",
+              "privacy_version": "gate-privacy-v1",
+              "beta_version": "gate-beta-v1",
+          }
+          with runtime.begin() as connection:
+              registered = connection.execute(text("""
+                  SELECT * FROM public.us_lacey_self_register(
+                      :legal_name, :business_type, :admin_name, :email,
+                      :password_hash, :verification_hash, :price_cents,
+                      :monthly_limit, :provider, :terms_version,
+                      :privacy_version, :beta_version
+                  )
+              """), values).mappings().one()
+              assert registered["account_status"] == "PENDING_EMAIL"
+              verified = connection.execute(text("""
+                  SELECT * FROM public.us_lacey_verify_email(:token_hash)
+              """), {"token_hash": verification_hash}).mappings().one()
+              assert verified["account_status"] == "PAYMENT_PENDING"
+              activation_args = {
+                  "organization_id": registered["organization_id"],
+                  "payment_public_id": registered["payment_public_id"],
+                  "provider_order_id": "gate-lemon-order-1",
+                  "event_name": "order_created",
+                  "payload_sha256": payload_hash,
+                  "amount_cents": 19900,
+                  "currency": "USD",
+                  "store_id": 321,
+                  "variant_id": 654,
+                  "test_mode": True,
+              }
+              first = connection.execute(text("""
+                  SELECT * FROM public.us_lacey_apply_lemon_order(
+                      :organization_id, :payment_public_id, :provider_order_id,
+                      :event_name, :payload_sha256, :amount_cents, :currency,
+                      :store_id, :variant_id, :test_mode
+                  )
+              """), activation_args).mappings().one()
+              assert first == {
+                  "payment_status": "VERIFIED",
+                  "subscription_status": "ACTIVE",
+                  "account_status": "ACTIVE",
+                  "idempotent": False,
+              }
+              second = connection.execute(text("""
+                  SELECT * FROM public.us_lacey_apply_lemon_order(
+                      :organization_id, :payment_public_id, :provider_order_id,
+                      :event_name, :payload_sha256, :amount_cents, :currency,
+                      :store_id, :variant_id, :test_mode
+                  )
+              """), activation_args).mappings().one()
+              assert second["idempotent"] is True
+              assert second["payment_status"] == "VERIFIED"
+              assert second["subscription_status"] == "ACTIVE"
+              assert second["account_status"] == "ACTIVE"
+          with migrator.connect() as connection:
+              event = connection.execute(text("""
+                  SELECT provider, provider_order_id, payload_sha256, amount_cents,
+                         currency, store_id, variant_id, test_mode
+                  FROM public.us_lacey_payment_events
+                  WHERE organization_id = :organization_id
+                    AND provider_order_id = :provider_order_id
+              """), {
+                  "organization_id": registered["organization_id"],
+                  "provider_order_id": "gate-lemon-order-1",
+              }).mappings().one()
+              assert event == {
+                  "provider": "LEMON_SQUEEZY",
+                  "provider_order_id": "gate-lemon-order-1",
+                  "payload_sha256": payload_hash,
+                  "amount_cents": 19900,
+                  "currency": "USD",
+                  "store_id": 321,
+                  "variant_id": 654,
+                  "test_mode": True,
+              }
+              count = connection.execute(text("""
+                  SELECT count(*) FROM public.us_lacey_payment_events
+                  WHERE provider_order_id = 'gate-lemon-order-1'
+              """)).scalar_one()
+              assert count == 1
+          runtime.dispose()
+          migrator.dispose()
+          PY
+      - name: Prove Lemon fail-closed parsing contracts
+        run: python -m pytest -q -rs tests/test_us_lacey_lemon_squeezy.py
       - name: Prove portal login, opaque session and logout
         env:
           DATABASE_URL: ""

--- a/alembic/versions/041_add_us_lacey_lemon_squeezy_billing.py
+++ b/alembic/versions/041_add_us_lacey_lemon_squeezy_billing.py
@@ -200,7 +200,10 @@ def upgrade() -> None:
             normalized_provider text := upper(btrim(coalesce(requested_payment_provider, '')));
             registration record;
         BEGIN
-            IF normalized_provider NOT IN ('MANUAL_BANK_TRANSFER','LEMON_SQUEEZY') THEN
+            -- 041 is additive: preserve both manual providers already supported
+            -- by the certified portal while introducing Lemon as a new path.
+            -- STRIPE remains schema-history only and is not valid for new signup.
+            IF normalized_provider NOT IN ('MANUAL_BANK_TRANSFER','WISE','LEMON_SQUEEZY') THEN
                 RAISE EXCEPTION 'invalid initial payment provider' USING ERRCODE = '22023';
             END IF;
 

--- a/alembic/versions/041_add_us_lacey_lemon_squeezy_billing.py
+++ b/alembic/versions/041_add_us_lacey_lemon_squeezy_billing.py
@@ -1,0 +1,408 @@
+"""Add signed Lemon Squeezy payment activation for U.S. Lacey.
+
+Revision ID: 041_us_lacey_lemon
+Revises: 040_us_lacey_ppq505
+Create Date: 2026-09-02 18:20:00.000000
+"""
+from __future__ import annotations
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = "041_us_lacey_lemon"
+down_revision: Union[str, Sequence[str], None] = "040_us_lacey_ppq505"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+RUNTIME_ROLE = "litoral_trace_app"
+PLATFORM_ROLE = "litoral_trace_platform_definer"
+WORKER_ROLE = "litoral_trace_worker_executor"
+REGISTER_SIGNATURE = (
+    "public.us_lacey_self_register(text,text,text,text,text,text,integer,integer,text,text,text,text)"
+)
+REGISTER_LEGACY_SIGNATURE = (
+    "public.us_lacey_self_register_legacy(text,text,text,text,text,text,integer,integer,text,text,text,text)"
+)
+APPLY_SIGNATURE = (
+    "public.us_lacey_apply_lemon_order(integer,uuid,text,text,text,integer,text,integer,integer,boolean)"
+)
+
+
+def _grant_temp_platform_set() -> None:
+    op.execute(
+        f"GRANT {PLATFORM_ROLE} TO CURRENT_USER "
+        "WITH ADMIN FALSE, INHERIT FALSE, SET TRUE GRANTED BY CURRENT_USER"
+    )
+
+
+def _revoke_temp_platform_set() -> None:
+    op.execute(f"REVOKE {PLATFORM_ROLE} FROM CURRENT_USER GRANTED BY CURRENT_USER")
+
+
+def _enter_platform_role() -> None:
+    _grant_temp_platform_set()
+    op.execute(f"GRANT CREATE ON SCHEMA public TO {PLATFORM_ROLE}")
+    op.execute(f"SET ROLE {PLATFORM_ROLE}")
+
+
+def _leave_platform_role() -> None:
+    op.execute("RESET ROLE")
+    op.execute(f"REVOKE CREATE ON SCHEMA public FROM {PLATFORM_ROLE}")
+    _revoke_temp_platform_set()
+
+
+def upgrade() -> None:
+    op.drop_constraint(
+        "ck_us_lacey_payments_provider", "us_lacey_payments", type_="check"
+    )
+    op.create_check_constraint(
+        "ck_us_lacey_payments_provider",
+        "us_lacey_payments",
+        "provider IN ('MANUAL_BANK_TRANSFER','WISE','STRIPE','LEMON_SQUEEZY')",
+    )
+
+    op.create_table(
+        "us_lacey_payment_events",
+        sa.Column("id", sa.Integer(), autoincrement=True, nullable=False),
+        sa.Column("organization_id", sa.Integer(), nullable=False),
+        sa.Column("payment_id", sa.Integer(), nullable=False),
+        sa.Column("provider", sa.String(length=40), nullable=False),
+        sa.Column("provider_order_id", sa.String(length=128), nullable=False),
+        sa.Column("event_name", sa.String(length=64), nullable=False),
+        sa.Column("payload_sha256", sa.String(length=64), nullable=False),
+        sa.Column("amount_cents", sa.Integer(), nullable=False),
+        sa.Column("currency", sa.String(length=3), nullable=False),
+        sa.Column("store_id", sa.Integer(), nullable=False),
+        sa.Column("variant_id", sa.Integer(), nullable=False),
+        sa.Column("test_mode", sa.Boolean(), nullable=False),
+        sa.Column(
+            "processed_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("CURRENT_TIMESTAMP"),
+            nullable=False,
+        ),
+        sa.ForeignKeyConstraint(
+            ["payment_id", "organization_id"],
+            ["us_lacey_payments.id", "us_lacey_payments.organization_id"],
+            name="fk_us_lacey_payment_events_payment_tenant",
+            ondelete="CASCADE",
+        ),
+        sa.PrimaryKeyConstraint("id", name="pk_us_lacey_payment_events"),
+        sa.UniqueConstraint(
+            "provider", "provider_order_id", name="uq_us_lacey_payment_events_provider_order"
+        ),
+        sa.CheckConstraint(
+            "provider = 'LEMON_SQUEEZY'", name="ck_us_lacey_payment_events_provider"
+        ),
+        sa.CheckConstraint(
+            "event_name = 'order_created'", name="ck_us_lacey_payment_events_name"
+        ),
+        sa.CheckConstraint(
+            "payload_sha256 ~ '^[0-9a-f]{64}$'",
+            name="ck_us_lacey_payment_events_payload_sha256",
+        ),
+        sa.CheckConstraint(
+            "amount_cents > 0", name="ck_us_lacey_payment_events_amount_positive"
+        ),
+        sa.CheckConstraint(
+            "currency = 'USD'", name="ck_us_lacey_payment_events_currency_usd"
+        ),
+        sa.CheckConstraint(
+            "store_id > 0", name="ck_us_lacey_payment_events_store_positive"
+        ),
+        sa.CheckConstraint(
+            "variant_id > 0", name="ck_us_lacey_payment_events_variant_positive"
+        ),
+    )
+    op.create_index(
+        "ix_us_lacey_payment_events_org_payment",
+        "us_lacey_payment_events",
+        ["organization_id", "payment_id"],
+    )
+
+    op.execute("ALTER TABLE public.us_lacey_payment_events ENABLE ROW LEVEL SECURITY")
+    op.execute("ALTER TABLE public.us_lacey_payment_events FORCE ROW LEVEL SECURITY")
+    op.execute(
+        "CREATE POLICY us_lacey_payment_events_platform_all "
+        "ON public.us_lacey_payment_events FOR ALL "
+        f"TO {PLATFORM_ROLE} USING (true) WITH CHECK (true)"
+    )
+    op.execute("REVOKE ALL ON TABLE public.us_lacey_payment_events FROM PUBLIC")
+    op.execute(f"REVOKE ALL ON TABLE public.us_lacey_payment_events FROM {RUNTIME_ROLE}")
+    op.execute(f"REVOKE ALL ON TABLE public.us_lacey_payment_events FROM {WORKER_ROLE}")
+    op.execute(
+        f"GRANT SELECT, INSERT ON TABLE public.us_lacey_payment_events TO {PLATFORM_ROLE}"
+    )
+    op.execute("REVOKE ALL ON SEQUENCE public.us_lacey_payment_events_id_seq FROM PUBLIC")
+    op.execute(
+        f"REVOKE ALL ON SEQUENCE public.us_lacey_payment_events_id_seq FROM {RUNTIME_ROLE}"
+    )
+    op.execute(
+        f"REVOKE ALL ON SEQUENCE public.us_lacey_payment_events_id_seq FROM {WORKER_ROLE}"
+    )
+    op.execute(
+        f"GRANT USAGE, SELECT ON SEQUENCE public.us_lacey_payment_events_id_seq TO {PLATFORM_ROLE}"
+    )
+
+    # The original registration function remains the proven account-creation
+    # implementation. Rename it behind a same-signature facade so Python callers
+    # do not change and Lemon can be introduced without duplicating that contract.
+    _enter_platform_role()
+    op.execute(
+        "ALTER FUNCTION public.us_lacey_self_register(text,text,text,text,text,text,integer,integer,text,text,text,text) "
+        "RENAME TO us_lacey_self_register_legacy"
+    )
+    op.execute(f"REVOKE ALL ON FUNCTION {REGISTER_LEGACY_SIGNATURE} FROM PUBLIC")
+    op.execute(f"REVOKE ALL ON FUNCTION {REGISTER_LEGACY_SIGNATURE} FROM {RUNTIME_ROLE}")
+    op.execute(f"GRANT EXECUTE ON FUNCTION {REGISTER_LEGACY_SIGNATURE} TO {PLATFORM_ROLE}")
+
+    op.execute(
+        """
+        CREATE FUNCTION public.us_lacey_self_register(
+            requested_legal_name text,
+            requested_business_type text,
+            requested_admin_name text,
+            requested_admin_email text,
+            requested_password_hash text,
+            requested_verification_token_hash text,
+            requested_price_cents integer,
+            requested_monthly_operation_limit integer,
+            requested_payment_provider text,
+            requested_terms_version text,
+            requested_privacy_version text,
+            requested_beta_version text
+        )
+        RETURNS TABLE (
+            organization_id integer,
+            user_id integer,
+            payment_public_id uuid,
+            payment_reference text,
+            amount_cents integer,
+            account_status text
+        )
+        LANGUAGE plpgsql
+        SECURITY DEFINER
+        SET search_path = public, pg_temp
+        AS $$
+        DECLARE
+            normalized_provider text := upper(btrim(coalesce(requested_payment_provider, '')));
+            registration record;
+        BEGIN
+            IF normalized_provider NOT IN ('MANUAL_BANK_TRANSFER','LEMON_SQUEEZY') THEN
+                RAISE EXCEPTION 'invalid initial payment provider' USING ERRCODE = '22023';
+            END IF;
+
+            SELECT * INTO registration
+            FROM public.us_lacey_self_register_legacy(
+                requested_legal_name,
+                requested_business_type,
+                requested_admin_name,
+                requested_admin_email,
+                requested_password_hash,
+                requested_verification_token_hash,
+                requested_price_cents,
+                requested_monthly_operation_limit,
+                CASE
+                    WHEN normalized_provider = 'LEMON_SQUEEZY' THEN 'MANUAL_BANK_TRANSFER'
+                    ELSE normalized_provider
+                END,
+                requested_terms_version,
+                requested_privacy_version,
+                requested_beta_version
+            );
+
+            IF normalized_provider = 'LEMON_SQUEEZY' THEN
+                UPDATE public.us_lacey_payments
+                SET provider = 'LEMON_SQUEEZY', updated_at = now()
+                WHERE organization_id = registration.organization_id
+                  AND public_id = registration.payment_public_id
+                  AND status = 'PENDING';
+                IF NOT FOUND THEN
+                    RAISE EXCEPTION 'registered Lemon payment not found' USING ERRCODE = 'P0002';
+                END IF;
+            END IF;
+
+            RETURN QUERY SELECT
+                registration.organization_id::integer,
+                registration.user_id::integer,
+                registration.payment_public_id::uuid,
+                registration.payment_reference::text,
+                registration.amount_cents::integer,
+                registration.account_status::text;
+        END;
+        $$;
+        """
+    )
+    op.execute(f"REVOKE ALL ON FUNCTION {REGISTER_SIGNATURE} FROM PUBLIC")
+    op.execute(f"GRANT EXECUTE ON FUNCTION {REGISTER_SIGNATURE} TO {RUNTIME_ROLE}")
+
+    op.execute(
+        """
+        CREATE FUNCTION public.us_lacey_apply_lemon_order(
+            target_organization_id integer,
+            target_payment_public_id uuid,
+            target_provider_order_id text,
+            target_event_name text,
+            target_payload_sha256 text,
+            target_amount_cents integer,
+            target_currency text,
+            target_store_id integer,
+            target_variant_id integer,
+            target_test_mode boolean
+        )
+        RETURNS TABLE (
+            payment_status text,
+            subscription_status text,
+            account_status text,
+            idempotent boolean
+        )
+        LANGUAGE plpgsql
+        SECURITY DEFINER
+        SET search_path = public, pg_temp
+        AS $$
+        DECLARE
+            normalized_order_id text := btrim(coalesce(target_provider_order_id, ''));
+            payment_row_id integer;
+            payment_subscription_id integer;
+            current_payment_status text;
+            expected_amount integer;
+            expected_currency text;
+            existing_event_payment_id integer;
+            existing_event_org_id integer;
+            existing_event_hash text;
+            current_subscription_status text;
+            current_account_status text;
+        BEGIN
+            IF target_organization_id IS NULL OR target_organization_id <= 0
+               OR target_payment_public_id IS NULL
+               OR normalized_order_id = '' OR char_length(normalized_order_id) > 128
+               OR coalesce(target_event_name, '') <> 'order_created'
+               OR target_payload_sha256 IS NULL
+               OR target_payload_sha256 !~ '^[0-9a-f]{64}$'
+               OR target_amount_cents IS NULL OR target_amount_cents <= 0
+               OR upper(btrim(coalesce(target_currency, ''))) <> 'USD'
+               OR target_store_id IS NULL OR target_store_id <= 0
+               OR target_variant_id IS NULL OR target_variant_id <= 0
+               OR target_test_mode IS NULL THEN
+                RAISE EXCEPTION 'invalid Lemon order activation payload' USING ERRCODE = '22023';
+            END IF;
+
+            SELECT p.id, p.subscription_id, p.status, p.amount_cents, p.currency
+            INTO payment_row_id, payment_subscription_id, current_payment_status,
+                 expected_amount, expected_currency
+            FROM public.us_lacey_payments p
+            WHERE p.organization_id = target_organization_id
+              AND p.public_id = target_payment_public_id
+              AND p.provider = 'LEMON_SQUEEZY'
+            FOR UPDATE;
+
+            IF payment_row_id IS NULL THEN
+                RAISE EXCEPTION 'Lemon payment not found' USING ERRCODE = 'P0002';
+            END IF;
+            IF expected_amount <> target_amount_cents OR expected_currency <> 'USD' THEN
+                RAISE EXCEPTION 'Lemon payment amount mismatch' USING ERRCODE = '22023';
+            END IF;
+
+            SELECT e.payment_id, e.organization_id, e.payload_sha256
+            INTO existing_event_payment_id, existing_event_org_id, existing_event_hash
+            FROM public.us_lacey_payment_events e
+            WHERE e.provider = 'LEMON_SQUEEZY'
+              AND e.provider_order_id = normalized_order_id;
+
+            IF existing_event_payment_id IS NOT NULL THEN
+                IF existing_event_payment_id <> payment_row_id
+                   OR existing_event_org_id <> target_organization_id
+                   OR existing_event_hash <> target_payload_sha256 THEN
+                    RAISE EXCEPTION 'Lemon order idempotency conflict' USING ERRCODE = '23505';
+                END IF;
+                SELECT s.status INTO current_subscription_status
+                FROM public.us_lacey_subscriptions s
+                WHERE s.id = payment_subscription_id
+                  AND s.organization_id = target_organization_id;
+                SELECT p.account_status INTO current_account_status
+                FROM public.us_lacey_organization_profiles p
+                WHERE p.organization_id = target_organization_id;
+                RETURN QUERY SELECT current_payment_status, current_subscription_status,
+                                    current_account_status, true;
+                RETURN;
+            END IF;
+
+            IF current_payment_status <> 'PENDING' THEN
+                RAISE EXCEPTION 'Lemon payment is not pending' USING ERRCODE = '22023';
+            END IF;
+
+            INSERT INTO public.us_lacey_payment_events (
+                organization_id, payment_id, provider, provider_order_id,
+                event_name, payload_sha256, amount_cents, currency,
+                store_id, variant_id, test_mode, processed_at
+            ) VALUES (
+                target_organization_id, payment_row_id, 'LEMON_SQUEEZY',
+                normalized_order_id, target_event_name, target_payload_sha256,
+                target_amount_cents, 'USD', target_store_id, target_variant_id,
+                target_test_mode, now()
+            );
+
+            UPDATE public.us_lacey_payments
+            SET status = 'VERIFIED', paid_at = coalesce(paid_at, now()),
+                verified_at = now(), updated_at = now()
+            WHERE id = payment_row_id
+              AND organization_id = target_organization_id;
+
+            UPDATE public.us_lacey_subscriptions
+            SET status = 'ACTIVE', started_at = coalesce(started_at, now()),
+                updated_at = now()
+            WHERE id = payment_subscription_id
+              AND organization_id = target_organization_id;
+
+            UPDATE public.us_lacey_organization_profiles
+            SET account_status = 'ACTIVE', updated_at = now()
+            WHERE organization_id = target_organization_id
+              AND account_status IN ('PAYMENT_PENDING','PILOT');
+
+            SELECT s.status INTO current_subscription_status
+            FROM public.us_lacey_subscriptions s
+            WHERE s.id = payment_subscription_id
+              AND s.organization_id = target_organization_id;
+            SELECT p.account_status INTO current_account_status
+            FROM public.us_lacey_organization_profiles p
+            WHERE p.organization_id = target_organization_id;
+
+            RETURN QUERY SELECT 'VERIFIED'::text, current_subscription_status,
+                                current_account_status, false;
+        END;
+        $$;
+        """
+    )
+    op.execute(f"REVOKE ALL ON FUNCTION {APPLY_SIGNATURE} FROM PUBLIC")
+    op.execute(f"GRANT EXECUTE ON FUNCTION {APPLY_SIGNATURE} TO {RUNTIME_ROLE}")
+    _leave_platform_role()
+
+
+def downgrade() -> None:
+    _enter_platform_role()
+    op.execute(f"DROP FUNCTION IF EXISTS {APPLY_SIGNATURE}")
+    op.execute(f"DROP FUNCTION IF EXISTS {REGISTER_SIGNATURE}")
+    op.execute(
+        "ALTER FUNCTION public.us_lacey_self_register_legacy(text,text,text,text,text,text,integer,integer,text,text,text,text) "
+        "RENAME TO us_lacey_self_register"
+    )
+    op.execute(f"REVOKE ALL ON FUNCTION {REGISTER_SIGNATURE} FROM PUBLIC")
+    op.execute(f"GRANT EXECUTE ON FUNCTION {REGISTER_SIGNATURE} TO {RUNTIME_ROLE}")
+    _leave_platform_role()
+
+    op.drop_index(
+        "ix_us_lacey_payment_events_org_payment", table_name="us_lacey_payment_events"
+    )
+    op.drop_table("us_lacey_payment_events")
+
+    op.drop_constraint(
+        "ck_us_lacey_payments_provider", "us_lacey_payments", type_="check"
+    )
+    op.create_check_constraint(
+        "ck_us_lacey_payments_provider",
+        "us_lacey_payments",
+        "provider IN ('MANUAL_BANK_TRANSFER','WISE','STRIPE')",
+    )

--- a/alembic/versions/041_add_us_lacey_lemon_squeezy_billing.py
+++ b/alembic/versions/041_add_us_lacey_lemon_squeezy_billing.py
@@ -224,11 +224,11 @@ def upgrade() -> None:
             );
 
             IF normalized_provider = 'LEMON_SQUEEZY' THEN
-                UPDATE public.us_lacey_payments
+                UPDATE public.us_lacey_payments AS payment
                 SET provider = 'LEMON_SQUEEZY', updated_at = now()
-                WHERE organization_id = registration.organization_id
-                  AND public_id = registration.payment_public_id
-                  AND status = 'PENDING';
+                WHERE payment.organization_id = registration.organization_id
+                  AND payment.public_id = registration.payment_public_id
+                  AND payment.status = 'PENDING';
                 IF NOT FOUND THEN
                     RAISE EXCEPTION 'registered Lemon payment not found' USING ERRCODE = 'P0002';
                 END IF;
@@ -354,22 +354,22 @@ def upgrade() -> None:
                 target_test_mode, now()
             );
 
-            UPDATE public.us_lacey_payments
-            SET status = 'VERIFIED', paid_at = coalesce(paid_at, now()),
+            UPDATE public.us_lacey_payments AS payment
+            SET status = 'VERIFIED', paid_at = coalesce(payment.paid_at, now()),
                 verified_at = now(), updated_at = now()
-            WHERE id = payment_row_id
-              AND organization_id = target_organization_id;
+            WHERE payment.id = payment_row_id
+              AND payment.organization_id = target_organization_id;
 
-            UPDATE public.us_lacey_subscriptions
-            SET status = 'ACTIVE', started_at = coalesce(started_at, now()),
+            UPDATE public.us_lacey_subscriptions AS subscription
+            SET status = 'ACTIVE', started_at = coalesce(subscription.started_at, now()),
                 updated_at = now()
-            WHERE id = payment_subscription_id
-              AND organization_id = target_organization_id;
+            WHERE subscription.id = payment_subscription_id
+              AND subscription.organization_id = target_organization_id;
 
-            UPDATE public.us_lacey_organization_profiles
+            UPDATE public.us_lacey_organization_profiles AS profile
             SET account_status = 'ACTIVE', updated_at = now()
-            WHERE organization_id = target_organization_id
-              AND account_status IN ('PAYMENT_PENDING','PILOT');
+            WHERE profile.organization_id = target_organization_id
+              AND profile.account_status IN ('PAYMENT_PENDING','PILOT');
 
             SELECT s.status INTO current_subscription_status
             FROM public.us_lacey_subscriptions s

--- a/alembic/versions/041_add_us_lacey_lemon_squeezy_billing.py
+++ b/alembic/versions/041_add_us_lacey_lemon_squeezy_billing.py
@@ -30,6 +30,15 @@ APPLY_SIGNATURE = (
     "public.us_lacey_apply_lemon_order(integer,uuid,text,text,text,integer,text,integer,integer,boolean)"
 )
 
+_SHA256_HEX_REMAINDER_SQL = "payload_sha256"
+for _hex_char in "0123456789abcdef":
+    _SHA256_HEX_REMAINDER_SQL = (
+        f"replace({_SHA256_HEX_REMAINDER_SQL}, '{_hex_char}', '')"
+    )
+_SHA256_HEX_CHECK_SQL = (
+    f"length(payload_sha256) = 64 AND {_SHA256_HEX_REMAINDER_SQL} = ''"
+)
+
 
 def _grant_temp_platform_set() -> None:
     op.execute(
@@ -101,7 +110,7 @@ def upgrade() -> None:
             "event_name = 'order_created'", name="ck_us_lacey_payment_events_name"
         ),
         sa.CheckConstraint(
-            "payload_sha256 ~ '^[0-9a-f]{64}$'",
+            _SHA256_HEX_CHECK_SQL,
             name="ck_us_lacey_payment_events_payload_sha256",
         ),
         sa.CheckConstraint(

--- a/deploy/render-us-lacey-pilot-free.yaml
+++ b/deploy/render-us-lacey-pilot-free.yaml
@@ -81,6 +81,20 @@ services:
         sync: false
       - key: US_LACEY_BETA_TERMS_VERSION
         sync: false
+
+      # Lemon Squeezy remains dormant until Test Mode is explicitly configured.
+      # No API key is required for the hosted-checkout + signed-webhook path.
+      - key: US_LACEY_LEMON_CHECKOUT_URL
+        sync: false
+      - key: US_LACEY_LEMON_WEBHOOK_SECRET
+        sync: false
+      - key: US_LACEY_LEMON_STORE_ID
+        sync: false
+      - key: US_LACEY_LEMON_VARIANT_ID
+        sync: false
+      - key: US_LACEY_LEMON_TEST_MODE
+        sync: false
+
       # Legal pages live on the same canonical U.S. Lacey origin.
       - key: US_LACEY_TERMS_URL
         value: https://lacey.litoraltrace.com/legal/terms

--- a/src/litoral_trace/db/models/__init__.py
+++ b/src/litoral_trace/db/models/__init__.py
@@ -44,6 +44,7 @@ from litoral_trace.db.models.us_lacey_commercial import (
     UsLaceySubscription,
     UsLaceyTermsAcceptance,
 )
+from litoral_trace.db.models.us_lacey_payment_event import UsLaceyPaymentEvent
 from litoral_trace.db.models.integration import (
     ExternalEntity,
     ExternalEntityVersion,
@@ -100,6 +101,7 @@ __all__ = [
     "UsLaceyPlantDeclaration",
     "UsLaceySubscription",
     "UsLaceyPayment",
+    "UsLaceyPaymentEvent",
     "UsLaceyTermsAcceptance",
     "UsLaceyProcessingJob",
     "TraceabilityBatch",

--- a/src/litoral_trace/db/models/us_lacey_commercial.py
+++ b/src/litoral_trace/db/models/us_lacey_commercial.py
@@ -97,7 +97,7 @@ class UsLaceyPayment(Base):
         CheckConstraint("amount_cents > 0", name="ck_us_lacey_payments_amount_positive"),
         CheckConstraint("currency = 'USD'", name="ck_us_lacey_payments_currency_usd"),
         CheckConstraint(
-            "provider IN ('MANUAL_BANK_TRANSFER','WISE','STRIPE')",
+            "provider IN ('MANUAL_BANK_TRANSFER','WISE','STRIPE','LEMON_SQUEEZY')",
             name="ck_us_lacey_payments_provider",
         ),
         CheckConstraint(

--- a/src/litoral_trace/db/models/us_lacey_payment_event.py
+++ b/src/litoral_trace/db/models/us_lacey_payment_event.py
@@ -1,0 +1,76 @@
+"""Provider payment event audit model for U.S. Lacey billing."""
+from __future__ import annotations
+
+from datetime import datetime
+
+from sqlalchemy import (
+    Boolean,
+    CheckConstraint,
+    DateTime,
+    ForeignKeyConstraint,
+    Index,
+    Integer,
+    String,
+    UniqueConstraint,
+    func,
+)
+from sqlalchemy.orm import Mapped, mapped_column
+
+from litoral_trace.db.base import Base
+
+
+class UsLaceyPaymentEvent(Base):
+    __tablename__ = "us_lacey_payment_events"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    organization_id: Mapped[int] = mapped_column(Integer, nullable=False)
+    payment_id: Mapped[int] = mapped_column(Integer, nullable=False)
+    provider: Mapped[str] = mapped_column(String(40), nullable=False)
+    provider_order_id: Mapped[str] = mapped_column(String(128), nullable=False)
+    event_name: Mapped[str] = mapped_column(String(64), nullable=False)
+    payload_sha256: Mapped[str] = mapped_column(String(64), nullable=False)
+    amount_cents: Mapped[int] = mapped_column(Integer, nullable=False)
+    currency: Mapped[str] = mapped_column(String(3), nullable=False)
+    store_id: Mapped[int] = mapped_column(Integer, nullable=False)
+    variant_id: Mapped[int] = mapped_column(Integer, nullable=False)
+    test_mode: Mapped[bool] = mapped_column(Boolean, nullable=False)
+    processed_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )
+
+    __table_args__ = (
+        ForeignKeyConstraint(
+            ["payment_id", "organization_id"],
+            ["us_lacey_payments.id", "us_lacey_payments.organization_id"],
+            name="fk_us_lacey_payment_events_payment_tenant",
+            ondelete="CASCADE",
+        ),
+        UniqueConstraint(
+            "provider", "provider_order_id", name="uq_us_lacey_payment_events_provider_order"
+        ),
+        CheckConstraint(
+            "provider = 'LEMON_SQUEEZY'", name="ck_us_lacey_payment_events_provider"
+        ),
+        CheckConstraint(
+            "event_name = 'order_created'", name="ck_us_lacey_payment_events_name"
+        ),
+        CheckConstraint(
+            "payload_sha256 ~ '^[0-9a-f]{64}$'",
+            name="ck_us_lacey_payment_events_payload_sha256",
+        ),
+        CheckConstraint(
+            "amount_cents > 0", name="ck_us_lacey_payment_events_amount_positive"
+        ),
+        CheckConstraint(
+            "currency = 'USD'", name="ck_us_lacey_payment_events_currency_usd"
+        ),
+        CheckConstraint(
+            "store_id > 0", name="ck_us_lacey_payment_events_store_positive"
+        ),
+        CheckConstraint(
+            "variant_id > 0", name="ck_us_lacey_payment_events_variant_positive"
+        ),
+        Index(
+            "ix_us_lacey_payment_events_org_payment", "organization_id", "payment_id"
+        ),
+    )

--- a/src/litoral_trace/db/models/us_lacey_payment_event.py
+++ b/src/litoral_trace/db/models/us_lacey_payment_event.py
@@ -19,6 +19,16 @@ from sqlalchemy.orm import Mapped, mapped_column
 from litoral_trace.db.base import Base
 
 
+_SHA256_HEX_REMAINDER_SQL = "payload_sha256"
+for _hex_char in "0123456789abcdef":
+    _SHA256_HEX_REMAINDER_SQL = (
+        f"replace({_SHA256_HEX_REMAINDER_SQL}, '{_hex_char}', '')"
+    )
+_SHA256_HEX_CHECK_SQL = (
+    f"length(payload_sha256) = 64 AND {_SHA256_HEX_REMAINDER_SQL} = ''"
+)
+
+
 class UsLaceyPaymentEvent(Base):
     __tablename__ = "us_lacey_payment_events"
 
@@ -55,7 +65,7 @@ class UsLaceyPaymentEvent(Base):
             "event_name = 'order_created'", name="ck_us_lacey_payment_events_name"
         ),
         CheckConstraint(
-            "payload_sha256 ~ '^[0-9a-f]{64}$'",
+            _SHA256_HEX_CHECK_SQL,
             name="ck_us_lacey_payment_events_payload_sha256",
         ),
         CheckConstraint(

--- a/src/litoral_trace/us_lacey/commercial.py
+++ b/src/litoral_trace/us_lacey/commercial.py
@@ -1,7 +1,7 @@
 """Fail-closed commercial configuration for the U.S. Lacey self-service launch.
 
-No price, bank destination or legal version is hard-coded here. Production must
-provide each value explicitly so a deploy cannot silently charge the wrong
+No price, payment destination or legal version is hard-coded here. Production
+must provide each value explicitly so a deploy cannot silently charge the wrong
 amount or accept the wrong legal text.
 """
 from __future__ import annotations
@@ -50,9 +50,18 @@ def load_us_lacey_commercial_config(
 ) -> UsLaceyCommercialConfig:
     env = os.environ if environ is None else environ
     provider = _required(env, "US_LACEY_PAYMENT_PROVIDER").upper()
-    if provider not in {"MANUAL_BANK_TRANSFER", "WISE"}:
+    # WISE remains accepted only as a backward-compatible deployment value so
+    # an existing environment cannot become unready during the Lemon cutover.
+    # New commercial configuration is intended to use LEMON_SQUEEZY.
+    if provider not in {"MANUAL_BANK_TRANSFER", "WISE", "LEMON_SQUEEZY"}:
         raise UsLaceyCommercialConfigurationError(
-            "US_LACEY_PAYMENT_PROVIDER must be MANUAL_BANK_TRANSFER or WISE for launch."
+            "US_LACEY_PAYMENT_PROVIDER must be MANUAL_BANK_TRANSFER, WISE, or LEMON_SQUEEZY."
+        )
+
+    bank_instructions = str(env.get("US_LACEY_BANK_TRANSFER_INSTRUCTIONS", "")).strip()
+    if provider in {"MANUAL_BANK_TRANSFER", "WISE"} and not bank_instructions:
+        raise UsLaceyCommercialConfigurationError(
+            "US_LACEY_BANK_TRANSFER_INSTRUCTIONS is required for transfer-based payment."
         )
 
     support_email = str(env.get("US_LACEY_SUPPORT_EMAIL", "support@litoraltrace.com")).strip().lower()
@@ -63,7 +72,7 @@ def load_us_lacey_commercial_config(
         price_cents=_positive_int(env, "US_LACEY_PRIVATE_BETA_PRICE_CENTS"),
         monthly_operation_limit=_positive_int(env, "US_LACEY_MONTHLY_OPERATION_LIMIT"),
         payment_provider=provider,
-        bank_transfer_instructions=_required(env, "US_LACEY_BANK_TRANSFER_INSTRUCTIONS"),
+        bank_transfer_instructions=bank_instructions,
         terms_version=_required(env, "US_LACEY_TERMS_VERSION"),
         privacy_version=_required(env, "US_LACEY_PRIVACY_VERSION"),
         beta_terms_version=_required(env, "US_LACEY_BETA_TERMS_VERSION"),

--- a/src/litoral_trace/us_lacey/lemon_billing.py
+++ b/src/litoral_trace/us_lacey/lemon_billing.py
@@ -1,0 +1,71 @@
+"""Transactional application of validated Lemon Squeezy orders."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from sqlalchemy import text
+
+from litoral_trace.us_lacey.db import get_us_lacey_db_session
+from litoral_trace.us_lacey.lemon_squeezy import UsLaceyLemonPaidOrder
+
+
+class UsLaceyLemonBillingError(RuntimeError):
+    """Sanitized error safe to return from the webhook endpoint."""
+
+
+@dataclass(frozen=True)
+class UsLaceyLemonActivationResult:
+    payment_status: str
+    subscription_status: str
+    account_status: str
+    idempotent: bool
+
+
+def apply_us_lacey_lemon_order(
+    order: UsLaceyLemonPaidOrder,
+) -> UsLaceyLemonActivationResult:
+    """Apply one already signature-validated paid order atomically in PostgreSQL."""
+    session = get_us_lacey_db_session()
+    try:
+        row = session.execute(
+            text(
+                """
+                SELECT * FROM public.us_lacey_apply_lemon_order(
+                    :organization_id,
+                    :payment_public_id,
+                    :provider_order_id,
+                    :event_name,
+                    :payload_sha256,
+                    :amount_cents,
+                    :currency,
+                    :store_id,
+                    :variant_id,
+                    :test_mode
+                )
+                """
+            ),
+            {
+                "organization_id": order.organization_id,
+                "payment_public_id": order.payment_public_id,
+                "provider_order_id": order.provider_order_id,
+                "event_name": order.event_name,
+                "payload_sha256": order.payload_sha256,
+                "amount_cents": order.amount_cents,
+                "currency": order.currency,
+                "store_id": order.store_id,
+                "variant_id": order.variant_id,
+                "test_mode": order.test_mode,
+            },
+        ).mappings().one()
+        session.commit()
+        return UsLaceyLemonActivationResult(
+            payment_status=str(row["payment_status"]),
+            subscription_status=str(row["subscription_status"]),
+            account_status=str(row["account_status"]),
+            idempotent=bool(row["idempotent"]),
+        )
+    except Exception as exc:
+        session.rollback()
+        raise UsLaceyLemonBillingError("Unable to apply Lemon Squeezy payment.") from exc
+    finally:
+        session.close()

--- a/src/litoral_trace/us_lacey/lemon_squeezy.py
+++ b/src/litoral_trace/us_lacey/lemon_squeezy.py
@@ -1,0 +1,199 @@
+"""Lemon Squeezy checkout and signed-webhook primitives for U.S. Lacey billing.
+
+The first integration intentionally uses Lemon's hosted checkout URL instead of
+an API key. Customer/account correlation is carried only through minimal custom
+checkout data and payment activation is driven by a verified webhook.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+import hashlib
+import hmac
+import json
+import os
+from collections.abc import Mapping
+from urllib.parse import parse_qsl, urlencode, urlsplit, urlunsplit
+from uuid import UUID
+
+
+class UsLaceyLemonConfigurationError(RuntimeError):
+    """Raised when Lemon Squeezy configuration is missing or unsafe."""
+
+
+class UsLaceyLemonWebhookError(RuntimeError):
+    """Sanitized webhook validation error."""
+
+
+@dataclass(frozen=True)
+class UsLaceyLemonConfig:
+    checkout_url: str
+    webhook_secret: str
+    store_id: int
+    variant_id: int
+    test_mode: bool
+
+
+@dataclass(frozen=True)
+class UsLaceyLemonPaidOrder:
+    organization_id: int
+    payment_public_id: UUID
+    provider_order_id: str
+    event_name: str
+    payload_sha256: str
+    amount_cents: int
+    currency: str
+    store_id: int
+    variant_id: int
+    test_mode: bool
+
+
+def _required(env: Mapping[str, str], name: str) -> str:
+    value = str(env.get(name, "")).strip()
+    if not value:
+        raise UsLaceyLemonConfigurationError(f"{name} is required.")
+    return value
+
+
+def _positive_int(env: Mapping[str, str], name: str) -> int:
+    raw = _required(env, name)
+    try:
+        value = int(raw)
+    except ValueError as exc:
+        raise UsLaceyLemonConfigurationError(f"{name} must be an integer.") from exc
+    if value <= 0:
+        raise UsLaceyLemonConfigurationError(f"{name} must be positive.")
+    return value
+
+
+def _strict_bool(env: Mapping[str, str], name: str) -> bool:
+    raw = _required(env, name).lower()
+    if raw in {"1", "true", "yes", "on"}:
+        return True
+    if raw in {"0", "false", "no", "off"}:
+        return False
+    raise UsLaceyLemonConfigurationError(f"{name} must be a boolean value.")
+
+
+def load_us_lacey_lemon_config(
+    environ: Mapping[str, str] | None = None,
+) -> UsLaceyLemonConfig:
+    env = os.environ if environ is None else environ
+    checkout_url = _required(env, "US_LACEY_LEMON_CHECKOUT_URL")
+    parts = urlsplit(checkout_url)
+    if parts.scheme != "https" or not parts.netloc or "/checkout/buy/" not in parts.path:
+        raise UsLaceyLemonConfigurationError(
+            "US_LACEY_LEMON_CHECKOUT_URL must be an HTTPS Lemon checkout URL."
+        )
+    secret = _required(env, "US_LACEY_LEMON_WEBHOOK_SECRET")
+    if len(secret) < 16:
+        raise UsLaceyLemonConfigurationError(
+            "US_LACEY_LEMON_WEBHOOK_SECRET must contain at least 16 characters."
+        )
+    return UsLaceyLemonConfig(
+        checkout_url=checkout_url,
+        webhook_secret=secret,
+        store_id=_positive_int(env, "US_LACEY_LEMON_STORE_ID"),
+        variant_id=_positive_int(env, "US_LACEY_LEMON_VARIANT_ID"),
+        test_mode=_strict_bool(env, "US_LACEY_LEMON_TEST_MODE"),
+    )
+
+
+def build_us_lacey_lemon_checkout_url(
+    *,
+    config: UsLaceyLemonConfig,
+    organization_id: int,
+    payment_public_id: UUID,
+) -> str:
+    if organization_id <= 0:
+        raise UsLaceyLemonConfigurationError("Organization is invalid.")
+    parts = urlsplit(config.checkout_url)
+    query = dict(parse_qsl(parts.query, keep_blank_values=True))
+    query["checkout[custom][organization_id]"] = str(organization_id)
+    query["checkout[custom][payment_public_id]"] = str(payment_public_id)
+    return urlunsplit(
+        (parts.scheme, parts.netloc, parts.path, urlencode(query), parts.fragment)
+    )
+
+
+def verify_us_lacey_lemon_signature(
+    *, raw_body: bytes, signature: str, secret: str
+) -> bool:
+    if not raw_body or not signature or not secret:
+        return False
+    expected = hmac.new(secret.encode("utf-8"), raw_body, hashlib.sha256).hexdigest()
+    return hmac.compare_digest(expected, signature.strip().lower())
+
+
+def parse_us_lacey_lemon_paid_order(
+    *,
+    raw_body: bytes,
+    signature: str,
+    config: UsLaceyLemonConfig,
+    expected_price_cents: int,
+) -> UsLaceyLemonPaidOrder:
+    """Validate one paid order event and return only data safe for activation."""
+    if expected_price_cents <= 0:
+        raise UsLaceyLemonWebhookError("Expected price is invalid.")
+    if not verify_us_lacey_lemon_signature(
+        raw_body=raw_body, signature=signature, secret=config.webhook_secret
+    ):
+        raise UsLaceyLemonWebhookError("Webhook signature is invalid.")
+    try:
+        payload = json.loads(raw_body.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise UsLaceyLemonWebhookError("Webhook payload is invalid.") from exc
+
+    meta = payload.get("meta") if isinstance(payload, dict) else None
+    data = payload.get("data") if isinstance(payload, dict) else None
+    if not isinstance(meta, dict) or not isinstance(data, dict):
+        raise UsLaceyLemonWebhookError("Webhook payload is incomplete.")
+    event_name = str(meta.get("event_name", "")).strip()
+    if event_name != "order_created" or data.get("type") != "orders":
+        raise UsLaceyLemonWebhookError("Webhook event is not a payable order.")
+
+    attributes = data.get("attributes")
+    custom = meta.get("custom_data")
+    if not isinstance(attributes, dict) or not isinstance(custom, dict):
+        raise UsLaceyLemonWebhookError("Webhook order metadata is incomplete.")
+    if str(attributes.get("status", "")).lower() != "paid":
+        raise UsLaceyLemonWebhookError("Order is not paid.")
+
+    try:
+        store_id = int(attributes["store_id"])
+        amount_cents = int(attributes["subtotal"])
+        organization_id = int(custom["organization_id"])
+        payment_public_id = UUID(str(custom["payment_public_id"]))
+        first_item = attributes["first_order_item"]
+        if not isinstance(first_item, dict):
+            raise TypeError("first_order_item")
+        variant_id = int(first_item["variant_id"])
+    except (KeyError, TypeError, ValueError) as exc:
+        raise UsLaceyLemonWebhookError("Webhook order identifiers are invalid.") from exc
+
+    currency = str(attributes.get("currency", "")).upper()
+    test_mode = attributes.get("test_mode")
+    provider_order_id = str(data.get("id", "")).strip()
+    if (
+        organization_id <= 0
+        or not provider_order_id
+        or len(provider_order_id) > 128
+        or currency != "USD"
+        or store_id != config.store_id
+        or variant_id != config.variant_id
+        or test_mode is not config.test_mode
+        or amount_cents != expected_price_cents
+    ):
+        raise UsLaceyLemonWebhookError("Webhook order does not match this offer.")
+
+    return UsLaceyLemonPaidOrder(
+        organization_id=organization_id,
+        payment_public_id=payment_public_id,
+        provider_order_id=provider_order_id,
+        event_name=event_name,
+        payload_sha256=hashlib.sha256(raw_body).hexdigest(),
+        amount_cents=amount_cents,
+        currency=currency,
+        store_id=store_id,
+        variant_id=variant_id,
+        test_mode=test_mode,
+    )

--- a/src/litoral_trace/web/us_lacey_lemon_billing.py
+++ b/src/litoral_trace/web/us_lacey_lemon_billing.py
@@ -1,0 +1,134 @@
+"""Hosted Lemon Squeezy checkout and signed webhook routes for U.S. Lacey."""
+from __future__ import annotations
+
+from fastapi import APIRouter, Cookie, HTTPException, Request, status
+from fastapi.responses import RedirectResponse, Response
+
+from litoral_trace.us_lacey.commercial import (
+    UsLaceyCommercialConfigurationError,
+    load_us_lacey_commercial_config,
+)
+from litoral_trace.us_lacey.lemon_billing import (
+    UsLaceyLemonBillingError,
+    apply_us_lacey_lemon_order,
+)
+from litoral_trace.us_lacey.lemon_squeezy import (
+    UsLaceyLemonConfigurationError,
+    UsLaceyLemonWebhookError,
+    build_us_lacey_lemon_checkout_url,
+    load_us_lacey_lemon_config,
+    parse_us_lacey_lemon_paid_order,
+)
+from litoral_trace.us_lacey.portal_auth import (
+    US_LACEY_SESSION_COOKIE,
+    UsLaceyPortalAuthError,
+    resolve_us_lacey_session,
+)
+from litoral_trace.us_lacey.self_service import (
+    UsLaceySelfServiceError,
+    get_us_lacey_billing_summary,
+)
+
+
+router = APIRouter()
+_MAX_WEBHOOK_BYTES = 1_000_000
+
+
+def _login_redirect() -> RedirectResponse:
+    response = RedirectResponse("/login", status_code=303)
+    response.delete_cookie(US_LACEY_SESSION_COOKIE, path="/")
+    return response
+
+
+@router.get("/billing/lemon-checkout", include_in_schema=False)
+def lemon_checkout(
+    us_session: str | None = Cookie(None, alias=US_LACEY_SESSION_COOKIE),
+):
+    if not us_session:
+        return RedirectResponse("/login", status_code=303)
+    try:
+        identity = resolve_us_lacey_session(us_session)
+        billing = get_us_lacey_billing_summary(organization_id=identity.organization_id)
+        commercial = load_us_lacey_commercial_config()
+        lemon = load_us_lacey_lemon_config()
+    except UsLaceyPortalAuthError:
+        return _login_redirect()
+    except (
+        UsLaceySelfServiceError,
+        UsLaceyCommercialConfigurationError,
+        UsLaceyLemonConfigurationError,
+    ) as exc:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Online checkout is temporarily unavailable.",
+        ) from exc
+
+    if (
+        identity.account_status != "PAYMENT_PENDING"
+        or commercial.payment_provider != "LEMON_SQUEEZY"
+        or billing.payment_provider != "LEMON_SQUEEZY"
+        or billing.payment_status != "PENDING"
+    ):
+        return RedirectResponse("/billing", status_code=303)
+
+    checkout_url = build_us_lacey_lemon_checkout_url(
+        config=lemon,
+        organization_id=identity.organization_id,
+        payment_public_id=billing.payment_public_id,
+    )
+    response = RedirectResponse(checkout_url, status_code=303)
+    response.headers["Cache-Control"] = "no-store, max-age=0"
+    return response
+
+
+@router.post("/webhooks/lemon-squeezy", include_in_schema=False)
+async def lemon_webhook(request: Request) -> Response:
+    signature = request.headers.get("X-Signature", "")
+    event_header = request.headers.get("X-Event-Name", "")
+    content_length = request.headers.get("content-length")
+    try:
+        if content_length is not None and int(content_length) > _MAX_WEBHOOK_BYTES:
+            raise HTTPException(status_code=status.HTTP_413_REQUEST_ENTITY_TOO_LARGE)
+    except ValueError as exc:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST) from exc
+
+    raw_body = await request.body()
+    if not raw_body or len(raw_body) > _MAX_WEBHOOK_BYTES:
+        raise HTTPException(status_code=status.HTTP_413_REQUEST_ENTITY_TOO_LARGE)
+
+    try:
+        commercial = load_us_lacey_commercial_config()
+        if commercial.payment_provider != "LEMON_SQUEEZY":
+            raise UsLaceyLemonConfigurationError("Lemon Squeezy is not enabled.")
+        lemon = load_us_lacey_lemon_config()
+    except (UsLaceyCommercialConfigurationError, UsLaceyLemonConfigurationError) as exc:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Payment webhook is not configured.",
+        ) from exc
+
+    if event_header != "order_created":
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Unsupported event.")
+
+    try:
+        order = parse_us_lacey_lemon_paid_order(
+            raw_body=raw_body,
+            signature=signature,
+            config=lemon,
+            expected_price_cents=commercial.price_cents,
+        )
+        apply_us_lacey_lemon_order(order)
+    except UsLaceyLemonWebhookError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Invalid payment event.",
+        ) from exc
+    except UsLaceyLemonBillingError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Payment event could not be applied.",
+        ) from exc
+
+    response = Response(status_code=200)
+    response.headers["Cache-Control"] = "no-store, max-age=0"
+    return response

--- a/src/litoral_trace/web/us_lacey_unified_app.py
+++ b/src/litoral_trace/web/us_lacey_unified_app.py
@@ -1,10 +1,10 @@
 """Unified free-tier entrypoint for the customer-facing U.S. Lacey product.
 
 This module composes the already-certified private portal/inline-worker runtime
-with the public U.S. Lacey marketing and synthetic-demo routes. It deliberately
-keeps the operational application unchanged: authenticated traffic, PostgreSQL
-RLS, S3 probes, worker lifecycle, billing and review routes continue to be owned
-by ``us_lacey_free_app``.
+with the public U.S. Lacey marketing, synthetic-demo and hosted-billing routes.
+It deliberately keeps the operational application unchanged: authenticated
+traffic, PostgreSQL RLS, S3 probes, worker lifecycle and review routes continue
+to be owned by ``us_lacey_free_app``.
 
 The composition exists so one customer-facing hostname can serve the full flow:
 landing -> sample -> signup -> verification -> login -> billing -> operations.
@@ -16,11 +16,13 @@ from fastapi import Request, Response
 from litoral_trace.us_lacey.portal_auth import US_LACEY_SESSION_COOKIE
 from litoral_trace.web.lacey_gtm import render_lacey_landing, router as lacey_router
 from litoral_trace.web.us_lacey_free_app import app
+from litoral_trace.web.us_lacey_lemon_billing import router as lemon_billing_router
 
 
-# Public marketing/sample routes are additive and do not shadow the certified
-# portal endpoints (/signup, /login, /billing, /operations, /ready, ...).
+# Public marketing/sample and payment-provider routes are additive and do not
+# shadow the certified portal endpoints (/signup, /login, /billing, ...).
 app.include_router(lacey_router)
+app.include_router(lemon_billing_router)
 
 
 @app.head("/health", include_in_schema=False)

--- a/tests/test_assurance_migration_contract.py
+++ b/tests/test_assurance_migration_contract.py
@@ -108,7 +108,7 @@ def test_us_lacey_portal_auth_is_chained_after_status_fix():
 
 def test_ci_canonical_head_tracks_latest_platform_migration():
     text = Path(".github/workflows/ci.yml").read_text(encoding="utf-8")
-    assert "040_us_lacey_ppq505 (head)" in text
+    assert "041_us_lacey_lemon (head)" in text
 
 
 def test_us_lacey_pilot_activation_follows_portal_auth():

--- a/tests/test_ci_p26a_unittest.py
+++ b/tests/test_ci_p26a_unittest.py
@@ -59,7 +59,7 @@ def test_p26a_ci_runs_pytest_and_disables_postgres_integration():
 def test_p26a_ci_checks_single_canonical_alembic_head():
     workflow = _workflow_text()
     assert "alembic heads" in workflow
-    assert "040_us_lacey_ppq505 (head)" in workflow
+    assert "041_us_lacey_lemon (head)" in workflow
     assert "alembic upgrade head" not in workflow
 
 

--- a/tests/test_us_lacey_lemon_squeezy.py
+++ b/tests/test_us_lacey_lemon_squeezy.py
@@ -1,0 +1,134 @@
+"""Fail-closed Lemon Squeezy contracts for U.S. Lacey billing."""
+from __future__ import annotations
+
+import hashlib
+import hmac
+import json
+from urllib.parse import parse_qs, urlsplit
+from uuid import UUID
+
+import pytest
+
+from litoral_trace.us_lacey.lemon_squeezy import (
+    UsLaceyLemonConfigurationError,
+    UsLaceyLemonWebhookError,
+    build_us_lacey_lemon_checkout_url,
+    load_us_lacey_lemon_config,
+    parse_us_lacey_lemon_paid_order,
+)
+
+
+PAYMENT_ID = UUID("d8123ecb-3901-46b8-85af-e0b13f048177")
+SECRET = "test-signing-secret-2026"
+
+
+def _env(**overrides: str) -> dict[str, str]:
+    values = {
+        "US_LACEY_LEMON_CHECKOUT_URL": "https://litoral-trace.lemonsqueezy.com/checkout/buy/test-variant",
+        "US_LACEY_LEMON_WEBHOOK_SECRET": SECRET,
+        "US_LACEY_LEMON_STORE_ID": "321",
+        "US_LACEY_LEMON_VARIANT_ID": "654",
+        "US_LACEY_LEMON_TEST_MODE": "1",
+    }
+    values.update(overrides)
+    return values
+
+
+def _payload(**attribute_overrides: object) -> bytes:
+    attributes: dict[str, object] = {
+        "store_id": 321,
+        "currency": "USD",
+        "subtotal": 19900,
+        "status": "paid",
+        "test_mode": True,
+        "first_order_item": {"variant_id": 654},
+    }
+    attributes.update(attribute_overrides)
+    return json.dumps(
+        {
+            "meta": {
+                "event_name": "order_created",
+                "custom_data": {
+                    "organization_id": "42",
+                    "payment_public_id": str(PAYMENT_ID),
+                },
+            },
+            "data": {"type": "orders", "id": "9001", "attributes": attributes},
+        },
+        separators=(",", ":"),
+    ).encode("utf-8")
+
+
+def _signature(body: bytes) -> str:
+    return hmac.new(SECRET.encode(), body, hashlib.sha256).hexdigest()
+
+
+def test_lemon_config_is_fail_closed_and_test_mode_explicit() -> None:
+    config = load_us_lacey_lemon_config(_env())
+    assert config.store_id == 321
+    assert config.variant_id == 654
+    assert config.test_mode is True
+
+    with pytest.raises(UsLaceyLemonConfigurationError):
+        load_us_lacey_lemon_config(_env(US_LACEY_LEMON_WEBHOOK_SECRET="short"))
+    with pytest.raises(UsLaceyLemonConfigurationError):
+        load_us_lacey_lemon_config(_env(US_LACEY_LEMON_TEST_MODE="maybe"))
+
+
+def test_checkout_url_carries_only_local_correlation_ids() -> None:
+    config = load_us_lacey_lemon_config(_env())
+    url = build_us_lacey_lemon_checkout_url(
+        config=config, organization_id=42, payment_public_id=PAYMENT_ID
+    )
+    query = parse_qs(urlsplit(url).query)
+    assert query["checkout[custom][organization_id]"] == ["42"]
+    assert query["checkout[custom][payment_public_id]"] == [str(PAYMENT_ID)]
+    assert "secret" not in url.lower()
+
+
+def test_paid_order_requires_valid_signature_and_exact_offer() -> None:
+    config = load_us_lacey_lemon_config(_env())
+    body = _payload()
+    order = parse_us_lacey_lemon_paid_order(
+        raw_body=body,
+        signature=_signature(body),
+        config=config,
+        expected_price_cents=19900,
+    )
+    assert order.organization_id == 42
+    assert order.payment_public_id == PAYMENT_ID
+    assert order.provider_order_id == "9001"
+    assert order.amount_cents == 19900
+    assert order.currency == "USD"
+    assert order.test_mode is True
+
+    with pytest.raises(UsLaceyLemonWebhookError):
+        parse_us_lacey_lemon_paid_order(
+            raw_body=body,
+            signature="0" * 64,
+            config=config,
+            expected_price_cents=19900,
+        )
+
+
+@pytest.mark.parametrize(
+    "override",
+    [
+        {"store_id": 999},
+        {"currency": "EUR"},
+        {"subtotal": 19899},
+        {"status": "pending"},
+        {"test_mode": False},
+        {"first_order_item": {"variant_id": 999}},
+    ],
+)
+def test_paid_order_rejects_mismatched_or_unpaid_events(override: dict[str, object]) -> None:
+    config = load_us_lacey_lemon_config(_env())
+    body = _payload(**override)
+    with pytest.raises(UsLaceyLemonWebhookError):
+        parse_us_lacey_lemon_paid_order(
+            raw_body=body,
+            signature=_signature(body),
+            config=config,
+            expected_price_cents=19900,
+        )


### PR DESCRIPTION
## Scope

Clean rebuild of the U.S. Lacey Lemon Squeezy billing integration on top of the current certified base (`83ef046`). This supersedes the stale/conflicting draft #162.

### Included
- Alembic `041_us_lacey_lemon` directly on `040_us_lacey_ppq505`
- hosted Lemon checkout correlation using organization/payment IDs only
- HMAC-SHA256 signed webhook validation, fail-closed offer matching
- server-side payment/subscription/account activation
- idempotent provider-order event ledger with FORCE RLS and least privilege
- ORM/migration SHA-256 constraint portable across PostgreSQL + SQLite metadata tests
- Render configuration keys for Lemon test/live configuration
- generic CI canonical-head contract updated to 041
- isolated PostgreSQL gate upgraded to physically migrate and certify 041
- PostgreSQL proof of Lemon registration, email transition, activation and repeat-event idempotency

### Deliberately preserved from the current base
- clarified Signup/Billing UX from #161
- current `billing.html` (not transplanted from the stale Lemon branch)
- Uptime `/health` GET/HEAD contract and regression coverage

### Gate expectations before merge
- CI green
- US Lacey PostgreSQL Gate green at `041_us_lacey_lemon`
- CSS Drift green
- no skipped PostgreSQL tenant-isolation acceptance in the isolated gate

No production Lemon secrets or live activation are included in this PR.