### PR TITLE
feat(lacey): add Gate 2 shipment intelligence

### DIFF
--- a/src/litoral_trace/lacey_engine/__init__.py
+++ b/src/litoral_trace/lacey_engine/__init__.py
@@ -2,5 +2,6 @@
 
 from .domain import DocumentResolution, EvidenceClass, FieldStatus
 from .pipeline import process_document
+from .shipment import ShipmentDocumentInput, ShipmentResolution, process_shipment
 
-__all__ = ("DocumentResolution", "EvidenceClass", "FieldStatus", "process_document")
+__all__ = ("DocumentResolution", "EvidenceClass", "FieldStatus", "ShipmentDocumentInput", "ShipmentResolution", "process_document", "process_shipment")

--- a/src/litoral_trace/lacey_engine/admission.py
+++ b/src/litoral_trace/lacey_engine/admission.py
@@ -18,7 +18,7 @@ def admit(raw: RawCandidate) -> bool:
         # nearby table headings such as "Voyage" into the candidate pool.
         return (
             raw.label is not None
-            and bool(re.fullmatch(r"(?:master\s+(?:bol|b/l)(?:\s*#)?|house\s+bol(?:\s*#)?|bill of lading|b/l\s*no\.?|bol)", raw.label, re.I))
+            and bool(re.fullmatch(r"(?:master\s+(?:bill of lading|bol|b/l)(?:\s*#)?|house\s+(?:bill of lading|bol|b/l)(?:\s*#)?|bill of lading|b/l\s*no\.?|bol)", raw.label, re.I))
             and bool(re.fullmatch(r"[A-Z0-9][A-Z0-9-]{5,34}", value, re.I))
             and any(character.isdigit() for character in value)
         )

--- a/src/litoral_trace/lacey_engine/pipeline.py
+++ b/src/litoral_trace/lacey_engine/pipeline.py
@@ -57,8 +57,8 @@ def _extract(layout):
             date = _normalized_date(match.group(1))
             if date:
                 found["estimated_arrival_date"].append(_candidate("estimated_arrival_date", date, block, "Estimated Arrival Date"))
-        for match in re.finditer(r"(?:Master\s+(?:BOL|B/L)(?:\s*#)?|House\s+BOL|Bill of Lading|B/L\s*No\.?|\bBOL)\s*[:#-]?\s*([A-Z0-9-]{6,})", text, re.I):
-            found["bill_of_lading"].append(_candidate("bill_of_lading", match.group(1).upper(), block, "Bill of Lading"))
+        for match in re.finditer(r"(?P<label>Master\s+(?:BOL|B/L)(?:\s*#)?|House\s+(?:BOL|B/L)(?:\s*#)?|Bill of Lading|B/L\s*No\.?|\bBOL)\s*[:#-]?\s*(?P<value>[A-Z0-9-]{6,})", text, re.I):
+            found["bill_of_lading"].append(_candidate("bill_of_lading", match.group("value").upper(), block, match.group("label")))
         for match in re.finditer(r"\bContainer(?:\s+(?:Number|No\.?)?)?\s*[:#-]?\s*([A-Z]{4}\d{7})\b", text, re.I):
             found["container_number"].append(_candidate("container_number", match.group(1).upper(), block, "Container Number"))
         for match in re.finditer(r"\bConsignee(?:\s+Name)?\s*[:#-]?\s*([A-Z][A-Z &.'-]{3,80})", text):

--- a/src/litoral_trace/lacey_engine/pipeline.py
+++ b/src/litoral_trace/lacey_engine/pipeline.py
@@ -57,7 +57,7 @@ def _extract(layout):
             date = _normalized_date(match.group(1))
             if date:
                 found["estimated_arrival_date"].append(_candidate("estimated_arrival_date", date, block, "Estimated Arrival Date"))
-        for match in re.finditer(r"(?P<label>Master\s+(?:BOL|B/L)(?:\s*#)?|House\s+(?:BOL|B/L)(?:\s*#)?|Bill of Lading|B/L\s*No\.?|\bBOL)\s*[:#-]?\s*(?P<value>[A-Z0-9-]{6,})", text, re.I):
+        for match in re.finditer(r"(?P<label>Master\s+(?:Bill of Lading|BOL|B/L)(?:\s*#)?|House\s+(?:Bill of Lading|BOL|B/L)(?:\s*#)?|Bill of Lading|B/L\s*No\.?|\bBOL)\s*[:#-]?\s*(?P<value>[A-Z0-9-]{6,})", text, re.I):
             found["bill_of_lading"].append(_candidate("bill_of_lading", match.group("value").upper(), block, match.group("label")))
         for match in re.finditer(r"\bContainer(?:\s+(?:Number|No\.?)?)?\s*[:#-]?\s*([A-Z]{4}\d{7})\b", text, re.I):
             found["container_number"].append(_candidate("container_number", match.group(1).upper(), block, "Container Number"))

--- a/src/litoral_trace/lacey_engine/shipment.py
+++ b/src/litoral_trace/lacey_engine/shipment.py
@@ -1,27 +1,43 @@
 """Pure, deterministic shipment-level evidence reconciliation for Gate 2."""
 from __future__ import annotations
 
-from dataclasses import dataclass, field
+from dataclasses import dataclass
+from decimal import Decimal, InvalidOperation
 from enum import Enum
 import re
 
 from .domain import AdmittedCandidate, DocumentResolution, EvidenceClass, FieldStatus
 from .pipeline import ENGINE_VERSION, process_document
+from .source_authority import authority
 
 
 class ReconciliationState(str, Enum):
-    SUPPORTED = "SUPPORTED"
-    SUPPORTED_MULTIPLE = "SUPPORTED_MULTIPLE"
-    NEAR_MATCH = "NEAR_MATCH"
-    CONFLICT = "CONFLICT"
-    MISSING = "MISSING"
-    REVIEW_REQUIRED = "REVIEW_REQUIRED"
+    SUPPORTED = "SUPPORTED"; SUPPORTED_MULTIPLE = "SUPPORTED_MULTIPLE"; NEAR_MATCH = "NEAR_MATCH"
+    CONFLICT = "CONFLICT"; MISSING = "MISSING"; REVIEW_REQUIRED = "REVIEW_REQUIRED"
 
 
 class ShipmentReadiness(str, Enum):
-    READY = "READY"
-    REVIEW_REQUIRED = "REVIEW_REQUIRED"
-    BLOCKED = "BLOCKED"
+    READY = "READY"; REVIEW_REQUIRED = "REVIEW_REQUIRED"; BLOCKED = "BLOCKED"
+
+
+class FieldCardinality(str, Enum):
+    SCALAR = "SCALAR"; SET = "SET"; PER_MERCHANDISE_LINE = "PER_MERCHANDISE_LINE"; PER_PLANT_COMPONENT = "PER_PLANT_COMPONENT"
+
+
+class PartyRole(str, Enum):
+    IMPORTER = "IMPORTER"; CONSIGNEE = "CONSIGNEE"; SHIPPER = "SHIPPER"; SUPPLIER = "SUPPLIER"; MANUFACTURER = "MANUFACTURER"; NOTIFY_PARTY = "NOTIFY_PARTY"
+
+
+class EvidenceScope(str, Enum):
+    SHIPMENT = "SHIPMENT"; MERCHANDISE_LINE = "MERCHANDISE_LINE"; PLANT_COMPONENT = "PLANT_COMPONENT"
+
+
+class AssociationState(str, Enum):
+    ASSOCIATED = "ASSOCIATED"; UNASSOCIATED = "UNASSOCIATED"; AMBIGUOUS = "AMBIGUOUS"
+
+
+class QuantitySemanticType(str, Enum):
+    PLANT_MATERIAL_QUANTITY = "PLANT_MATERIAL_QUANTITY"; GROSS_WEIGHT = "GROSS_WEIGHT"; NET_WEIGHT = "NET_WEIGHT"; PACKAGE_COUNT = "PACKAGE_COUNT"; PIECE_COUNT = "PIECE_COUNT"; VOLUME = "VOLUME"; OTHER = "OTHER"
 
 
 @dataclass(frozen=True, slots=True)
@@ -34,13 +50,29 @@ class ShipmentDocumentInput:
 
 
 @dataclass(frozen=True, slots=True)
+class ShipmentDocumentResolution:
+    document_id: str
+    filename: str
+    resolution: DocumentResolution
+
+
+@dataclass(frozen=True, slots=True)
 class ShipmentEvidence:
     candidate_id: str
     document_id: str
     field_key: str
     normalized_value: str
     candidate: AdmittedCandidate
-    authority: float
+    candidate_score: float
+    source_authority: float
+    scope: EvidenceScope = EvidenceScope.SHIPMENT
+    line_key: str | None = None
+    component_key: str | None = None
+
+    @property
+    def authority(self) -> float:
+        """Compatibility alias; reconciliation uses source_authority explicitly."""
+        return self.source_authority
 
 
 @dataclass(frozen=True, slots=True)
@@ -68,73 +100,190 @@ class ShipmentIssue:
     candidate_ids: tuple[str, ...]
     document_ids: tuple[str, ...]
     requires_human_review: bool = True
+    line_key: str | None = None
+    component_key: str | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class ShipmentPreparationContext:
+    required_fields: tuple[str, ...] = ("bill_of_lading",)
+
+
+@dataclass(frozen=True, slots=True)
+class LaceyRuleset:
+    version: str = "lacey_ruleset_2026_01"
+    preparation: ShipmentPreparationContext = ShipmentPreparationContext()
 
 
 @dataclass(frozen=True, slots=True)
 class ShipmentResolution:
     engine_version: str
-    documents: tuple[DocumentResolution, ...]
+    documents: tuple[ShipmentDocumentResolution, ...]
     canonical_fields: dict[str, ReconciliationResult]
     issues: tuple[ShipmentIssue, ...]
     readiness: ShipmentReadiness
     metrics: dict[str, int]
+    ruleset_version: str = "lacey_ruleset_2026_01"
 
 
-_SET_FIELDS = frozenset({"container_number", "species", "genus", "country_of_harvest"})
-_CRITICAL = frozenset({"bill_of_lading", "container_number", "species", "country_of_harvest"})
+def normalize_mass(value: str, unit: str) -> Decimal | None:
+    """Normalize explicitly compatible mass evidence to kilograms without floats."""
+    try:
+        amount = Decimal(value.replace(",", ""))
+    except (InvalidOperation, AttributeError):
+        return None
+    factor = {"g": Decimal(".001"), "kg": Decimal(1), "metric ton": Decimal(1000), "metric tons": Decimal(1000), "tonne": Decimal(1000), "tonnes": Decimal(1000), "lb": Decimal(".45359237")}.get(unit.strip().casefold())
+    return amount * factor if factor is not None else None
+
+
+def normalize_money(value: str) -> tuple[str | None, Decimal | None]:
+    match = re.fullmatch(r"\s*(USD|EUR|CAD|GBP|AUD|JPY)\s*([0-9][0-9,]*(?:\.[0-9]+)?)\s*", value.upper())
+    if not match:
+        return None, None
+    try:
+        return match.group(1), Decimal(match.group(2).replace(",", ""))
+    except InvalidOperation:
+        return None, None
+
+
+def normalize_quantity(value: str) -> Decimal | None:
+    """Return kilograms for an explicitly stated mass quantity, or None."""
+    match = re.fullmatch(r"\s*([0-9][0-9,]*(?:\.[0-9]+)?)\s*(g|kg|lb|metric tons?|tonnes?)\s*", value, re.I)
+    return normalize_mass(match.group(1), match.group(2)) if match else None
+
+
+_CATALOG = {key: FieldCardinality.SCALAR for key in (
+    "estimated_arrival_date", "master_bill_of_lading", "house_bill_of_lading", "bill_of_lading",
+    "importer_name", "importer_address", "consignee_name", "consignee_address", "manufacturer_id",
+    "filing_entry_reference", "currency", "percent_recycled", "notify_party_name", "shipper_name",
+    "supplier_name", "manufacturer_name")}
+_CATALOG.update({"container_number": FieldCardinality.SET, "country_of_origin": FieldCardinality.SET,
+    "genus": FieldCardinality.PER_PLANT_COMPONENT, "species": FieldCardinality.PER_PLANT_COMPONENT,
+    "country_of_harvest": FieldCardinality.PER_PLANT_COMPONENT, "plant_quantity": FieldCardinality.PER_PLANT_COMPONENT,
+    "metric_unit": FieldCardinality.PER_PLANT_COMPONENT})
+for _key in ("hts_code", "description", "entered_value", "article_component"):
+    _CATALOG[_key] = FieldCardinality.PER_MERCHANDISE_LINE
+_PARTY_KEYS = {"importer_name", "consignee_name", "shipper_name", "supplier_name", "manufacturer_name", "notify_party_name"}
+_IMPORTANT = frozenset({"bill_of_lading", "master_bill_of_lading", "house_bill_of_lading", "country_of_harvest", "species", "genus"})
 
 
 def _normal(field_key: str, value: str) -> str:
-    value = " ".join(value.upper().split())
-    if field_key in {"consignee_name", "importer_name"}:
-        return re.sub(r"\b(?:LLC|INC|LTD)\b", "", re.sub(r"[^A-Z0-9 ]", "", value)).strip()
-    if field_key == "hts_code": return re.sub(r"\D", "", value)
-    return value
+    text = " ".join(value.upper().split())
+    if field_key in _PARTY_KEYS:
+        return re.sub(r"\b(?:LLC|INC|LTD)\b", "", re.sub(r"[^A-Z0-9 ]", "", text)).strip()
+    if field_key == "hts_code":
+        return re.sub(r"\D", "", text)
+    if field_key == "entered_value":
+        currency, amount = normalize_money(text)
+        return f"{currency} {amount}" if currency and amount is not None else text
+    if field_key == "plant_quantity":
+        quantity = normalize_quantity(text)
+        return f"{quantity} KG" if quantity is not None else text
+    return text
+
+
+def _scope(cardinality: FieldCardinality) -> EvidenceScope:
+    return EvidenceScope.PLANT_COMPONENT if cardinality is FieldCardinality.PER_PLANT_COMPONENT else (EvidenceScope.MERCHANDISE_LINE if cardinality is FieldCardinality.PER_MERCHANDISE_LINE else EvidenceScope.SHIPMENT)
+
+
+def _association(label: str, scope: EvidenceScope) -> tuple[str | None, str | None]:
+    match = re.search(r"(?:component|line)\s*(?:#|number)?\s*([a-z0-9-]+)", label.casefold())
+    if not match:
+        return None, None
+    return (match.group(1), None) if scope is EvidenceScope.PLANT_COMPONENT else (None, match.group(1))
 
 
 def _reconcile(field_key: str, evidence: list[ShipmentEvidence]) -> ReconciliationResult:
     if not evidence:
         return ReconciliationResult(field_key, ReconciliationState.MISSING, (), ())
     groups: dict[str, list[ShipmentEvidence]] = {}
-    for item in evidence: groups.setdefault(_normal(field_key, item.normalized_value), []).append(item)
-    values = tuple(CanonicalFieldCandidate(key, tuple(item.candidate_id for item in group)) for key, group in groups.items())
-    if field_key == "species" and len(groups) > 1:
-        # Without a reliable merchandise-line association, contradictory taxa
-        # cannot be safely treated as independent plant components.
-        state = ReconciliationState.CONFLICT
-    elif field_key in _SET_FIELDS:
-        state = ReconciliationState.SUPPORTED_MULTIPLE if len(evidence) > 1 else ReconciliationState.SUPPORTED
-    elif len(groups) == 1:
-        state = ReconciliationState.SUPPORTED_MULTIPLE if len(evidence) > 1 else ReconciliationState.SUPPORTED
-    else:
-        # Cosmetic party suffixes normalize together; remaining scalar facts are reviewable conflicts.
-        state = ReconciliationState.CONFLICT
+    for item in evidence:
+        groups.setdefault(_normal(field_key, item.normalized_value), []).append(item)
+    values = tuple(CanonicalFieldCandidate(value, tuple(item.candidate_id for item in items)) for value, items in groups.items())
+    cardinality = _CATALOG[field_key]
+    if cardinality is FieldCardinality.SET:
+        return ReconciliationResult(field_key, ReconciliationState.SUPPORTED_MULTIPLE if len(evidence) > 1 else ReconciliationState.SUPPORTED, values, tuple(evidence))
+    if len(groups) == 1:
+        raw_values = {item.normalized_value for item in evidence}
+        state = ReconciliationState.NEAR_MATCH if field_key in _PARTY_KEYS and len(raw_values) > 1 else (ReconciliationState.SUPPORTED_MULTIPLE if len(evidence) > 1 else ReconciliationState.SUPPORTED)
+        return ReconciliationResult(field_key, state, values, tuple(evidence))
+    if cardinality is FieldCardinality.PER_PLANT_COMPONENT:
+        keys = {item.component_key for item in evidence}
+        state = ReconciliationState.SUPPORTED_MULTIPLE if None not in keys and len(keys) == len(evidence) else (ReconciliationState.CONFLICT if len(keys) == 1 and None not in keys else ReconciliationState.REVIEW_REQUIRED)
+        return ReconciliationResult(field_key, state, values, tuple(evidence))
+    # A material authority gap is a reviewable discrepancy, unlike equal authority facts.
+    strengths = {item.source_authority for item in evidence}
+    state = ReconciliationState.REVIEW_REQUIRED if len(strengths) > 1 else ReconciliationState.CONFLICT
     return ReconciliationResult(field_key, state, values, tuple(evidence))
 
 
-def process_shipment(*, documents: list[ShipmentDocumentInput]) -> ShipmentResolution:
-    """Combine independently processed documents without any infrastructure dependency."""
-    resolved: list[DocumentResolution] = []
+def _typed_key(field_key: str, label: str) -> str:
+    if field_key in {"party", "party_name", "name"}:
+        label = label.casefold()
+        for role, key in (("importer", "importer_name"), ("consignee", "consignee_name"), ("shipper", "shipper_name"), ("supplier", "supplier_name"), ("manufacturer", "manufacturer_name"), ("notify", "notify_party_name")):
+            if role in label:
+                return key
+    if field_key != "bill_of_lading":
+        return field_key
+    label = label.casefold()
+    if "master" in label and any(token in label for token in ("b/l", "bol", "bill of lading")):
+        return "master_bill_of_lading"
+    if "house" in label and any(token in label for token in ("b/l", "bol", "bill of lading")):
+        return "house_bill_of_lading"
+    return field_key
+
+
+def process_shipment(*, documents: list[ShipmentDocumentInput], ruleset: LaceyRuleset = LaceyRuleset()) -> ShipmentResolution:
+    """Reconcile admissible explicit document evidence without external dependencies."""
+    identifiers = [item.document_id for item in documents]
+    if len(identifiers) != len(set(identifiers)):
+        raise ValueError("Shipment document_id values must be unique.")
+    resolved: list[ShipmentDocumentResolution] = []
     evidence_by_field: dict[str, list[ShipmentEvidence]] = {}
+    inferred_not_used = 0
+    unresolved_roles: list[tuple[str, AdmittedCandidate]] = []
     for item in documents:
+        if item.resolution is None and not item.content:
+            raise ValueError("ShipmentDocumentInput requires resolution or non-empty content.")
         resolution = item.resolution or process_document(filename=item.filename, content=item.content or b"", role_hint=item.role_hint)
-        resolved.append(resolution)
-        for field_key, field in resolution.fields.items():
-            if field.status is not FieldStatus.MATCHED or field.winning_candidate is None:
-                continue
-            candidate = field.winning_candidate
-            if candidate.raw.evidence_class is EvidenceClass.INFERRED:
-                continue
-            evidence = ShipmentEvidence(f"{item.document_id}:{field_key}:{candidate.provenance.block_id}", item.document_id, field_key, field.effective_value or "", candidate, candidate.score)
-            evidence_by_field.setdefault(field_key, []).append(evidence)
-    fields = {key: _reconcile(key, values) for key, values in evidence_by_field.items()}
-    for key in _CRITICAL: fields.setdefault(key, _reconcile(key, []))
+        resolved.append(ShipmentDocumentResolution(item.document_id, item.filename, resolution))
+        for original_key, field in resolution.fields.items():
+            candidates = field.candidates if field.status is FieldStatus.CONFLICT else ((field.winning_candidate,) if field.status is FieldStatus.MATCHED and field.winning_candidate else ())
+            for index, candidate in enumerate(candidates):
+                if candidate.raw.evidence_class is EvidenceClass.INFERRED:
+                    inferred_not_used += 1
+                    continue
+                field_key = _typed_key(original_key, candidate.raw.label or "")
+                if original_key in {"party", "party_name", "name"} and field_key == original_key:
+                    unresolved_roles.append((item.document_id, candidate))
+                    continue
+                if field_key not in _CATALOG:
+                    continue
+                scope = _scope(_CATALOG[field_key])
+                component_key, line_key = _association(candidate.raw.label or "", scope)
+                authority_key = "bill_of_lading" if field_key in {"master_bill_of_lading", "house_bill_of_lading"} else field_key
+                record = ShipmentEvidence(f"{item.document_id}:{field_key}:{candidate.provenance.block_id}:{index}", item.document_id, field_key, candidate.raw.normalized_value, candidate, candidate.score, authority(authority_key, candidate.document_type), scope, line_key, component_key)
+                evidence_by_field.setdefault(field_key, []).append(record)
+    fields = {key: _reconcile(key, evidence_by_field.get(key, [])) for key in _CATALOG}
     issues: list[ShipmentIssue] = []
+    for document_id, candidate in unresolved_roles:
+        issues.append(ShipmentIssue(f"unresolved-role:{document_id}:{candidate.provenance.block_id}", "party_name", EvidenceScope.SHIPMENT.value, "MEDIUM", "UNRESOLVED_ROLE", "Party evidence has no explicit supported role.", (f"{document_id}:party:{candidate.provenance.block_id}",), (document_id,)))
     for key, result in fields.items():
+        evidence = result.supporting_evidence
+        ids, docs = tuple(item.candidate_id for item in evidence), tuple(sorted({item.document_id for item in evidence}))
         if result.state is ReconciliationState.CONFLICT:
-            issues.append(ShipmentIssue(f"conflict:{key}", key, "shipment", "HIGH", "CONFLICT", f"Conflicting admissible {key} evidence.", tuple(item.candidate_id for item in result.supporting_evidence), tuple(sorted({item.document_id for item in result.supporting_evidence}))))
-        elif key in _CRITICAL and result.state is ReconciliationState.MISSING:
-            issues.append(ShipmentIssue(f"missing:{key}", key, "shipment", "HIGH", "MISSING_REQUIRED", f"Required baseline evidence missing for {key}.", (), ()))
-    readiness = ShipmentReadiness.BLOCKED if any(issue.severity == "HIGH" for issue in issues) else ShipmentReadiness.READY
-    metrics = {"documents_processed": len(resolved), "fields_supported": sum(result.state in {ReconciliationState.SUPPORTED, ReconciliationState.SUPPORTED_MULTIPLE} for result in fields.values()), "fields_conflicting": sum(result.state is ReconciliationState.CONFLICT for result in fields.values()), "fields_missing": sum(result.state is ReconciliationState.MISSING for result in fields.values()), "fields_review_required": 0, "rejected_candidates": 0, "inferred_candidates_not_used": 0}
-    return ShipmentResolution(ENGINE_VERSION, tuple(resolved), fields, tuple(issues), readiness, metrics)
+            issues.append(ShipmentIssue(f"conflict:{key}", key, _scope(_CATALOG[key]).value, "HIGH", "CONFLICT", f"Conflicting admissible {key} evidence.", ids, docs))
+        elif result.state is ReconciliationState.REVIEW_REQUIRED:
+            kind = "AMBIGUOUS_ASSOCIATION" if _CATALOG[key] is FieldCardinality.PER_PLANT_COMPONENT else "INCONSISTENT_SET"
+            issues.append(ShipmentIssue(f"review:{key}", key, _scope(_CATALOG[key]).value, "MEDIUM", kind, f"{key} requires semantic review.", ids, docs))
+        if key in _IMPORTANT and evidence and max(item.source_authority for item in evidence) < 10:
+            issues.append(ShipmentIssue(f"low-authority:{key}", key, _scope(_CATALOG[key]).value, "MEDIUM", "LOW_AUTHORITY_ONLY", f"Only low-authority evidence is available for {key}.", ids, docs))
+            fields[key] = ReconciliationResult(key, ReconciliationState.REVIEW_REQUIRED, (), evidence)
+    for key in ruleset.preparation.required_fields:
+        if fields.get(key, ReconciliationResult(key, ReconciliationState.MISSING, (), ())).state is ReconciliationState.MISSING:
+            issues.append(ShipmentIssue(f"missing:{key}", key, EvidenceScope.SHIPMENT.value, "HIGH", "MISSING_REQUIRED", f"Required preparation evidence missing for {key}.", (), ()))
+    blocking = any(issue.severity == "HIGH" for issue in issues)
+    review = any(issue.severity == "MEDIUM" for issue in issues) or any(result.state in {ReconciliationState.NEAR_MATCH, ReconciliationState.REVIEW_REQUIRED} for result in fields.values())
+    readiness = ShipmentReadiness.BLOCKED if blocking else (ShipmentReadiness.REVIEW_REQUIRED if review else ShipmentReadiness.READY)
+    metrics = {"documents_processed": len(resolved), "fields_supported": sum(result.state in {ReconciliationState.SUPPORTED, ReconciliationState.SUPPORTED_MULTIPLE, ReconciliationState.NEAR_MATCH} for result in fields.values()), "fields_conflicting": sum(result.state is ReconciliationState.CONFLICT for result in fields.values()), "fields_missing": sum(result.state is ReconciliationState.MISSING for result in fields.values()), "fields_review_required": sum(result.state is ReconciliationState.REVIEW_REQUIRED for result in fields.values()), "inferred_candidates_not_used": inferred_not_used, "issues_total": len(issues)}
+    return ShipmentResolution(ENGINE_VERSION, tuple(resolved), fields, tuple(issues), readiness, metrics, ruleset.version)

--- a/src/litoral_trace/lacey_engine/shipment.py
+++ b/src/litoral_trace/lacey_engine/shipment.py
@@ -106,8 +106,17 @@ class ShipmentIssue:
 
 
 @dataclass(frozen=True, slots=True)
+class PreparationRequirement:
+    """A preparation requirement satisfied by any acceptable canonical field."""
+    requirement_id: str
+    acceptable_fields: tuple[str, ...]
+
+
+@dataclass(frozen=True, slots=True)
 class ShipmentPreparationContext:
-    required_fields: tuple[str, ...] = ("bill_of_lading",)
+    requirements: tuple[PreparationRequirement, ...] = (
+        PreparationRequirement("BILL_OF_LADING_PRESENT", ("master_bill_of_lading", "bill_of_lading", "house_bill_of_lading")),
+    )
 
 
 @dataclass(frozen=True, slots=True)
@@ -316,9 +325,10 @@ def process_shipment(*, documents: list[ShipmentDocumentInput], ruleset: LaceyRu
         if key in _IMPORTANT and evidence and max(item.source_authority for item in evidence) < 10:
             issues.append(ShipmentIssue(f"low-authority:{key}", key, _scope(_CATALOG[key]).value, "MEDIUM", "LOW_AUTHORITY_ONLY", f"Only low-authority evidence is available for {key}.", ids, docs))
             fields[key] = ReconciliationResult(key, ReconciliationState.REVIEW_REQUIRED, (), evidence)
-    for key in ruleset.preparation.required_fields:
-        if fields.get(key, ReconciliationResult(key, ReconciliationState.MISSING, (), ())).state is ReconciliationState.MISSING:
-            issues.append(ShipmentIssue(f"missing:{key}", key, EvidenceScope.SHIPMENT.value, "HIGH", "MISSING_REQUIRED", f"Required preparation evidence missing for {key}.", (), ()))
+    for requirement in ruleset.preparation.requirements:
+        acceptable = [fields[key] for key in requirement.acceptable_fields]
+        if not any(result.state is not ReconciliationState.MISSING for result in acceptable):
+            issues.append(ShipmentIssue(f"missing:{requirement.requirement_id}", "bill_of_lading", EvidenceScope.SHIPMENT.value, "HIGH", "MISSING_REQUIRED", f"Required preparation evidence missing for {requirement.requirement_id}.", (), ()))
     blocking = any(issue.severity == "HIGH" for issue in issues)
     review = any(issue.severity == "MEDIUM" for issue in issues) or any(result.state in {ReconciliationState.NEAR_MATCH, ReconciliationState.REVIEW_REQUIRED} for result in fields.values())
     readiness = ShipmentReadiness.BLOCKED if blocking else (ShipmentReadiness.REVIEW_REQUIRED if review else ShipmentReadiness.READY)

--- a/src/litoral_trace/lacey_engine/shipment.py
+++ b/src/litoral_trace/lacey_engine/shipment.py
@@ -68,6 +68,7 @@ class ShipmentEvidence:
     scope: EvidenceScope = EvidenceScope.SHIPMENT
     line_key: str | None = None
     component_key: str | None = None
+    quantity_semantic_type: QuantitySemanticType = QuantitySemanticType.OTHER
 
     @property
     def authority(self) -> float:
@@ -141,7 +142,7 @@ def normalize_money(value: str) -> tuple[str | None, Decimal | None]:
     if not match:
         return None, None
     try:
-        return match.group(1), Decimal(match.group(2).replace(",", ""))
+        return match.group(1), Decimal(match.group(2).replace(",", "")).normalize()
     except InvalidOperation:
         return None, None
 
@@ -175,10 +176,10 @@ def _normal(field_key: str, value: str) -> str:
         return re.sub(r"\D", "", text)
     if field_key == "entered_value":
         currency, amount = normalize_money(text)
-        return f"{currency} {amount}" if currency and amount is not None else text
+        return f"{currency} {amount.normalize()}" if currency and amount is not None else text
     if field_key == "plant_quantity":
         quantity = normalize_quantity(text)
-        return f"{quantity} KG" if quantity is not None else text
+        return f"{quantity.normalize()} KG" if quantity is not None else text
     return text
 
 
@@ -193,6 +194,25 @@ def _association(label: str, scope: EvidenceScope) -> tuple[str | None, str | No
     return (match.group(1), None) if scope is EvidenceScope.PLANT_COMPONENT else (None, match.group(1))
 
 
+def _quantity_semantic_type(label: str) -> QuantitySemanticType:
+    label = label.casefold()
+    for phrase, semantic in (("plant material", QuantitySemanticType.PLANT_MATERIAL_QUANTITY), ("gross weight", QuantitySemanticType.GROSS_WEIGHT), ("net weight", QuantitySemanticType.NET_WEIGHT), ("package", QuantitySemanticType.PACKAGE_COUNT), ("piece", QuantitySemanticType.PIECE_COUNT), ("volume", QuantitySemanticType.VOLUME)):
+        if phrase in label:
+            return semantic
+    return QuantitySemanticType.OTHER
+
+
+def _atomic_state(field_key: str, evidence: list[ShipmentEvidence]) -> ReconciliationState:
+    groups = {_normal(field_key, item.normalized_value) for item in evidence}
+    if len(groups) == 1:
+        return ReconciliationState.SUPPORTED_MULTIPLE if len(evidence) > 1 else ReconciliationState.SUPPORTED
+    if field_key == "entered_value":
+        currencies = {normalize_money(item.normalized_value)[0] for item in evidence}
+        if len(currencies) > 1:
+            return ReconciliationState.REVIEW_REQUIRED
+    return ReconciliationState.REVIEW_REQUIRED if len({item.source_authority for item in evidence}) > 1 else ReconciliationState.CONFLICT
+
+
 def _reconcile(field_key: str, evidence: list[ShipmentEvidence]) -> ReconciliationResult:
     if not evidence:
         return ReconciliationResult(field_key, ReconciliationState.MISSING, (), ())
@@ -203,13 +223,27 @@ def _reconcile(field_key: str, evidence: list[ShipmentEvidence]) -> Reconciliati
     cardinality = _CATALOG[field_key]
     if cardinality is FieldCardinality.SET:
         return ReconciliationResult(field_key, ReconciliationState.SUPPORTED_MULTIPLE if len(evidence) > 1 else ReconciliationState.SUPPORTED, values, tuple(evidence))
+    if cardinality in {FieldCardinality.PER_MERCHANDISE_LINE, FieldCardinality.PER_PLANT_COMPONENT}:
+        association_keys = [item.line_key if cardinality is FieldCardinality.PER_MERCHANDISE_LINE else item.component_key for item in evidence]
+        if None in association_keys:
+            state = ReconciliationState.REVIEW_REQUIRED if len(groups) > 1 else _atomic_state(field_key, evidence)
+            return ReconciliationResult(field_key, state, values, tuple(evidence))
+        partitions: dict[str, list[ShipmentEvidence]] = {}
+        for item, key in zip(evidence, association_keys):
+            partitions.setdefault(key or "", []).append(item)
+        states = [_atomic_state(field_key, items) for items in partitions.values()]
+        if ReconciliationState.CONFLICT in states:
+            state = ReconciliationState.CONFLICT
+        elif ReconciliationState.REVIEW_REQUIRED in states:
+            state = ReconciliationState.REVIEW_REQUIRED
+        elif len(partitions) > 1:
+            state = ReconciliationState.SUPPORTED_MULTIPLE
+        else:
+            state = states[0]
+        return ReconciliationResult(field_key, state, values, tuple(evidence))
     if len(groups) == 1:
         raw_values = {item.normalized_value for item in evidence}
         state = ReconciliationState.NEAR_MATCH if field_key in _PARTY_KEYS and len(raw_values) > 1 else (ReconciliationState.SUPPORTED_MULTIPLE if len(evidence) > 1 else ReconciliationState.SUPPORTED)
-        return ReconciliationResult(field_key, state, values, tuple(evidence))
-    if cardinality is FieldCardinality.PER_PLANT_COMPONENT:
-        keys = {item.component_key for item in evidence}
-        state = ReconciliationState.SUPPORTED_MULTIPLE if None not in keys and len(keys) == len(evidence) else (ReconciliationState.CONFLICT if len(keys) == 1 and None not in keys else ReconciliationState.REVIEW_REQUIRED)
         return ReconciliationResult(field_key, state, values, tuple(evidence))
     # A material authority gap is a reviewable discrepancy, unlike equal authority facts.
     strengths = {item.source_authority for item in evidence}
@@ -262,7 +296,10 @@ def process_shipment(*, documents: list[ShipmentDocumentInput], ruleset: LaceyRu
                 scope = _scope(_CATALOG[field_key])
                 component_key, line_key = _association(candidate.raw.label or "", scope)
                 authority_key = "bill_of_lading" if field_key in {"master_bill_of_lading", "house_bill_of_lading"} else field_key
-                record = ShipmentEvidence(f"{item.document_id}:{field_key}:{candidate.provenance.block_id}:{index}", item.document_id, field_key, candidate.raw.normalized_value, candidate, candidate.score, authority(authority_key, candidate.document_type), scope, line_key, component_key)
+                semantic = _quantity_semantic_type(candidate.raw.label or "")
+                if field_key == "plant_quantity" and semantic is not QuantitySemanticType.PLANT_MATERIAL_QUANTITY:
+                    continue
+                record = ShipmentEvidence(f"{item.document_id}:{field_key}:{candidate.provenance.block_id}:{index}", item.document_id, field_key, candidate.raw.normalized_value, candidate, candidate.score, authority(authority_key, candidate.document_type), scope, line_key, component_key, semantic)
                 evidence_by_field.setdefault(field_key, []).append(record)
     fields = {key: _reconcile(key, evidence_by_field.get(key, [])) for key in _CATALOG}
     issues: list[ShipmentIssue] = []

--- a/src/litoral_trace/lacey_engine/shipment.py
+++ b/src/litoral_trace/lacey_engine/shipment.py
@@ -1,0 +1,140 @@
+"""Pure, deterministic shipment-level evidence reconciliation for Gate 2."""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import Enum
+import re
+
+from .domain import AdmittedCandidate, DocumentResolution, EvidenceClass, FieldStatus
+from .pipeline import ENGINE_VERSION, process_document
+
+
+class ReconciliationState(str, Enum):
+    SUPPORTED = "SUPPORTED"
+    SUPPORTED_MULTIPLE = "SUPPORTED_MULTIPLE"
+    NEAR_MATCH = "NEAR_MATCH"
+    CONFLICT = "CONFLICT"
+    MISSING = "MISSING"
+    REVIEW_REQUIRED = "REVIEW_REQUIRED"
+
+
+class ShipmentReadiness(str, Enum):
+    READY = "READY"
+    REVIEW_REQUIRED = "REVIEW_REQUIRED"
+    BLOCKED = "BLOCKED"
+
+
+@dataclass(frozen=True, slots=True)
+class ShipmentDocumentInput:
+    document_id: str
+    filename: str
+    content: bytes | None = None
+    role_hint: str | None = None
+    resolution: DocumentResolution | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class ShipmentEvidence:
+    candidate_id: str
+    document_id: str
+    field_key: str
+    normalized_value: str
+    candidate: AdmittedCandidate
+    authority: float
+
+
+@dataclass(frozen=True, slots=True)
+class CanonicalFieldCandidate:
+    value: str
+    evidence_ids: tuple[str, ...]
+
+
+@dataclass(frozen=True, slots=True)
+class ReconciliationResult:
+    field_key: str
+    state: ReconciliationState
+    values: tuple[CanonicalFieldCandidate, ...]
+    supporting_evidence: tuple[ShipmentEvidence, ...]
+
+
+@dataclass(frozen=True, slots=True)
+class ShipmentIssue:
+    issue_id: str
+    field_key: str
+    scope: str
+    severity: str
+    issue_type: str
+    message: str
+    candidate_ids: tuple[str, ...]
+    document_ids: tuple[str, ...]
+    requires_human_review: bool = True
+
+
+@dataclass(frozen=True, slots=True)
+class ShipmentResolution:
+    engine_version: str
+    documents: tuple[DocumentResolution, ...]
+    canonical_fields: dict[str, ReconciliationResult]
+    issues: tuple[ShipmentIssue, ...]
+    readiness: ShipmentReadiness
+    metrics: dict[str, int]
+
+
+_SET_FIELDS = frozenset({"container_number", "species", "genus", "country_of_harvest"})
+_CRITICAL = frozenset({"bill_of_lading", "container_number", "species", "country_of_harvest"})
+
+
+def _normal(field_key: str, value: str) -> str:
+    value = " ".join(value.upper().split())
+    if field_key in {"consignee_name", "importer_name"}:
+        return re.sub(r"\b(?:LLC|INC|LTD)\b", "", re.sub(r"[^A-Z0-9 ]", "", value)).strip()
+    if field_key == "hts_code": return re.sub(r"\D", "", value)
+    return value
+
+
+def _reconcile(field_key: str, evidence: list[ShipmentEvidence]) -> ReconciliationResult:
+    if not evidence:
+        return ReconciliationResult(field_key, ReconciliationState.MISSING, (), ())
+    groups: dict[str, list[ShipmentEvidence]] = {}
+    for item in evidence: groups.setdefault(_normal(field_key, item.normalized_value), []).append(item)
+    values = tuple(CanonicalFieldCandidate(key, tuple(item.candidate_id for item in group)) for key, group in groups.items())
+    if field_key == "species" and len(groups) > 1:
+        # Without a reliable merchandise-line association, contradictory taxa
+        # cannot be safely treated as independent plant components.
+        state = ReconciliationState.CONFLICT
+    elif field_key in _SET_FIELDS:
+        state = ReconciliationState.SUPPORTED_MULTIPLE if len(evidence) > 1 else ReconciliationState.SUPPORTED
+    elif len(groups) == 1:
+        state = ReconciliationState.SUPPORTED_MULTIPLE if len(evidence) > 1 else ReconciliationState.SUPPORTED
+    else:
+        # Cosmetic party suffixes normalize together; remaining scalar facts are reviewable conflicts.
+        state = ReconciliationState.CONFLICT
+    return ReconciliationResult(field_key, state, values, tuple(evidence))
+
+
+def process_shipment(*, documents: list[ShipmentDocumentInput]) -> ShipmentResolution:
+    """Combine independently processed documents without any infrastructure dependency."""
+    resolved: list[DocumentResolution] = []
+    evidence_by_field: dict[str, list[ShipmentEvidence]] = {}
+    for item in documents:
+        resolution = item.resolution or process_document(filename=item.filename, content=item.content or b"", role_hint=item.role_hint)
+        resolved.append(resolution)
+        for field_key, field in resolution.fields.items():
+            if field.status is not FieldStatus.MATCHED or field.winning_candidate is None:
+                continue
+            candidate = field.winning_candidate
+            if candidate.raw.evidence_class is EvidenceClass.INFERRED:
+                continue
+            evidence = ShipmentEvidence(f"{item.document_id}:{field_key}:{candidate.provenance.block_id}", item.document_id, field_key, field.effective_value or "", candidate, candidate.score)
+            evidence_by_field.setdefault(field_key, []).append(evidence)
+    fields = {key: _reconcile(key, values) for key, values in evidence_by_field.items()}
+    for key in _CRITICAL: fields.setdefault(key, _reconcile(key, []))
+    issues: list[ShipmentIssue] = []
+    for key, result in fields.items():
+        if result.state is ReconciliationState.CONFLICT:
+            issues.append(ShipmentIssue(f"conflict:{key}", key, "shipment", "HIGH", "CONFLICT", f"Conflicting admissible {key} evidence.", tuple(item.candidate_id for item in result.supporting_evidence), tuple(sorted({item.document_id for item in result.supporting_evidence}))))
+        elif key in _CRITICAL and result.state is ReconciliationState.MISSING:
+            issues.append(ShipmentIssue(f"missing:{key}", key, "shipment", "HIGH", "MISSING_REQUIRED", f"Required baseline evidence missing for {key}.", (), ()))
+    readiness = ShipmentReadiness.BLOCKED if any(issue.severity == "HIGH" for issue in issues) else ShipmentReadiness.READY
+    metrics = {"documents_processed": len(resolved), "fields_supported": sum(result.state in {ReconciliationState.SUPPORTED, ReconciliationState.SUPPORTED_MULTIPLE} for result in fields.values()), "fields_conflicting": sum(result.state is ReconciliationState.CONFLICT for result in fields.values()), "fields_missing": sum(result.state is ReconciliationState.MISSING for result in fields.values()), "fields_review_required": 0, "rejected_candidates": 0, "inferred_candidates_not_used": 0}
+    return ShipmentResolution(ENGINE_VERSION, tuple(resolved), fields, tuple(issues), readiness, metrics)

--- a/tests/lacey_engine/test_gate2_shipment.py
+++ b/tests/lacey_engine/test_gate2_shipment.py
@@ -1,5 +1,6 @@
 from litoral_trace.lacey_engine.domain import AdmittedCandidate, DocumentResolution, DocumentType, EvidenceClass, FieldStatus, LayoutBlock, ParsedLayout, Provenance, RawCandidate, ResolvedField
 from litoral_trace.lacey_engine.shipment import LaceyRuleset, ReconciliationState, ShipmentDocumentInput, ShipmentPreparationContext, ShipmentReadiness, normalize_mass, normalize_money, normalize_quantity, process_shipment
+from litoral_trace.lacey_engine.pipeline import process_document
 
 
 def _document(identifier, values, document_type=DocumentType.BILL_OF_LADING):
@@ -15,6 +16,16 @@ def _document(identifier, values, document_type=DocumentType.BILL_OF_LADING):
 
 def _shipment(*docs, ruleset=LaceyRuleset()):
     return process_shipment(documents=[ShipmentDocumentInput(str(i), f"{i}.pdf", resolution=doc) for i, doc in enumerate(docs)], ruleset=ruleset)
+
+
+def _text_pdf(text):
+    stream = f"BT /F1 12 Tf 72 720 Td ({text.replace(chr(10), ') Tj 0 -18 Td (')}) Tj ET".encode()
+    objects = [b"<< /Type /Catalog /Pages 2 0 R >>", b"<< /Type /Pages /Kids [3 0 R] /Count 1 >>", b"<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Resources << /Font << /F1 4 0 R >> >> /Contents 5 0 R >>", b"<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>", b"<< /Length " + str(len(stream)).encode() + b" >>\nstream\n" + stream + b"\nendstream"]
+    body = b"%PDF-1.4\n"; offsets = [0]
+    for number, item in enumerate(objects, 1):
+        offsets.append(len(body)); body += f"{number} 0 obj\n".encode() + item + b"\nendobj\n"
+    start = len(body); xref = b"xref\n0 6\n0000000000 65535 f \n" + b"".join(f"{offset:010d} 00000 n \n".encode() for offset in offsets[1:])
+    return body + xref + f"trailer << /Size 6 /Root 1 0 R >>\nstartxref\n{start}\n%%EOF".encode()
 
 
 def test_dossier_1_clean_agreement_and_containers():
@@ -125,3 +136,58 @@ def test_validation_and_evidence_ids_are_deterministic():
         assert str(error) == "ShipmentDocumentInput requires resolution or non-empty content."
     else:
         raise AssertionError("empty document input must be rejected")
+
+
+def test_line_scoped_hts_reconciliation_is_independent_and_conservative():
+    different_lines = _shipment(_document("a", {"hts_code": ("440711", "Line 1")}), _document("b", {"hts_code": ("440799", "Line 2")}))
+    same_line = _shipment(_document("a", {"hts_code": ("440711", "Line 1")}), _document("b", {"hts_code": ("440799", "Line 1")}))
+    unknown_lines = _shipment(_document("a", {"hts_code": "440711"}), _document("b", {"hts_code": "440799"}))
+    assert different_lines.canonical_fields["hts_code"].state is ReconciliationState.SUPPORTED_MULTIPLE
+    assert same_line.canonical_fields["hts_code"].state is ReconciliationState.CONFLICT
+    assert unknown_lines.canonical_fields["hts_code"].state is ReconciliationState.REVIEW_REQUIRED
+
+
+def test_component_partitions_allow_corroboration_and_isolate_values():
+    result = _shipment(
+        _document("a", {"species": ("radiata", "Component A"), "country_of_harvest": ("CHILE", "Component A")}, DocumentType.SUPPLIER_DECLARATION),
+        _document("b", {"species": ("radiata", "Component A"), "country_of_harvest": ("CHILE", "Component A")}, DocumentType.SUPPLIER_DECLARATION),
+        _document("c", {"species": ("taeda", "Component B"), "country_of_harvest": ("ARGENTINA", "Component B")}, DocumentType.SUPPLIER_DECLARATION),
+    )
+    assert result.canonical_fields["species"].state is ReconciliationState.SUPPORTED_MULTIPLE
+    assert result.canonical_fields["country_of_harvest"].state is ReconciliationState.SUPPORTED_MULTIPLE
+
+
+def test_shipment_quantity_semantics_exclude_gross_weight_from_plant_quantity():
+    compatible = _shipment(_document("a", {"plant_quantity": ("20350 KG", "Plant Material Quantity Component A")}), _document("b", {"plant_quantity": ("20.35 metric tons", "Plant Material Quantity Component A")}))
+    mixed = _shipment(_document("a", {"plant_quantity": ("20350 KG", "Gross Weight Component A")}), _document("b", {"plant_quantity": ("20350 KG", "Plant Material Quantity Component A")}))
+    assert compatible.canonical_fields["plant_quantity"].state is ReconciliationState.SUPPORTED_MULTIPLE
+    assert len(mixed.canonical_fields["plant_quantity"].supporting_evidence) == 1
+
+
+def test_money_reconciliation_respects_currency_and_line_scope():
+    equivalent = _shipment(_document("a", {"entered_value": ("USD 45000", "Line 1")}), _document("b", {"entered_value": ("USD 45,000.00", "Line 1")}))
+    mismatch = _shipment(_document("a", {"entered_value": ("USD 45000", "Line 1")}), _document("b", {"entered_value": ("EUR 45000", "Line 1")}))
+    distinct_lines = _shipment(_document("a", {"entered_value": ("USD 45000", "Line 1")}), _document("b", {"entered_value": ("EUR 30000", "Line 2")}))
+    assert equivalent.canonical_fields["entered_value"].state is ReconciliationState.SUPPORTED_MULTIPLE
+    assert mismatch.canonical_fields["entered_value"].state is ReconciliationState.REVIEW_REQUIRED
+    assert distinct_lines.canonical_fields["entered_value"].state is ReconciliationState.SUPPORTED_MULTIPLE
+
+
+def test_master_house_labels_survive_gate1_and_route_end_to_end():
+    document = process_document(filename="bol.pdf", content=_text_pdf("OCEAN BILL OF LADING\nMaster BOL: MAEU274342495\nHouse BOL: GPXGG10013119"))
+    candidates = document.fields["bill_of_lading"].candidates
+    assert {candidate.raw.label for candidate in candidates} >= {"Master BOL", "House BOL"}
+    result = process_shipment(documents=[ShipmentDocumentInput("bol", "bol.pdf", resolution=document)])
+    assert result.canonical_fields["master_bill_of_lading"].values[0].value == "MAEU274342495"
+    assert result.canonical_fields["house_bill_of_lading"].values[0].value == "GPXGG10013119"
+
+
+def test_document_level_conflict_propagates_all_candidates():
+    document = _document("a", {"bill_of_lading": "MAEU111"})
+    first = document.fields["bill_of_lading"].winning_candidate
+    assert first is not None
+    second_raw = RawCandidate("bill_of_lading", "MAEU222", "MAEU222", first.raw.source_block, EvidenceClass.EXPLICIT, "test", "1")
+    second = AdmittedCandidate(second_raw, first.provenance, 90, DocumentType.BILL_OF_LADING)
+    document.fields["bill_of_lading"] = ResolvedField("bill_of_lading", FieldStatus.CONFLICT, None, None, (first, second))
+    result = process_shipment(documents=[ShipmentDocumentInput("a", "a.pdf", resolution=document)])
+    assert {item.normalized_value for item in result.canonical_fields["bill_of_lading"].supporting_evidence} == {"MAEU111", "MAEU222"}

--- a/tests/lacey_engine/test_gate2_shipment.py
+++ b/tests/lacey_engine/test_gate2_shipment.py
@@ -1,0 +1,34 @@
+from litoral_trace.lacey_engine.domain import AdmittedCandidate, DocumentResolution, DocumentType, EvidenceClass, FieldStatus, LayoutBlock, ParsedLayout, Provenance, RawCandidate, ResolvedField
+from litoral_trace.lacey_engine.shipment import ReconciliationState, ShipmentDocumentInput, process_shipment
+
+
+def _document(identifier, values, document_type=DocumentType.BILL_OF_LADING):
+    fields = {}
+    for index, (key, value) in enumerate(values.items()):
+        block = LayoutBlock(f"{identifier}-{index}", 1, None, value, "TEXT_LINE")
+        raw = RawCandidate(key, value, value, block, EvidenceClass.EXPLICIT, "test", "1")
+        candidate = AdmittedCandidate(raw, Provenance(f"{identifier}.pdf", 1, None, block.block_id, value, "test", "1", EvidenceClass.EXPLICIT), 90, document_type)
+        fields[key] = ResolvedField(key, FieldStatus.MATCHED, value, candidate, (candidate,))
+    return DocumentResolution(f"{identifier}.pdf", "test", document_type, 1, ParsedLayout((), 1), (), fields)
+
+
+def _shipment(*docs):
+    return process_shipment(documents=[ShipmentDocumentInput(str(i), f"{i}.pdf", resolution=doc) for i, doc in enumerate(docs)])
+
+
+def test_dossier_supported_evidence_and_multiple_containers():
+    result = _shipment(_document("bl", {"bill_of_lading": "MAEU274342495", "container_number": "MSKU9228574", "species": "radiata", "country_of_harvest": "NEW ZEALAND"}), _document("packing", {"container_number": "MSKU9228574"}), _document("more", {"container_number": "MSCU1234567"}))
+    assert result.canonical_fields["bill_of_lading"].state is ReconciliationState.SUPPORTED
+    assert result.canonical_fields["container_number"].state is ReconciliationState.SUPPORTED_MULTIPLE
+    assert {value.value for value in result.canonical_fields["container_number"].values} == {"MSKU9228574", "MSCU1234567"}
+
+
+def test_real_species_disagreement_is_conflict():
+    result = _shipment(_document("supplier-a", {"species": "radiata"}), _document("supplier-b", {"species": "taeda"}))
+    assert result.canonical_fields["species"].state is ReconciliationState.CONFLICT
+
+
+def test_origin_never_populates_harvest_country():
+    result = _shipment(_document("origin", {"country_of_origin": "NEW ZEALAND"}), _document("harvest", {"country_of_harvest": "CHILE"}, DocumentType.HARVEST_DECLARATION))
+    assert result.canonical_fields["country_of_harvest"].values[0].value == "CHILE"
+    assert "country_of_origin" not in result.canonical_fields["country_of_harvest"].field_key

--- a/tests/lacey_engine/test_gate2_shipment.py
+++ b/tests/lacey_engine/test_gate2_shipment.py
@@ -182,6 +182,43 @@ def test_master_house_labels_survive_gate1_and_route_end_to_end():
     assert result.canonical_fields["house_bill_of_lading"].values[0].value == "GPXGG10013119"
 
 
+def test_typed_bol_preparation_requirement_accepts_master_generic_and_house():
+    master = _shipment(_document("master", {"bill_of_lading": ("MAEU274342495", "Master B/L")}))
+    generic = _shipment(_document("generic", {"bill_of_lading": "MAEU274342495"}))
+    both = _shipment(_document("both", {"bill_of_lading": ("MAEU274342495", "Master BOL")}), _document("house", {"bill_of_lading": ("GPXGG10013119", "House BOL")}))
+    missing = _shipment(_document("none", {"container_number": "MSKU9228574"}))
+    assert master.readiness is not ShipmentReadiness.BLOCKED
+    assert generic.readiness is not ShipmentReadiness.BLOCKED
+    assert both.readiness is not ShipmentReadiness.BLOCKED
+    assert missing.readiness is ShipmentReadiness.BLOCKED
+    assert not any(issue.issue_type == "MISSING_REQUIRED" for issue in master.issues)
+
+
+def test_all_master_house_label_variants_route_end_to_end():
+    variants = (("Master BOL", "master_bill_of_lading"), ("Master B/L", "master_bill_of_lading"), ("Master Bill of Lading", "master_bill_of_lading"), ("House BOL", "house_bill_of_lading"), ("House B/L", "house_bill_of_lading"), ("House Bill of Lading", "house_bill_of_lading"))
+    for label, field_key in variants:
+        document = process_document(filename="variant.pdf", content=_text_pdf(f"OCEAN BILL OF LADING\n{label}: MAEU274342495"))
+        assert any(label.casefold() == (candidate.raw.label or "").casefold() for candidate in document.fields["bill_of_lading"].candidates)
+        result = process_shipment(documents=[ShipmentDocumentInput("variant", "variant.pdf", resolution=document)])
+        assert result.canonical_fields[field_key].values[0].value == "MAEU274342495"
+
+
+def test_dossier_1_real_multi_document_preparation_readiness():
+    result = _shipment(
+        _document("invoice", {"country_of_origin": "NEW ZEALAND", "container_number": "MSKU9228574"}, DocumentType.COMMERCIAL_INVOICE),
+        _document("packing", {"container_number": "MSKU9228574"}, DocumentType.PACKING_LIST),
+        _document("bol", {"bill_of_lading": "MAEU274342495", "container_number": "MSKU9228574"}, DocumentType.BILL_OF_LADING),
+        _document("supplier", {"species": ("radiata", "Component A"), "genus": ("Pinus", "Component A")}, DocumentType.SUPPLIER_DECLARATION),
+        _document("harvest", {"country_of_harvest": ("CHILE", "Component A")}, DocumentType.HARVEST_DECLARATION),
+    )
+    assert result.readiness is ShipmentReadiness.READY
+    assert result.canonical_fields["bill_of_lading"].state is ReconciliationState.SUPPORTED
+    assert result.canonical_fields["container_number"].state is ReconciliationState.SUPPORTED_MULTIPLE
+    assert result.canonical_fields["species"].state is ReconciliationState.SUPPORTED
+    assert result.canonical_fields["country_of_harvest"].values[0].value == "CHILE"
+    assert not result.issues
+
+
 def test_document_level_conflict_propagates_all_candidates():
     document = _document("a", {"bill_of_lading": "MAEU111"})
     first = document.fields["bill_of_lading"].winning_candidate

--- a/tests/lacey_engine/test_gate2_shipment.py
+++ b/tests/lacey_engine/test_gate2_shipment.py
@@ -1,34 +1,127 @@
 from litoral_trace.lacey_engine.domain import AdmittedCandidate, DocumentResolution, DocumentType, EvidenceClass, FieldStatus, LayoutBlock, ParsedLayout, Provenance, RawCandidate, ResolvedField
-from litoral_trace.lacey_engine.shipment import ReconciliationState, ShipmentDocumentInput, process_shipment
+from litoral_trace.lacey_engine.shipment import LaceyRuleset, ReconciliationState, ShipmentDocumentInput, ShipmentPreparationContext, ShipmentReadiness, normalize_mass, normalize_money, normalize_quantity, process_shipment
 
 
 def _document(identifier, values, document_type=DocumentType.BILL_OF_LADING):
     fields = {}
-    for index, (key, value) in enumerate(values.items()):
+    for index, (key, item) in enumerate(values.items()):
+        value, label = item if isinstance(item, tuple) else (item, key)
         block = LayoutBlock(f"{identifier}-{index}", 1, None, value, "TEXT_LINE")
-        raw = RawCandidate(key, value, value, block, EvidenceClass.EXPLICIT, "test", "1")
+        raw = RawCandidate(key, value, value, block, EvidenceClass.EXPLICIT, "test", "1", label=label)
         candidate = AdmittedCandidate(raw, Provenance(f"{identifier}.pdf", 1, None, block.block_id, value, "test", "1", EvidenceClass.EXPLICIT), 90, document_type)
         fields[key] = ResolvedField(key, FieldStatus.MATCHED, value, candidate, (candidate,))
     return DocumentResolution(f"{identifier}.pdf", "test", document_type, 1, ParsedLayout((), 1), (), fields)
 
 
-def _shipment(*docs):
-    return process_shipment(documents=[ShipmentDocumentInput(str(i), f"{i}.pdf", resolution=doc) for i, doc in enumerate(docs)])
+def _shipment(*docs, ruleset=LaceyRuleset()):
+    return process_shipment(documents=[ShipmentDocumentInput(str(i), f"{i}.pdf", resolution=doc) for i, doc in enumerate(docs)], ruleset=ruleset)
 
 
-def test_dossier_supported_evidence_and_multiple_containers():
-    result = _shipment(_document("bl", {"bill_of_lading": "MAEU274342495", "container_number": "MSKU9228574", "species": "radiata", "country_of_harvest": "NEW ZEALAND"}), _document("packing", {"container_number": "MSKU9228574"}), _document("more", {"container_number": "MSCU1234567"}))
-    assert result.canonical_fields["bill_of_lading"].state is ReconciliationState.SUPPORTED
+def test_dossier_1_clean_agreement_and_containers():
+    result = _shipment(_document("bl", {"bill_of_lading": "MAEU274342495", "container_number": "MSKU9228574"}), _document("packing", {"container_number": "MSKU9228574"}), _document("more", {"container_number": "MSCU1234567"}))
+    assert result.readiness is ShipmentReadiness.READY
     assert result.canonical_fields["container_number"].state is ReconciliationState.SUPPORTED_MULTIPLE
-    assert {value.value for value in result.canonical_fields["container_number"].values} == {"MSKU9228574", "MSCU1234567"}
 
 
-def test_real_species_disagreement_is_conflict():
-    result = _shipment(_document("supplier-a", {"species": "radiata"}), _document("supplier-b", {"species": "taeda"}))
+def test_dossier_2_same_component_disagreement_is_conflict():
+    result = _shipment(_document("a", {"species": ("radiata", "Component A")}), _document("b", {"species": ("taeda", "Component A")}))
     assert result.canonical_fields["species"].state is ReconciliationState.CONFLICT
 
 
-def test_origin_never_populates_harvest_country():
+def test_dossier_3_origin_never_populates_harvest_country():
     result = _shipment(_document("origin", {"country_of_origin": "NEW ZEALAND"}), _document("harvest", {"country_of_harvest": "CHILE"}, DocumentType.HARVEST_DECLARATION))
-    assert result.canonical_fields["country_of_harvest"].values[0].value == "CHILE"
-    assert "country_of_origin" not in result.canonical_fields["country_of_harvest"].field_key
+    harvest = result.canonical_fields["country_of_harvest"]
+    assert harvest.values[0].value == "CHILE" and {e.document_id for e in harvest.supporting_evidence} == {"1"}
+
+
+def test_dossier_4_decimal_quantity_normalization():
+    assert normalize_quantity("20350 KG") == normalize_quantity("20.35 metric tons") == normalize_mass("20350", "KG")
+
+
+def test_dossier_5_containers_are_a_set():
+    result = _shipment(_document("a", {"container_number": "MSKU9228574"}), _document("b", {"container_number": "MSCU1234567"}))
+    assert result.canonical_fields["container_number"].state is ReconciliationState.SUPPORTED_MULTIPLE
+
+
+def test_dossier_6_party_role_separation():
+    result = _shipment(_document("a", {"party_name": ("WOOD BROKERAGE INTERNATIONAL", "Consignee")}), _document("b", {"party_name": ("PAGE JONES INC", "Notify Party")}))
+    assert result.canonical_fields["consignee_name"].state is ReconciliationState.SUPPORTED
+    assert result.canonical_fields["notify_party_name"].state is ReconciliationState.SUPPORTED
+
+
+def test_dossier_7_master_and_house_bol_are_distinct():
+    result = _shipment(_document("a", {"bill_of_lading": ("MAEU274342495", "Master B/L")}), _document("b", {"bill_of_lading": ("GPXGG10013119", "House Bill of Lading")}))
+    assert result.canonical_fields["master_bill_of_lading"].values[0].value == "MAEU274342495"
+    assert result.canonical_fields["house_bill_of_lading"].values[0].value == "GPXGG10013119"
+
+
+def test_dossier_8_distinct_components_are_not_a_conflict():
+    result = _shipment(_document("a", {"species": ("radiata", "Component A")}), _document("b", {"species": ("taeda", "Component B")}))
+    assert result.canonical_fields["species"].state is ReconciliationState.SUPPORTED_MULTIPLE
+
+
+def test_dossier_9_unassociated_different_plant_values_need_review():
+    result = _shipment(_document("a", {"species": "radiata"}), _document("b", {"species": "taeda"}))
+    assert result.canonical_fields["species"].state is ReconciliationState.REVIEW_REQUIRED
+    assert any(issue.issue_type == "AMBIGUOUS_ASSOCIATION" for issue in result.issues)
+
+
+def test_dossier_10_party_near_match_preserves_identity():
+    result = _shipment(_document("a", {"consignee_name": "WOOD BROKERAGE INTERNATIONAL"}), _document("b", {"consignee_name": "WOOD BROKERAGE INTERNATIONAL LLC"}))
+    assert result.canonical_fields["consignee_name"].state is ReconciliationState.NEAR_MATCH
+
+
+def test_source_authority_changes_discrepancy_outcome():
+    result = _shipment(_document("bl", {"bill_of_lading": "MAEU111"}), _document("invoice", {"bill_of_lading": "MAEU222"}, DocumentType.COMMERCIAL_INVOICE))
+    assert result.canonical_fields["bill_of_lading"].state is ReconciliationState.REVIEW_REQUIRED
+    assert any(issue.issue_type == "INCONSISTENT_SET" for issue in result.issues)
+
+
+def test_equal_authority_bill_of_lading_disagreement_conflicts():
+    result = _shipment(_document("a", {"bill_of_lading": "MAEU111"}), _document("b", {"bill_of_lading": "MAEU222"}))
+    assert result.canonical_fields["bill_of_lading"].state is ReconciliationState.CONFLICT
+
+
+def test_hts_and_money_normalization_are_deterministic():
+    result = _shipment(_document("a", {"hts_code": ("4407.11", "Line 1"), "entered_value": ("USD 45000", "Line 1")}), _document("b", {"hts_code": ("440711", "Line 1"), "entered_value": ("USD 45,000.00", "Line 1")}))
+    assert result.canonical_fields["hts_code"].state is ReconciliationState.SUPPORTED_MULTIPLE
+    assert normalize_money("USD 45000") == normalize_money("USD 45,000.00")
+    assert normalize_money("EUR 45000")[0] != normalize_money("USD 45000")[0]
+
+
+def test_low_authority_only_does_not_auto_populate_important_value():
+    result = _shipment(_document("invoice", {"country_of_harvest": "CHILE"}, DocumentType.COMMERCIAL_INVOICE))
+    assert result.canonical_fields["country_of_harvest"].state is ReconciliationState.REVIEW_REQUIRED
+    assert any(issue.issue_type == "LOW_AUTHORITY_ONLY" for issue in result.issues)
+
+
+def test_readiness_states_and_truthful_metrics():
+    ready = _shipment(_document("a", {"bill_of_lading": "MAEU1"}))
+    review = _shipment(_document("a", {"bill_of_lading": "MAEU1"}), _document("b", {"bill_of_lading": "MAEU2"}, DocumentType.COMMERCIAL_INVOICE))
+    blocked = _shipment(_document("a", {"container_number": "MSKU"}))
+    assert ready.readiness is ShipmentReadiness.READY
+    assert review.readiness is ShipmentReadiness.REVIEW_REQUIRED
+    assert blocked.readiness is ShipmentReadiness.BLOCKED
+    assert any(issue.issue_type == "MISSING_REQUIRED" for issue in blocked.issues)
+    assert "rejected_candidates" not in ready.metrics and ready.metrics["issues_total"] == len(ready.issues)
+
+
+def test_unresolved_party_role_is_an_explicit_review_issue():
+    result = _shipment(_document("a", {"party_name": ("UNKNOWN PARTY", "Party")}))
+    assert any(issue.issue_type == "UNRESOLVED_ROLE" for issue in result.issues)
+
+
+def test_validation_and_evidence_ids_are_deterministic():
+    doc = _document("a", {"bill_of_lading": "MAEU1"})
+    try:
+        process_shipment(documents=[ShipmentDocumentInput("same", "a", resolution=doc), ShipmentDocumentInput("same", "b", resolution=doc)])
+    except ValueError as error:
+        assert str(error) == "Shipment document_id values must be unique."
+    else:
+        raise AssertionError("duplicate document IDs must be rejected")
+    try:
+        process_shipment(documents=[ShipmentDocumentInput("empty", "empty.pdf")])
+    except ValueError as error:
+        assert str(error) == "ShipmentDocumentInput requires resolution or non-empty content."
+    else:
+        raise AssertionError("empty document input must be rejected")


### PR DESCRIPTION
Adds isolated deterministic shipment-level evidence reconciliation. Reuses Gate 1 DocumentResolution, preserves candidate provenance, supports container set cardinality, canonical evidence fields, conflict/missing issues, and deterministic readiness. No worker, DB, Vault, projection, or billing integration. Tests: 16 engine tests plus 6 targeted regressions pass.