### PR TITLE
feat(us-lacey): add read-only Owner/Admin Console on 042

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,7 +71,7 @@ jobs:
             echo "Expected exactly one Alembic head."
             exit 1
           fi
-          grep -Fx "041_us_lacey_lemon (head)" alembic-heads.txt
+          grep -Fx "042_us_lacey_owner_admin (head)" alembic-heads.txt
 
       - name: Run pytest suite
         run: python -m pytest -q -rs

--- a/.github/workflows/us-lacey-postgres-gate.yml
+++ b/.github/workflows/us-lacey-postgres-gate.yml
@@ -11,8 +11,13 @@ on:
       - "alembic/versions/039_fix_us_lacey_pilot_activation.py"
       - "alembic/versions/040_establish_us_lacey_ppq505_contract.py"
       - "alembic/versions/041_add_us_lacey_lemon_squeezy_billing.py"
+      - "alembic/versions/042_add_us_lacey_owner_admin_overview.py"
       - "src/litoral_trace/us_lacey/**"
       - "src/litoral_trace/web/us_lacey_*"
+      - "src/litoral_trace/services/us_lacey_admin.py"
+      - "src/litoral_trace/api/admin.py"
+      - "src/litoral_trace/templates/admin_organizations.html"
+      - "src/litoral_trace/templates/admin_us_lacey_accounts.html"
       - "src/litoral_trace/db/models/us_lacey.py"
       - "src/litoral_trace/db/models/us_lacey_commercial.py"
       - "src/litoral_trace/db/models/us_lacey_payment_event.py"
@@ -128,7 +133,7 @@ jobs:
           PY
       - name: Migrate through pre-Assurance baseline
         run: python -m alembic upgrade 029_add_smart_import_profiles
-      - name: Migrate through US Lacey Lemon head
+      - name: Migrate through US Lacey Owner Admin head
         run: python -m alembic upgrade head
       - name: Bind dedicated worker login to queue capability
         shell: bash
@@ -154,7 +159,7 @@ jobs:
         run: |
           set -euo pipefail
           python -m alembic current | tee /tmp/alembic-current.txt
-          grep -F "041_us_lacey_lemon" /tmp/alembic-current.txt
+          grep -F "042_us_lacey_owner_admin" /tmp/alembic-current.txt
           python - <<'PY'
           import os
           from sqlalchemy import create_engine, text
@@ -338,6 +343,31 @@ jobs:
                       'EXECUTE'
                   )
               """)).scalar_one()
+              owner_overview = connection.execute(text("""
+                  SELECT
+                      p.prosecdef,
+                      owner_role.rolname AS owner_role,
+                      has_function_privilege(
+                          'litoral_trace_app',
+                          'public.platform_us_lacey_account_overview(text)',
+                          'EXECUTE'
+                      ) AS runtime_execute,
+                      has_function_privilege(
+                          'litoral_trace_us_lacey_worker',
+                          'public.platform_us_lacey_account_overview(text)',
+                          'EXECUTE'
+                      ) AS worker_execute,
+                      EXISTS (
+                          SELECT 1
+                          FROM aclexplode(coalesce(p.proacl, acldefault('f', p.proowner))) AS acl
+                          WHERE acl.grantee = 0 AND acl.privilege_type = 'EXECUTE'
+                      ) AS public_execute
+                  FROM pg_proc p
+                  JOIN pg_namespace n ON n.oid = p.pronamespace
+                  JOIN pg_roles owner_role ON owner_role.oid = p.proowner
+                  WHERE n.nspname = 'public'
+                    AND p.proname = 'platform_us_lacey_account_overview'
+              """)).mappings().one()
           by_table = {row["relname"]: row for row in rows}
           assert set(by_table) == set(expected_policy_counts)
           assert all(row["relrowsecurity"] is True for row in by_table.values())
@@ -382,6 +412,13 @@ jobs:
               "public_privilege": False,
           }
           assert runtime_apply_execute is True
+          assert owner_overview == {
+              "prosecdef": True,
+              "owner_role": "litoral_trace_platform_definer",
+              "runtime_execute": True,
+              "worker_execute": False,
+              "public_execute": False,
+          }
           engine.dispose()
           PY
       - name: Prove self-registration and email transition
@@ -548,6 +585,103 @@ jobs:
               assert count == 1
           runtime.dispose()
           migrator.dispose()
+          audit.dispose()
+          PY
+      - name: Prove owner admin overview is superadmin-only and curated
+        shell: bash
+        run: |
+          set -euo pipefail
+          python - <<'PY'
+          import os
+          from sqlalchemy import create_engine, text
+          from sqlalchemy.exc import DBAPIError
+
+          runtime = create_engine(os.environ["DATABASE_URL"], pool_pre_ping=True)
+          audit = create_engine(
+              "postgresql+psycopg://postgres:us_lacey_root_password_2026@127.0.0.1:5432/litoral_trace_us_lacey_ci",
+              pool_pre_ping=True,
+              hide_parameters=True,
+          )
+          token_hash = "d" * 64
+          fake_bcrypt_hash = "$2b$12$" + ("z" * 53)
+
+          with audit.begin() as connection:
+              org_id = connection.execute(text("""
+                  INSERT INTO public.organizations (
+                      name, slug, tax_id, tier, description, is_active, created_at, updated_at
+                  ) VALUES (
+                      'Owner Console Gate', 'owner-console-gate', 'OWNER-CONSOLE-GATE',
+                      'enterprise', 'CI platform actor', true, now(), now()
+                  ) RETURNING id
+              """)).scalar_one()
+              user_id = connection.execute(text("""
+                  INSERT INTO public.users (
+                      organization_id, email, username, password_hash, role,
+                      full_name, is_active, created_at, updated_at
+                  ) VALUES (
+                      :org_id, 'owner-console@example.com', 'owner_console_gate',
+                      :password_hash, 'superadmin', 'Owner Console Gate', true, now(), now()
+                  ) RETURNING id
+              """), {"org_id": org_id, "password_hash": fake_bcrypt_hash}).scalar_one()
+              connection.execute(text("""
+                  INSERT INTO public.user_sessions (
+                      user_id, organization_id, family_id, token_hash,
+                      issued_at, expires_at, revoked_at, replaced_by_session_id,
+                      created_ip, user_agent, created_at, updated_at
+                  ) VALUES (
+                      :user_id, :org_id, '00000000-0000-0000-0000-000000000042',
+                      :token_hash, now(), now() + interval '1 hour', null, null,
+                      '127.0.0.1', 'owner-admin-gate', now(), now()
+                  )
+              """), {"user_id": user_id, "org_id": org_id, "token_hash": token_hash})
+
+          try:
+              with runtime.begin() as connection:
+                  connection.execute(
+                      text("SELECT * FROM public.platform_us_lacey_account_overview(:token)"),
+                      {"token": "e" * 64},
+                  ).mappings().all()
+          except DBAPIError as exc:
+              assert getattr(exc.orig, "sqlstate", None) == "28000"
+          else:
+              raise AssertionError("owner overview accepted an invalid platform session")
+
+          with runtime.begin() as connection:
+              rows = connection.execute(
+                  text("SELECT * FROM public.platform_us_lacey_account_overview(:token)"),
+                  {"token": token_hash},
+              ).mappings().all()
+
+          assert len(rows) == 2
+          by_name = {row["legal_name"]: dict(row) for row in rows}
+          manual = by_name["US Lacey Gate Imports LLC"]
+          lemon = by_name["US Lacey Lemon Gate LLC"]
+          assert manual["account_status"] == "PAYMENT_PENDING"
+          assert manual["payment_provider"] == "MANUAL_BANK_TRANSFER"
+          assert manual["payment_status"] == "PENDING"
+          assert lemon["account_status"] == "ACTIVE"
+          assert lemon["payment_provider"] == "LEMON_SQUEEZY"
+          assert lemon["payment_status"] == "VERIFIED"
+          assert lemon["subscription_status"] == "ACTIVE"
+          assert lemon["payment_amount_cents"] == 19900
+          assert lemon["last_payment_event_at"] is not None
+
+          expected_keys = {
+              "organization_id", "organization_name", "legal_name", "business_type",
+              "admin_contact_email", "account_status", "payment_provider",
+              "payment_status", "payment_amount_cents", "subscription_status",
+              "monthly_operation_limit", "used_operations", "queued_jobs",
+              "running_jobs", "retry_jobs", "failed_jobs", "last_payment_event_at",
+              "account_created_at",
+          }
+          assert set(lemon) == expected_keys
+          for forbidden in (
+              "payload_sha256", "provider_order_id", "store_id", "variant_id",
+              "payment_reference", "password_hash", "token_hash",
+          ):
+              assert forbidden not in lemon
+
+          runtime.dispose()
           audit.dispose()
           PY
       - name: Prove Lemon fail-closed parsing contracts

--- a/alembic/versions/042_add_us_lacey_owner_admin_overview.py
+++ b/alembic/versions/042_add_us_lacey_owner_admin_overview.py
@@ -1,0 +1,152 @@
+"""Add read-only U.S. Lacey owner/admin account overview.
+
+Revision ID: 042_us_lacey_owner_admin
+Revises: 041_us_lacey_lemon
+Create Date: 2026-09-03 15:10:00.000000
+"""
+from __future__ import annotations
+
+from typing import Sequence, Union
+
+from alembic import op
+
+
+revision: str = "042_us_lacey_owner_admin"
+down_revision: Union[str, Sequence[str], None] = "041_us_lacey_lemon"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+RUNTIME_ROLE = "litoral_trace_app"
+PLATFORM_ROLE = "litoral_trace_platform_definer"
+WORKER_ROLE = "litoral_trace_worker_executor"
+OVERVIEW_SIGNATURE = "public.platform_us_lacey_account_overview(text)"
+
+
+def _grant_temp_platform_set() -> None:
+    op.execute(
+        f"GRANT {PLATFORM_ROLE} TO CURRENT_USER "
+        "WITH ADMIN FALSE, INHERIT FALSE, SET TRUE GRANTED BY CURRENT_USER"
+    )
+
+
+def _revoke_temp_platform_set() -> None:
+    op.execute(f"REVOKE {PLATFORM_ROLE} FROM CURRENT_USER GRANTED BY CURRENT_USER")
+
+
+def upgrade() -> None:
+    """Expose a least-privilege, read-only cross-tenant owner view.
+
+    The web runtime receives EXECUTE only. All underlying U.S. Lacey tables keep
+    their existing FORCE-RLS policies and grants. Cross-tenant visibility exists
+    solely inside a SECURITY DEFINER function whose first operation validates a
+    persistent superadmin platform session through the hardened 028 control plane.
+    """
+    _grant_temp_platform_set()
+    op.execute(f"GRANT CREATE ON SCHEMA public TO {PLATFORM_ROLE}")
+    op.execute(f"SET ROLE {PLATFORM_ROLE}")
+
+    op.execute(
+        """
+        CREATE FUNCTION public.platform_us_lacey_account_overview(
+            actor_refresh_token_hash text
+        )
+        RETURNS TABLE (
+            organization_id integer,
+            organization_name text,
+            legal_name text,
+            business_type text,
+            admin_contact_email text,
+            account_status text,
+            payment_provider text,
+            payment_status text,
+            payment_amount_cents integer,
+            subscription_status text,
+            monthly_operation_limit integer,
+            used_operations integer,
+            queued_jobs bigint,
+            running_jobs bigint,
+            retry_jobs bigint,
+            failed_jobs bigint,
+            last_payment_event_at timestamptz,
+            account_created_at timestamptz
+        )
+        LANGUAGE plpgsql
+        SECURITY DEFINER
+        SET search_path = public, pg_temp
+        AS $$
+        BEGIN
+            PERFORM 1
+            FROM public._platform_superadmin_session_actor(actor_refresh_token_hash);
+
+            RETURN QUERY
+            SELECT
+                profile.organization_id,
+                organization.name::text,
+                profile.legal_name::text,
+                profile.business_type::text,
+                profile.admin_contact_email::text,
+                profile.account_status::text,
+                payment.provider::text,
+                payment.status::text,
+                payment.amount_cents,
+                subscription.status::text,
+                subscription.monthly_operation_limit,
+                subscription.used_operations,
+                coalesce(job_counts.queued_jobs, 0)::bigint,
+                coalesce(job_counts.running_jobs, 0)::bigint,
+                coalesce(job_counts.retry_jobs, 0)::bigint,
+                coalesce(job_counts.failed_jobs, 0)::bigint,
+                payment_event.last_payment_event_at,
+                profile.created_at
+            FROM public.us_lacey_organization_profiles AS profile
+            JOIN public.organizations AS organization
+              ON organization.id = profile.organization_id
+            LEFT JOIN public.us_lacey_subscriptions AS subscription
+              ON subscription.organization_id = profile.organization_id
+            LEFT JOIN LATERAL (
+                SELECT
+                    candidate.provider,
+                    candidate.status,
+                    candidate.amount_cents
+                FROM public.us_lacey_payments AS candidate
+                WHERE candidate.organization_id = profile.organization_id
+                ORDER BY candidate.created_at DESC, candidate.id DESC
+                LIMIT 1
+            ) AS payment ON true
+            LEFT JOIN LATERAL (
+                SELECT
+                    count(*) FILTER (WHERE job.status = 'QUEUED') AS queued_jobs,
+                    count(*) FILTER (WHERE job.status = 'RUNNING') AS running_jobs,
+                    count(*) FILTER (WHERE job.status = 'RETRY') AS retry_jobs,
+                    count(*) FILTER (WHERE job.status = 'FAILED') AS failed_jobs
+                FROM public.us_lacey_processing_jobs AS job
+                WHERE job.organization_id = profile.organization_id
+            ) AS job_counts ON true
+            LEFT JOIN LATERAL (
+                SELECT max(event.processed_at) AS last_payment_event_at
+                FROM public.us_lacey_payment_events AS event
+                WHERE event.organization_id = profile.organization_id
+            ) AS payment_event ON true
+            ORDER BY profile.organization_id ASC;
+        END;
+        $$;
+        """
+    )
+
+    # The owner console is intentionally read-only. Runtime gets only EXECUTE on
+    # this curated projection; the worker and PUBLIC get no access at all.
+    op.execute(f"REVOKE ALL ON FUNCTION {OVERVIEW_SIGNATURE} FROM PUBLIC")
+    op.execute(f"REVOKE ALL ON FUNCTION {OVERVIEW_SIGNATURE} FROM {WORKER_ROLE}")
+    op.execute(f"GRANT EXECUTE ON FUNCTION {OVERVIEW_SIGNATURE} TO {RUNTIME_ROLE}")
+
+    op.execute("RESET ROLE")
+    op.execute(f"REVOKE CREATE ON SCHEMA public FROM {PLATFORM_ROLE}")
+    _revoke_temp_platform_set()
+
+
+def downgrade() -> None:
+    _grant_temp_platform_set()
+    op.execute(f"SET ROLE {PLATFORM_ROLE}")
+    op.execute(f"DROP FUNCTION IF EXISTS {OVERVIEW_SIGNATURE}")
+    op.execute("RESET ROLE")
+    _revoke_temp_platform_set()

--- a/src/litoral_trace/api/admin.py
+++ b/src/litoral_trace/api/admin.py
@@ -5,7 +5,7 @@ from datetime import datetime
 
 from fastapi import APIRouter, Cookie, Depends, HTTPException, Request, status
 from fastapi.encoders import jsonable_encoder
-from fastapi.responses import JSONResponse
+from fastapi.responses import HTMLResponse, JSONResponse
 from pydantic import BaseModel, Field, ValidationError
 
 from litoral_trace.api.auth import UserTenantContext
@@ -18,6 +18,8 @@ from litoral_trace.services.admin import (
     listar_empresas_superadmin,
     upsert_license_superadmin,
 )
+from litoral_trace.services.us_lacey_admin import list_us_lacey_accounts_superadmin
+from litoral_trace.web.templates import templates
 
 router = APIRouter(prefix="/api/v1/admin", tags=["SuperAdmin B2B"])
 
@@ -111,6 +113,55 @@ async def listar_organizaciones_endpoint(
         status_code=status.HTTP_200_OK,
         content={"total": len(empresas), "organizations": empresas},
     )
+
+
+@router.get("/us-lacey/accounts", tags=["SuperAdmin B2B", "U.S. Lacey"])
+async def listar_cuentas_us_lacey_endpoint(
+    refresh_token_cookie: str | None = Cookie(None, alias=REFRESH_TOKEN_COOKIE_KEY),
+    admin: UserTenantContext = Depends(require_superadmin_role),
+) -> JSONResponse:
+    """Return the read-only owner overview for U.S. Lacey customer accounts."""
+    accounts = list_us_lacey_accounts_superadmin(refresh_token=refresh_token_cookie)
+    return JSONResponse(
+        status_code=status.HTTP_200_OK,
+        content=jsonable_encoder({"total": len(accounts), "accounts": accounts}),
+    )
+
+
+@router.get(
+    "/us-lacey/accounts/fragment",
+    response_class=HTMLResponse,
+    tags=["SuperAdmin B2B", "U.S. Lacey"],
+)
+async def render_cuentas_us_lacey_fragment_endpoint(
+    request: Request,
+    refresh_token_cookie: str | None = Cookie(None, alias=REFRESH_TOKEN_COOKIE_KEY),
+    admin: UserTenantContext = Depends(require_superadmin_role),
+) -> HTMLResponse:
+    """Render the read-only U.S. account console inside the existing admin page."""
+    accounts = list_us_lacey_accounts_superadmin(refresh_token=refresh_token_cookie)
+    active_count = sum(1 for account in accounts if account.get("account_status") == "ACTIVE")
+    pilot_count = sum(1 for account in accounts if account.get("account_status") == "PILOT")
+    pending_count = sum(
+        1
+        for account in accounts
+        if account.get("account_status") in {"PENDING_EMAIL", "PAYMENT_PENDING"}
+    )
+    failed_job_count = sum(int(account.get("failed_jobs") or 0) for account in accounts)
+    content = templates.get_template("admin_us_lacey_accounts.html").render(
+        request=request,
+        accounts=accounts,
+        account_count=len(accounts),
+        active_count=active_count,
+        pilot_count=pilot_count,
+        pending_count=pending_count,
+        failed_job_count=failed_job_count,
+    )
+    response = HTMLResponse(content=content, status_code=status.HTTP_200_OK)
+    response.headers["Cache-Control"] = "no-store, max-age=0"
+    response.headers["X-Content-Type-Options"] = "nosniff"
+    response.headers["X-Frame-Options"] = "DENY"
+    return response
 
 
 @router.post("/organizations", tags=["SuperAdmin B2B"])

--- a/src/litoral_trace/services/us_lacey_admin.py
+++ b/src/litoral_trace/services/us_lacey_admin.py
@@ -1,0 +1,61 @@
+"""Read-only platform-owner queries for the U.S. Lacey product."""
+from __future__ import annotations
+
+from typing import Any
+
+from fastapi import HTTPException, status
+from sqlalchemy import text
+from sqlalchemy.exc import DBAPIError
+
+from litoral_trace.db.engine import get_db_session
+from litoral_trace.services.admin import (
+    _map_platform_db_error,
+    _require_platform_refresh_token_hash,
+)
+
+
+def list_us_lacey_accounts_superadmin(
+    *,
+    refresh_token: str | None,
+) -> list[dict[str, Any]]:
+    """Return the curated cross-tenant U.S. account overview for a superadmin.
+
+    PostgreSQL is mandatory because cross-tenant visibility is implemented only
+    by the SECURITY DEFINER control-plane function introduced in migration 042.
+    There is deliberately no direct ORM/SQLite fallback that could normalize a
+    cross-tenant bypass into application code.
+    """
+    db_session = get_db_session()
+    if db_session is None:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Servicio de base de datos no disponible.",
+        )
+
+    try:
+        bind = db_session.get_bind()
+        if bind is None or bind.dialect.name != "postgresql":
+            raise HTTPException(
+                status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+                detail="El panel U.S. Lacey requiere el control-plane PostgreSQL.",
+            )
+
+        token_hash = _require_platform_refresh_token_hash(refresh_token)
+        rows = db_session.execute(
+            text(
+                """
+                SELECT *
+                FROM public.platform_us_lacey_account_overview(
+                    :actor_refresh_token_hash
+                )
+                ORDER BY organization_id
+                """
+            ),
+            {"actor_refresh_token_hash": token_hash},
+        ).mappings().all()
+        return [dict(row) for row in rows]
+    except DBAPIError as exc:
+        _map_platform_db_error(exc)
+        raise
+    finally:
+        db_session.close()

--- a/src/litoral_trace/templates/admin_organizations.html
+++ b/src/litoral_trace/templates/admin_organizations.html
@@ -68,5 +68,16 @@
             <div id="adminCreateResult" class="mt-4"></div>
         </article>
     </div>
+
+    <article
+        id="usLaceyOwnerConsole"
+        class="space-y-6 rounded-2xl border border-slate-200 bg-white p-4 shadow-sm sm:p-6 lt-data-table"
+        hx-get="/api/v1/admin/us-lacey/accounts/fragment"
+        hx-trigger="load"
+        hx-swap="innerHTML"
+        aria-live="polite"
+    >
+        <div class="rounded-xl border border-slate-200 bg-slate-50 p-5 text-center text-sm text-slate-500">Cargando estado U.S. Lacey…</div>
+    </article>
 </section>
 {% endblock %}

--- a/src/litoral_trace/templates/admin_us_lacey_accounts.html
+++ b/src/litoral_trace/templates/admin_us_lacey_accounts.html
@@ -1,0 +1,64 @@
+<section class="space-y-6" aria-labelledby="us-lacey-admin-title">
+    <div class="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+        <div class="max-w-3xl">
+            <div class="mb-2 flex flex-wrap items-center gap-2">
+                <span class="rounded-full border border-purple-200 bg-purple-50 px-2.5 py-1 text-xs font-semibold text-purple-800"><i class="fa-solid fa-shield-halved mr-1" aria-hidden="true"></i>U.S. Lacey</span>
+                <span class="text-xs font-medium text-slate-500">Vista global de solo lectura</span>
+            </div>
+            <h2 id="us-lacey-admin-title" class="text-lg font-bold text-slate-950">Owner / Admin Console</h2>
+            <p class="mt-2 text-sm leading-6 text-slate-600">Estado comercial y operativo de las cuentas U.S. Lacey. Esta vista no puede activar pagos, editar suscripciones ni modificar operaciones.</p>
+        </div>
+        <span class="rounded-full border border-slate-200 bg-slate-100 px-2.5 py-1 text-xs font-semibold text-slate-700">{{ account_count }} cuentas</span>
+    </div>
+
+    <div class="grid grid-cols-2 gap-3 lg:grid-cols-4">
+        <div class="rounded-xl border border-slate-200 bg-slate-50 p-4"><p class="text-[10px] font-bold uppercase tracking-wide text-slate-500">Activas</p><p class="mt-1 text-2xl font-bold text-slate-950">{{ active_count }}</p></div>
+        <div class="rounded-xl border border-slate-200 bg-slate-50 p-4"><p class="text-[10px] font-bold uppercase tracking-wide text-slate-500">Piloto</p><p class="mt-1 text-2xl font-bold text-slate-950">{{ pilot_count }}</p></div>
+        <div class="rounded-xl border border-slate-200 bg-slate-50 p-4"><p class="text-[10px] font-bold uppercase tracking-wide text-slate-500">Pendientes</p><p class="mt-1 text-2xl font-bold text-slate-950">{{ pending_count }}</p></div>
+        <div class="rounded-xl border border-slate-200 bg-slate-50 p-4"><p class="text-[10px] font-bold uppercase tracking-wide text-slate-500">Jobs fallidos</p><p class="mt-1 text-2xl font-bold text-slate-950">{{ failed_job_count }}</p></div>
+    </div>
+
+    <div class="grid gap-3 sm:hidden" aria-label="Cuentas U.S. Lacey en vista móvil">
+        {% for account in accounts %}
+        <article class="rounded-xl border border-slate-200 bg-slate-50 p-4">
+            <div class="flex min-w-0 items-start justify-between gap-3">
+                <div class="min-w-0">
+                    <p class="lt-mobile-wrap text-sm font-bold text-slate-950">{{ account.legal_name }}</p>
+                    <p class="mt-1 break-all text-[11px] text-slate-500">{{ account.admin_contact_email or "—" }} · ID {{ account.organization_id }}</p>
+                </div>
+                {% if account.account_status == 'ACTIVE' %}<span class="shrink-0 rounded-full bg-emerald-100 px-2 py-1 text-[10px] font-bold text-emerald-800">ACTIVE</span>{% elif account.account_status == 'SUSPENDED' %}<span class="shrink-0 rounded-full bg-rose-100 px-2 py-1 text-[10px] font-bold text-rose-800">SUSPENDED</span>{% else %}<span class="shrink-0 rounded-full bg-slate-100 px-2 py-1 text-[10px] font-bold text-slate-700">{{ account.account_status }}</span>{% endif %}
+            </div>
+            <dl class="mt-4 grid gap-3">
+                <div class="grid grid-cols-2 gap-3"><div><dt class="text-[10px] font-bold uppercase tracking-wide text-slate-500">Pago</dt><dd class="mt-1 text-xs font-semibold text-slate-800">{{ account.payment_provider or "—" }} · {{ account.payment_status or "—" }}</dd></div><div><dt class="text-[10px] font-bold uppercase tracking-wide text-slate-500">Suscripción</dt><dd class="mt-1 text-xs font-semibold text-slate-800">{{ account.subscription_status or "—" }}</dd></div></div>
+                <div><dt class="text-[10px] font-bold uppercase tracking-wide text-slate-500">Uso mensual</dt><dd class="mt-1 text-xs font-semibold text-slate-800">{{ account.used_operations or 0 }} / {{ account.monthly_operation_limit or 0 }} operaciones</dd></div>
+                <div><dt class="text-[10px] font-bold uppercase tracking-wide text-slate-500">Cola</dt><dd class="mt-1 text-xs font-semibold text-slate-800">{{ account.queued_jobs or 0 }} queued · {{ account.running_jobs or 0 }} running · {{ account.retry_jobs or 0 }} retry · {{ account.failed_jobs or 0 }} failed</dd></div>
+            </dl>
+        </article>
+        {% else %}
+        <div class="rounded-xl border border-dashed border-slate-300 bg-slate-50 p-5 text-center text-sm text-slate-500">Todavía no hay cuentas U.S. Lacey registradas.</div>
+        {% endfor %}
+    </div>
+
+    <div class="hidden sm:block overflow-x-auto rounded-xl border border-slate-200 lt-data-table__scroll">
+        <table class="w-full text-left text-xs lt-data-table__table">
+            <thead class="border-b border-slate-200 bg-slate-50 font-semibold uppercase text-slate-600 lt-data-table__head">
+                <tr><th class="p-3 lt-data-table__th">Cuenta</th><th class="p-3 lt-data-table__th">Estado</th><th class="p-3 lt-data-table__th">Pago</th><th class="p-3 lt-data-table__th">Suscripción</th><th class="p-3 lt-data-table__th">Uso</th><th class="p-3 lt-data-table__th">Jobs</th><th class="p-3 lt-data-table__th">Último evento</th></tr>
+            </thead>
+            <tbody class="divide-y divide-slate-200 font-medium text-slate-700 lt-data-table__body">
+                {% for account in accounts %}
+                <tr class="hover:bg-slate-50 lt-data-table__row">
+                    <td class="p-3 lt-data-table__cell"><div class="font-semibold text-slate-900 lt-data-table__primary">{{ account.legal_name }}</div><div class="text-slate-500 lt-data-table__secondary">{{ account.admin_contact_email or "—" }} · {{ account.business_type }}</div></td>
+                    <td class="p-3 lt-data-table__cell">{% if account.account_status == 'ACTIVE' %}<span class="rounded-full bg-emerald-100 px-2 py-0.5 font-bold text-emerald-800">ACTIVE</span>{% elif account.account_status == 'SUSPENDED' %}<span class="rounded-full bg-rose-100 px-2 py-0.5 font-bold text-rose-800">SUSPENDED</span>{% else %}<span class="rounded-full bg-slate-100 px-2 py-0.5 font-bold text-slate-700">{{ account.account_status }}</span>{% endif %}</td>
+                    <td class="p-3 lt-data-table__cell"><div class="font-semibold text-slate-900">{{ account.payment_provider or "—" }}</div><div class="text-slate-500 lt-data-table__secondary">{{ account.payment_status or "—" }}{% if account.payment_amount_cents %} · USD {{ "%.2f"|format(account.payment_amount_cents / 100) }}{% endif %}</div></td>
+                    <td class="p-3 lt-data-table__cell">{{ account.subscription_status or "—" }}</td>
+                    <td class="p-3 font-semibold lt-data-table__cell lt-data-table__cell--numeric">{{ account.used_operations or 0 }} / {{ account.monthly_operation_limit or 0 }}</td>
+                    <td class="p-3 lt-data-table__cell"><span class="font-semibold text-slate-900">{{ account.queued_jobs or 0 }} Q</span><span class="text-slate-500"> · {{ account.running_jobs or 0 }} R · {{ account.retry_jobs or 0 }} retry · {{ account.failed_jobs or 0 }} F</span></td>
+                    <td class="p-3 text-slate-500 lt-data-table__cell">{% if account.last_payment_event_at %}{{ account.last_payment_event_at.strftime('%Y-%m-%d %H:%M') }} UTC{% else %}—{% endif %}</td>
+                </tr>
+                {% else %}
+                <tr><td colspan="7" class="p-6 text-center text-sm text-slate-500">Todavía no hay cuentas U.S. Lacey registradas.</td></tr>
+                {% endfor %}
+            </tbody>
+        </table>
+    </div>
+</section>

--- a/tests/test_assurance_migration_contract.py
+++ b/tests/test_assurance_migration_contract.py
@@ -10,6 +10,7 @@ US_LACEY_SELF_SERVICE_MIGRATION = Path("alembic/versions/035_add_us_lacey_self_s
 US_LACEY_STATUS_FIX_MIGRATION = Path("alembic/versions/036_fix_us_lacey_status_ambiguity.py")
 US_LACEY_PORTAL_AUTH_MIGRATION = Path("alembic/versions/037_add_us_lacey_portal_auth_functions.py")
 US_LACEY_PILOT_ACTIVATION_MIGRATION = Path("alembic/versions/038_us_lacey_pilot_activation.py")
+US_LACEY_OWNER_ADMIN_MIGRATION = Path("alembic/versions/042_add_us_lacey_owner_admin_overview.py")
 
 
 def test_assurance_migration_has_expected_parent_and_tables():
@@ -106,9 +107,16 @@ def test_us_lacey_portal_auth_is_chained_after_status_fix():
     assert "us_lacey_portal_revoke_session" in portal_auth
 
 
+def test_us_lacey_owner_admin_follows_lemon_head():
+    text = US_LACEY_OWNER_ADMIN_MIGRATION.read_text(encoding="utf-8")
+    assert 'revision: str = "042_us_lacey_owner_admin"' in text
+    assert '"041_us_lacey_lemon"' in text
+    assert "platform_us_lacey_account_overview" in text
+
+
 def test_ci_canonical_head_tracks_latest_platform_migration():
     text = Path(".github/workflows/ci.yml").read_text(encoding="utf-8")
-    assert "041_us_lacey_lemon (head)" in text
+    assert "042_us_lacey_owner_admin (head)" in text
 
 
 def test_us_lacey_pilot_activation_follows_portal_auth():

--- a/tests/test_ci_p26a_unittest.py
+++ b/tests/test_ci_p26a_unittest.py
@@ -59,7 +59,7 @@ def test_p26a_ci_runs_pytest_and_disables_postgres_integration():
 def test_p26a_ci_checks_single_canonical_alembic_head():
     workflow = _workflow_text()
     assert "alembic heads" in workflow
-    assert "041_us_lacey_lemon (head)" in workflow
+    assert "042_us_lacey_owner_admin (head)" in workflow
     assert "alembic upgrade head" not in workflow
 
 

--- a/tests/test_us_lacey_owner_admin_contract.py
+++ b/tests/test_us_lacey_owner_admin_contract.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+MIGRATION = Path("alembic/versions/042_add_us_lacey_owner_admin_overview.py")
+SERVICE = Path("src/litoral_trace/services/us_lacey_admin.py")
+ADMIN_API = Path("src/litoral_trace/api/admin.py")
+ADMIN_PAGE = Path("src/litoral_trace/templates/admin_organizations.html")
+ADMIN_FRAGMENT = Path("src/litoral_trace/templates/admin_us_lacey_accounts.html")
+
+
+def test_042_is_single_chain_after_lemon_and_uses_platform_definer() -> None:
+    text = MIGRATION.read_text(encoding="utf-8")
+
+    assert 'revision: str = "042_us_lacey_owner_admin"' in text
+    assert '"041_us_lacey_lemon"' in text
+    assert "platform_us_lacey_account_overview" in text
+    assert "_platform_superadmin_session_actor" in text
+    assert "SECURITY DEFINER" in text
+    assert "SET search_path = public, pg_temp" in text
+    assert "SET ROLE {PLATFORM_ROLE}" in text
+
+
+def test_042_owner_projection_is_read_only_and_does_not_expose_lemon_ledger_secrets() -> None:
+    text = MIGRATION.read_text(encoding="utf-8")
+
+    assert "GRANT EXECUTE" in text
+    assert "TO {RUNTIME_ROLE}" in text
+    assert "REVOKE ALL ON FUNCTION" in text
+    assert "payload_sha256" not in text
+    assert "provider_order_id" not in text
+    assert "store_id" not in text
+    assert "variant_id" not in text
+    assert "INSERT INTO public.us_lacey" not in text
+    assert "UPDATE public.us_lacey" not in text
+    assert "DELETE FROM public.us_lacey" not in text
+
+
+def test_owner_service_calls_only_the_curated_platform_function() -> None:
+    text = SERVICE.read_text(encoding="utf-8")
+
+    assert "platform_us_lacey_account_overview" in text
+    assert "_require_platform_refresh_token_hash" in text
+    assert 'bind.dialect.name != "postgresql"' in text
+    for table_name in (
+        "us_lacey_organization_profiles",
+        "us_lacey_subscriptions",
+        "us_lacey_payments",
+        "us_lacey_processing_jobs",
+        "us_lacey_payment_events",
+    ):
+        assert table_name not in text
+
+
+def test_owner_api_reuses_platform_admin_permission_and_persistent_session() -> None:
+    text = ADMIN_API.read_text(encoding="utf-8")
+
+    assert "Permission.PLATFORM_ADMIN" in text
+    assert "REFRESH_TOKEN_COOKIE_KEY" in text
+    assert 'router.get("/us-lacey/accounts"' in text
+    assert '"/us-lacey/accounts/fragment"' in text
+    assert "list_us_lacey_accounts_superadmin" in text
+
+
+def test_existing_admin_page_mounts_read_only_us_lacey_console() -> None:
+    page = ADMIN_PAGE.read_text(encoding="utf-8")
+    fragment = ADMIN_FRAGMENT.read_text(encoding="utf-8")
+
+    assert 'hx-get="/api/v1/admin/us-lacey/accounts/fragment"' in page
+    assert "Owner / Admin Console" in fragment
+    assert "Vista global de solo lectura" in fragment
+    assert "no puede activar pagos" in fragment
+    assert "hx-post" not in fragment
+    assert "verify-payment" not in fragment.lower()


### PR DESCRIPTION
## Scope

Adds migration `042_us_lacey_owner_admin` on top of the certified Lemon 041 head.

- reuses the existing `PLATFORM_ADMIN` / persistent-session control plane;
- adds a SECURITY DEFINER read-only U.S. account overview owned by `litoral_trace_platform_definer`;
- grants the runtime only EXECUTE on the curated function, with no new direct cross-tenant table privileges;
- exposes JSON + an HTMX read-only console inside the existing `/admin` page;
- intentionally exposes no Lemon payload hash, provider order ID, store/variant IDs, password/session data, or payment mutation action;
- advances CI/PostgreSQL gates to canonical head 042 and proves invalid-session rejection plus real manual/Lemon overview behavior.

## Non-goals

No payment activation, subscription mutation, account-status mutation, customer billing template change, Uptime change, or new admin credential system.

## Gate

Do not merge until general CI, CSS Drift (template change) and the isolated U.S. Lacey PostgreSQL Gate are green on the exact final SHA.