### PR TITLE
fix(us-lacey): disable Wise for new payments on 043

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,7 +71,7 @@ jobs:
             echo "Expected exactly one Alembic head."
             exit 1
           fi
-          grep -Fx "042_us_lacey_owner_admin (head)" alembic-heads.txt
+          grep -Fx "043_042_us_lacey_owner_admin (head)" alembic-heads.txt
 
       - name: Run pytest suite
         run: python -m pytest -q -rs

--- a/alembic/versions/043_disable_us_lacey_wise_signup.py
+++ b/alembic/versions/043_disable_us_lacey_wise_signup.py
@@ -1,0 +1,154 @@
+"""Disable Wise for new U.S. Lacey self-service registrations.
+
+Revision ID: 043_042_us_lacey_owner_admin
+Revises: 042_us_lacey_owner_admin
+Create Date: 2026-09-03 16:05:00.000000
+
+The payment table keeps its historical WISE value so existing audit records stay
+readable. This migration changes only the supported registration surface: new
+accounts may start with MANUAL_BANK_TRANSFER or LEMON_SQUEEZY, never WISE.
+"""
+from __future__ import annotations
+
+from typing import Sequence, Union
+
+from alembic import op
+
+
+revision: str = "043_042_us_lacey_owner_admin"
+down_revision: Union[str, Sequence[str], None] = "042_us_lacey_owner_admin"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+RUNTIME_ROLE = "litoral_trace_app"
+PLATFORM_ROLE = "litoral_trace_platform_definer"
+WORKER_ROLE = "litoral_trace_worker_executor"
+REGISTER_SIGNATURE = (
+    "public.us_lacey_self_register(text,text,text,text,text,text,integer,integer,text,text,text,text)"
+)
+PRE_043_SIGNATURE = (
+    "public.us_lacey_self_register_pre_043(text,text,text,text,text,text,integer,integer,text,text,text,text)"
+)
+
+
+def _grant_temp_platform_set() -> None:
+    op.execute(
+        f"GRANT {PLATFORM_ROLE} TO CURRENT_USER "
+        "WITH ADMIN FALSE, INHERIT FALSE, SET TRUE GRANTED BY CURRENT_USER"
+    )
+
+
+def _revoke_temp_platform_set() -> None:
+    op.execute(f"REVOKE {PLATFORM_ROLE} FROM CURRENT_USER GRANTED BY CURRENT_USER")
+
+
+def _enter_platform_role() -> None:
+    _grant_temp_platform_set()
+    op.execute(f"GRANT CREATE ON SCHEMA public TO {PLATFORM_ROLE}")
+    op.execute(f"SET ROLE {PLATFORM_ROLE}")
+
+
+def _leave_platform_role() -> None:
+    op.execute("RESET ROLE")
+    op.execute(f"REVOKE CREATE ON SCHEMA public FROM {PLATFORM_ROLE}")
+    _revoke_temp_platform_set()
+
+
+def upgrade() -> None:
+    """Put a fail-closed provider guard in front of the certified 041 registrar."""
+    _enter_platform_role()
+
+    # Preserve the already-certified 041 implementation behind a private name.
+    # Renaming instead of rewriting it keeps Lemon activation behavior unchanged.
+    op.execute(
+        "ALTER FUNCTION public.us_lacey_self_register(text,text,text,text,text,text,integer,integer,text,text,text,text) "
+        "RENAME TO us_lacey_self_register_pre_043"
+    )
+    op.execute(f"REVOKE ALL ON FUNCTION {PRE_043_SIGNATURE} FROM PUBLIC")
+    op.execute(f"REVOKE ALL ON FUNCTION {PRE_043_SIGNATURE} FROM {RUNTIME_ROLE}")
+    op.execute(f"REVOKE ALL ON FUNCTION {PRE_043_SIGNATURE} FROM {WORKER_ROLE}")
+    op.execute(f"GRANT EXECUTE ON FUNCTION {PRE_043_SIGNATURE} TO {PLATFORM_ROLE}")
+
+    op.execute(
+        """
+        CREATE FUNCTION public.us_lacey_self_register(
+            requested_legal_name text,
+            requested_business_type text,
+            requested_admin_name text,
+            requested_admin_email text,
+            requested_password_hash text,
+            requested_verification_token_hash text,
+            requested_price_cents integer,
+            requested_monthly_operation_limit integer,
+            requested_payment_provider text,
+            requested_terms_version text,
+            requested_privacy_version text,
+            requested_beta_version text
+        )
+        RETURNS TABLE (
+            organization_id integer,
+            user_id integer,
+            payment_public_id uuid,
+            payment_reference text,
+            amount_cents integer,
+            account_status text
+        )
+        LANGUAGE plpgsql
+        SECURITY DEFINER
+        SET search_path = public, pg_temp
+        AS $$
+        DECLARE
+            normalized_provider text := upper(btrim(coalesce(requested_payment_provider, '')));
+            registration record;
+        BEGIN
+            IF normalized_provider NOT IN ('MANUAL_BANK_TRANSFER','LEMON_SQUEEZY') THEN
+                RAISE EXCEPTION 'invalid initial payment provider'
+                    USING ERRCODE = '22023';
+            END IF;
+
+            SELECT * INTO registration
+            FROM public.us_lacey_self_register_pre_043(
+                requested_legal_name,
+                requested_business_type,
+                requested_admin_name,
+                requested_admin_email,
+                requested_password_hash,
+                requested_verification_token_hash,
+                requested_price_cents,
+                requested_monthly_operation_limit,
+                normalized_provider,
+                requested_terms_version,
+                requested_privacy_version,
+                requested_beta_version
+            );
+
+            RETURN QUERY SELECT
+                registration.organization_id::integer,
+                registration.user_id::integer,
+                registration.payment_public_id::uuid,
+                registration.payment_reference::text,
+                registration.amount_cents::integer,
+                registration.account_status::text;
+        END;
+        $$;
+        """
+    )
+    op.execute(f"REVOKE ALL ON FUNCTION {REGISTER_SIGNATURE} FROM PUBLIC")
+    op.execute(f"REVOKE ALL ON FUNCTION {REGISTER_SIGNATURE} FROM {WORKER_ROLE}")
+    op.execute(f"GRANT EXECUTE ON FUNCTION {REGISTER_SIGNATURE} TO {RUNTIME_ROLE}")
+
+    _leave_platform_role()
+
+
+def downgrade() -> None:
+    """Restore the exact 041 registration facade when rolling back 043."""
+    _enter_platform_role()
+    op.execute(f"DROP FUNCTION IF EXISTS {REGISTER_SIGNATURE}")
+    op.execute(
+        "ALTER FUNCTION public.us_lacey_self_register_pre_043(text,text,text,text,text,text,integer,integer,text,text,text,text) "
+        "RENAME TO us_lacey_self_register"
+    )
+    op.execute(f"REVOKE ALL ON FUNCTION {REGISTER_SIGNATURE} FROM PUBLIC")
+    op.execute(f"REVOKE ALL ON FUNCTION {REGISTER_SIGNATURE} FROM {WORKER_ROLE}")
+    op.execute(f"GRANT EXECUTE ON FUNCTION {REGISTER_SIGNATURE} TO {RUNTIME_ROLE}")
+    _leave_platform_role()

--- a/src/litoral_trace/us_lacey/commercial.py
+++ b/src/litoral_trace/us_lacey/commercial.py
@@ -50,18 +50,15 @@ def load_us_lacey_commercial_config(
 ) -> UsLaceyCommercialConfig:
     env = os.environ if environ is None else environ
     provider = _required(env, "US_LACEY_PAYMENT_PROVIDER").upper()
-    # WISE remains accepted only as a backward-compatible deployment value so
-    # an existing environment cannot become unready during the Lemon cutover.
-    # New commercial configuration is intended to use LEMON_SQUEEZY.
-    if provider not in {"MANUAL_BANK_TRANSFER", "WISE", "LEMON_SQUEEZY"}:
+    if provider not in {"MANUAL_BANK_TRANSFER", "LEMON_SQUEEZY"}:
         raise UsLaceyCommercialConfigurationError(
-            "US_LACEY_PAYMENT_PROVIDER must be MANUAL_BANK_TRANSFER, WISE, or LEMON_SQUEEZY."
+            "US_LACEY_PAYMENT_PROVIDER must be MANUAL_BANK_TRANSFER or LEMON_SQUEEZY."
         )
 
     bank_instructions = str(env.get("US_LACEY_BANK_TRANSFER_INSTRUCTIONS", "")).strip()
-    if provider in {"MANUAL_BANK_TRANSFER", "WISE"} and not bank_instructions:
+    if provider == "MANUAL_BANK_TRANSFER" and not bank_instructions:
         raise UsLaceyCommercialConfigurationError(
-            "US_LACEY_BANK_TRANSFER_INSTRUCTIONS is required for transfer-based payment."
+            "US_LACEY_BANK_TRANSFER_INSTRUCTIONS is required for manual bank transfer."
         )
 
     support_email = str(env.get("US_LACEY_SUPPORT_EMAIL", "support@litoraltrace.com")).strip().lower()

--- a/tests/test_assurance_migration_contract.py
+++ b/tests/test_assurance_migration_contract.py
@@ -11,6 +11,7 @@ US_LACEY_STATUS_FIX_MIGRATION = Path("alembic/versions/036_fix_us_lacey_status_a
 US_LACEY_PORTAL_AUTH_MIGRATION = Path("alembic/versions/037_add_us_lacey_portal_auth_functions.py")
 US_LACEY_PILOT_ACTIVATION_MIGRATION = Path("alembic/versions/038_us_lacey_pilot_activation.py")
 US_LACEY_OWNER_ADMIN_MIGRATION = Path("alembic/versions/042_add_us_lacey_owner_admin_overview.py")
+US_LACEY_NO_WISE_MIGRATION = Path("alembic/versions/043_disable_us_lacey_wise_signup.py")
 
 
 def test_assurance_migration_has_expected_parent_and_tables():
@@ -114,9 +115,16 @@ def test_us_lacey_owner_admin_follows_lemon_head():
     assert "platform_us_lacey_account_overview" in text
 
 
+def test_us_lacey_no_wise_guard_follows_owner_admin():
+    text = US_LACEY_NO_WISE_MIGRATION.read_text(encoding="utf-8")
+    assert 'revision: str = "043_042_us_lacey_owner_admin"' in text
+    assert '"042_us_lacey_owner_admin"' in text
+    assert "normalized_provider NOT IN ('MANUAL_BANK_TRANSFER','LEMON_SQUEEZY')" in text
+
+
 def test_ci_canonical_head_tracks_latest_platform_migration():
     text = Path(".github/workflows/ci.yml").read_text(encoding="utf-8")
-    assert "042_us_lacey_owner_admin (head)" in text
+    assert "043_042_us_lacey_owner_admin (head)" in text
 
 
 def test_us_lacey_pilot_activation_follows_portal_auth():

--- a/tests/test_ci_p26a_unittest.py
+++ b/tests/test_ci_p26a_unittest.py
@@ -59,7 +59,7 @@ def test_p26a_ci_runs_pytest_and_disables_postgres_integration():
 def test_p26a_ci_checks_single_canonical_alembic_head():
     workflow = _workflow_text()
     assert "alembic heads" in workflow
-    assert "042_us_lacey_owner_admin (head)" in workflow
+    assert "043_042_us_lacey_owner_admin (head)" in workflow
     assert "alembic upgrade head" not in workflow
 
 

--- a/tests/test_us_lacey_active_portal_postgres_e2e.py
+++ b/tests/test_us_lacey_active_portal_postgres_e2e.py
@@ -100,8 +100,8 @@ def _configure(monkeypatch: pytest.MonkeyPatch) -> None:
         "US_LACEY_PRIVATE_BETA_PRICE_CENTS": "12500",
         # Deliberately one slot: upload/review/export must keep working after it is consumed.
         "US_LACEY_MONTHLY_OPERATION_LIMIT": "1",
-        "US_LACEY_PAYMENT_PROVIDER": "WISE",
-        "US_LACEY_BANK_TRANSFER_INSTRUCTIONS": "CI-only Wise USD transfer instructions",
+        "US_LACEY_PAYMENT_PROVIDER": "MANUAL_BANK_TRANSFER",
+        "US_LACEY_BANK_TRANSFER_INSTRUCTIONS": "CI-only manual USD transfer instructions",
         "US_LACEY_TERMS_VERSION": "terms-active-e2e-v1",
         "US_LACEY_PRIVACY_VERSION": "privacy-active-e2e-v1",
         "US_LACEY_BETA_TERMS_VERSION": "beta-active-e2e-v1",

--- a/tests/test_us_lacey_no_wise_contract.py
+++ b/tests/test_us_lacey_no_wise_contract.py
@@ -1,0 +1,68 @@
+"""Contracts that keep Wise out of the U.S. Lacey commercial flow."""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from litoral_trace.us_lacey.commercial import (
+    UsLaceyCommercialConfigurationError,
+    load_us_lacey_commercial_config,
+)
+
+
+MIGRATION = Path("alembic/versions/043_disable_us_lacey_wise_signup.py")
+
+
+def _env(**overrides: str) -> dict[str, str]:
+    values = {
+        "US_LACEY_PRIVATE_BETA_PRICE_CENTS": "19900",
+        "US_LACEY_MONTHLY_OPERATION_LIMIT": "25",
+        "US_LACEY_PAYMENT_PROVIDER": "LEMON_SQUEEZY",
+        "US_LACEY_TERMS_VERSION": "terms-v1",
+        "US_LACEY_PRIVACY_VERSION": "privacy-v1",
+        "US_LACEY_BETA_TERMS_VERSION": "early-access-v1",
+        "US_LACEY_SUPPORT_EMAIL": "support@litoraltrace.com",
+    }
+    values.update(overrides)
+    return values
+
+
+def test_lemon_is_valid_without_manual_transfer_instructions() -> None:
+    config = load_us_lacey_commercial_config(_env())
+    assert config.payment_provider == "LEMON_SQUEEZY"
+    assert config.bank_transfer_instructions == ""
+
+
+def test_wise_is_rejected_fail_closed() -> None:
+    with pytest.raises(
+        UsLaceyCommercialConfigurationError,
+        match="MANUAL_BANK_TRANSFER or LEMON_SQUEEZY",
+    ):
+        load_us_lacey_commercial_config(
+            _env(
+                US_LACEY_PAYMENT_PROVIDER="WISE",
+                US_LACEY_BANK_TRANSFER_INSTRUCTIONS="unused",
+            )
+        )
+
+
+def test_manual_bank_transfer_still_requires_explicit_instructions() -> None:
+    with pytest.raises(
+        UsLaceyCommercialConfigurationError,
+        match="US_LACEY_BANK_TRANSFER_INSTRUCTIONS",
+    ):
+        load_us_lacey_commercial_config(
+            _env(US_LACEY_PAYMENT_PROVIDER="MANUAL_BANK_TRANSFER")
+        )
+
+
+def test_043_wraps_041_registration_and_rejects_wise() -> None:
+    text = MIGRATION.read_text(encoding="utf-8")
+    assert 'revision: str = "043_042_us_lacey_owner_admin"' in text
+    assert 'down_revision: Union[str, Sequence[str], None] = "042_us_lacey_owner_admin"' in text
+    assert "RENAME TO us_lacey_self_register_pre_043" in text
+    assert "normalized_provider NOT IN ('MANUAL_BANK_TRANSFER','LEMON_SQUEEZY')" in text
+    assert "ERRCODE = '22023'" in text
+    assert "REVOKE ALL ON FUNCTION {PRE_043_SIGNATURE} FROM {RUNTIME_ROLE}" in text
+    assert "FROM public.us_lacey_self_register_pre_043(" in text

--- a/tests/test_us_lacey_pilot_core.py
+++ b/tests/test_us_lacey_pilot_core.py
@@ -29,7 +29,7 @@ def _safe_env() -> dict[str, str]:
         "US_LACEY_APP_HOSTNAME": "lacey.litoraltrace.com",
         "US_LACEY_PRIVATE_BETA_PRICE_CENTS": "12500",
         "US_LACEY_MONTHLY_OPERATION_LIMIT": "25",
-        "US_LACEY_PAYMENT_PROVIDER": "WISE",
+        "US_LACEY_PAYMENT_PROVIDER": "MANUAL_BANK_TRANSFER",
         "US_LACEY_BANK_TRANSFER_INSTRUCTIONS": "Use the payment reference shown in Billing.",
         "US_LACEY_TERMS_VERSION": "terms-2026-08",
         "US_LACEY_PRIVACY_VERSION": "privacy-2026-08",

--- a/tests/test_us_lacey_portal_flow.py
+++ b/tests/test_us_lacey_portal_flow.py
@@ -22,7 +22,7 @@ def _portal_env(monkeypatch) -> None:
         "US_LACEY_APP_HOSTNAME": "app.lacey.litoraltrace.com",
         "US_LACEY_PRIVATE_BETA_PRICE_CENTS": "12500",
         "US_LACEY_MONTHLY_OPERATION_LIMIT": "25",
-        "US_LACEY_PAYMENT_PROVIDER": "WISE",
+        "US_LACEY_PAYMENT_PROVIDER": "MANUAL_BANK_TRANSFER",
         "US_LACEY_BANK_TRANSFER_INSTRUCTIONS": "Send USD and include the exact reference.",
         "US_LACEY_TERMS_VERSION": "terms-v1",
         "US_LACEY_PRIVACY_VERSION": "privacy-v1",
@@ -206,7 +206,7 @@ def test_payment_pending_account_can_view_billing_but_not_self_activate(monkeypa
         subscription_status="PENDING",
         payment_status="PENDING",
         payment_reference="LT-US-ABC123",
-        payment_provider="WISE",
+        payment_provider="MANUAL_BANK_TRANSFER",
     )
     monkeypatch.setattr(
         "litoral_trace.web.us_lacey_pilot_app.resolve_us_lacey_session",
@@ -281,7 +281,7 @@ def test_pilot_billing_and_operations_render_canonical_action_contracts(monkeypa
         subscription_status="PILOT",
         payment_status="WAIVED",
         payment_reference="LT-US-PILOT",
-        payment_provider="WISE",
+        payment_provider="MANUAL_BANK_TRANSFER",
     )
     detail = SimpleNamespace(
         public_id="OP-DEMO",

--- a/tests/test_us_lacey_portal_http_postgres_e2e.py
+++ b/tests/test_us_lacey_portal_http_postgres_e2e.py
@@ -26,8 +26,8 @@ def _configure_customer_portal(monkeypatch: pytest.MonkeyPatch) -> None:
         "US_LACEY_SESSION_TTL_HOURS": "1",
         "US_LACEY_PRIVATE_BETA_PRICE_CENTS": "12500",
         "US_LACEY_MONTHLY_OPERATION_LIMIT": "25",
-        "US_LACEY_PAYMENT_PROVIDER": "WISE",
-        "US_LACEY_BANK_TRANSFER_INSTRUCTIONS": "CI-only Wise USD transfer instructions",
+        "US_LACEY_PAYMENT_PROVIDER": "MANUAL_BANK_TRANSFER",
+        "US_LACEY_BANK_TRANSFER_INSTRUCTIONS": "CI-only manual USD transfer instructions",
         "US_LACEY_TERMS_VERSION": "terms-http-e2e-v1",
         "US_LACEY_PRIVACY_VERSION": "privacy-http-e2e-v1",
         "US_LACEY_BETA_TERMS_VERSION": "beta-http-e2e-v1",
@@ -131,7 +131,7 @@ def test_signup_verify_login_billing_logout_real_http_and_postgres(
         assert "How to complete the payment" in billing.text
         assert "Payment matching code" in billing.text
         assert "bank account, payment link or destination address" in billing.text
-        assert "CI-only Wise USD transfer instructions" in billing.text
+        assert "CI-only manual USD transfer instructions" in billing.text
         assert "Document processing unlocks only after Litoral Trace verifies the payment server-side" in billing.text
         assert "verify-payment" not in billing.text.lower()
 

--- a/tests/test_us_lacey_portal_postgres_integration.py
+++ b/tests/test_us_lacey_portal_postgres_integration.py
@@ -34,7 +34,7 @@ def _commercial_config() -> UsLaceyCommercialConfig:
     return UsLaceyCommercialConfig(
         price_cents=12500,
         monthly_operation_limit=25,
-        payment_provider="WISE",
+        payment_provider="MANUAL_BANK_TRANSFER",
         bank_transfer_instructions="CI-only payment instructions",
         terms_version="terms-ci-v1",
         privacy_version="privacy-ci-v1",

--- a/tests/test_us_lacey_portal_postgres_integration.py
+++ b/tests/test_us_lacey_portal_postgres_integration.py
@@ -16,6 +16,7 @@ from litoral_trace.us_lacey.portal_auth import (
     resolve_us_lacey_session,
 )
 from litoral_trace.us_lacey.self_service import (
+    UsLaceySelfServiceError,
     get_us_lacey_billing_summary,
     register_us_lacey_company,
     verify_us_lacey_email,
@@ -41,6 +42,36 @@ def _commercial_config() -> UsLaceyCommercialConfig:
         beta_terms_version="beta-ci-v1",
         support_email="support@litoraltrace.com",
     )
+
+
+def test_043_postgres_registration_rejects_wise_fail_closed():
+    """Prove the database front door rejects WISE even if Python is bypassed."""
+    reset_us_lacey_engine_state()
+    suffix = uuid4().hex[:12]
+    wise_config = UsLaceyCommercialConfig(
+        price_cents=12500,
+        monthly_operation_limit=25,
+        payment_provider="WISE",
+        bank_transfer_instructions="must never be used",
+        terms_version="terms-ci-v1",
+        privacy_version="privacy-ci-v1",
+        beta_terms_version="beta-ci-v1",
+        support_email="support@litoraltrace.com",
+    )
+
+    with pytest.raises(UsLaceySelfServiceError, match="Unable to create") as rejected:
+        register_us_lacey_company(
+            legal_name=f"Rejected Wise Signup {suffix} LLC",
+            business_type="IMPORTER",
+            admin_name="Rejected Wise Admin",
+            admin_email=f"wise-rejected-{suffix}@example.com",
+            password="correct-horse-wise-rejected-123",
+            commercial_config=wise_config,
+        )
+
+    db_error = rejected.value.__cause__
+    assert db_error is not None
+    assert getattr(getattr(db_error, "orig", None), "sqlstate", None) == "22023"
 
 
 def test_verified_customer_gets_isolated_opaque_session_and_billing():

--- a/tests/test_us_lacey_self_service_scale.py
+++ b/tests/test_us_lacey_self_service_scale.py
@@ -63,8 +63,8 @@ def _commercial_config() -> UsLaceyCommercialConfig:
     return UsLaceyCommercialConfig(
         price_cents=12500,
         monthly_operation_limit=25,
-        payment_provider="WISE",
-        bank_transfer_instructions="Configured outside source control",
+        payment_provider="LEMON_SQUEEZY",
+        bank_transfer_instructions="",
         terms_version="terms-2026-08",
         privacy_version="privacy-2026-08",
         beta_terms_version="beta-2026-08",
@@ -74,16 +74,15 @@ def _commercial_config() -> UsLaceyCommercialConfig:
 
 def test_commercial_config_fails_closed_without_price_or_legal_versions():
     with pytest.raises(UsLaceyCommercialConfigurationError):
-        load_us_lacey_commercial_config({"US_LACEY_PAYMENT_PROVIDER": "WISE"})
+        load_us_lacey_commercial_config({"US_LACEY_PAYMENT_PROVIDER": "LEMON_SQUEEZY"})
 
 
 def test_commercial_config_accepts_explicit_launch_values():
     config = load_us_lacey_commercial_config(
         {
-            "US_LACEY_PAYMENT_PROVIDER": "WISE",
+            "US_LACEY_PAYMENT_PROVIDER": "LEMON_SQUEEZY",
             "US_LACEY_PRIVATE_BETA_PRICE_CENTS": "12500",
             "US_LACEY_MONTHLY_OPERATION_LIMIT": "25",
-            "US_LACEY_BANK_TRANSFER_INSTRUCTIONS": "Configured at deploy time",
             "US_LACEY_TERMS_VERSION": "terms-v1",
             "US_LACEY_PRIVACY_VERSION": "privacy-v1",
             "US_LACEY_BETA_TERMS_VERSION": "beta-v1",
@@ -91,7 +90,8 @@ def test_commercial_config_accepts_explicit_launch_values():
     )
     assert config.price_cents == 12500
     assert config.monthly_operation_limit == 25
-    assert config.payment_provider == "WISE"
+    assert config.payment_provider == "LEMON_SQUEEZY"
+    assert config.bank_transfer_instructions == ""
 
 
 def test_registration_never_persists_raw_verification_token(monkeypatch):

--- a/tests/test_us_lacey_worker_postgres_integration.py
+++ b/tests/test_us_lacey_worker_postgres_integration.py
@@ -98,7 +98,7 @@ def _commercial_config() -> UsLaceyCommercialConfig:
     return UsLaceyCommercialConfig(
         price_cents=12500,
         monthly_operation_limit=25,
-        payment_provider="WISE",
+        payment_provider="MANUAL_BANK_TRANSFER",
         bank_transfer_instructions="CI-only payment instructions",
         terms_version="terms-worker-v1",
         privacy_version="privacy-worker-v1",


### PR DESCRIPTION
## Summary

Wise Business is not an available payment path for this deployment and must not be used for new U.S. Lacey accounts.

This change adds a fail-closed 043 guard after the merged 042 Owner/Admin Console:

- new self-service registration accepts only `MANUAL_BANK_TRANSFER` or `LEMON_SQUEEZY`;
- `WISE` is rejected by the runtime commercial configuration;
- the certified 041 registrar is preserved behind a private implementation and wrapped by the 043 provider guard;
- historical `WISE` values remain readable in the payment schema for audit/backward readability, but cannot be selected for new signup;
- PostgreSQL/HTTP/worker test fixtures that previously used Wise now exercise the manual fallback instead;
- the canonical Alembic head is advanced to `043_042_us_lacey_owner_admin`.

## Gates

Do not merge unless the final SHA passes the general CI and U.S. Lacey PostgreSQL gate. Lemon activation, RLS, Owner/Admin 042, portal, workers, ACTIVE E2E and A/B tenant isolation must remain green.