### PR TITLE
feat(admin): expose platform owner console on Lacey host

### DIFF
--- a/src/litoral_trace/templates/us_lacey/admin.html
+++ b/src/litoral_trace/templates/us_lacey/admin.html
@@ -30,15 +30,15 @@
   <article class="overflow-hidden rounded-2xl border border-slate-200 bg-white shadow-sm">
     <div class="border-b border-slate-200 px-5 py-4"><h2 class="text-lg font-bold text-slate-950">Accounts</h2><p class="mt-1 text-xs text-slate-500">{{ account_count }} U.S. Lacey account(s)</p></div>
     <div class="overflow-x-auto">
-      <table class="w-full min-w-[1050px] text-left text-xs">
+      <table class="w-full min-w-[53rem] text-left text-xs">
         <thead class="bg-slate-50 uppercase text-slate-600"><tr><th class="p-3">Account</th><th class="p-3">Status</th><th class="p-3">Payment</th><th class="p-3">Usage</th><th class="p-3">Jobs</th><th class="p-3">Controls</th></tr></thead>
         <tbody class="divide-y divide-slate-200 text-slate-700">
         {% for account in accounts %}
-          <tr class="align-top">
+          <tr>
             <td class="p-3"><div class="font-bold text-slate-950">{{ account.legal_name }}</div><div class="mt-1 text-slate-500">{{ account.admin_contact_email or '—' }} · Org {{ account.organization_id }}</div></td>
             <td class="p-3"><span class="rounded-full bg-slate-100 px-2 py-1 font-bold text-slate-800">{{ account.account_status }}</span></td>
             <td class="p-3"><div class="font-semibold">{{ account.payment_provider or '—' }} · {{ account.payment_status or '—' }}</div><div class="mt-1 text-slate-500">Subscription: {{ account.subscription_status or '—' }}</div></td>
-            <td class="p-3"><div class="font-bold">{{ account.used_operations or 0 }} / {{ account.monthly_operation_limit or 0 }}</div><form method="post" action="/admin/us-lacey/accounts/{{ account.organization_id }}/operation-limit" class="mt-2 flex gap-2"><input type="hidden" name="csrf_token" value="{{ limit_csrf[account.organization_id] }}"><input type="number" name="monthly_operation_limit" min="1" max="100000" value="{{ account.monthly_operation_limit or 25 }}" class="w-24 rounded border border-slate-300 px-2 py-1"><button class="rounded bg-slate-900 px-2 py-1 font-bold text-white">Set limit</button></form></td>
+            <td class="p-3"><div class="font-bold">{{ account.used_operations or 0 }} / {{ account.monthly_operation_limit or 0 }}</div><form method="post" action="/admin/us-lacey/accounts/{{ account.organization_id }}/operation-limit" class="mt-2 flex gap-2"><input type="hidden" name="csrf_token" value="{{ limit_csrf[account.organization_id] }}"><input type="number" name="monthly_operation_limit" min="1" max="100000" value="{{ account.monthly_operation_limit or 25 }}" class="w-32 rounded border border-slate-300 px-2 py-1"><button class="rounded bg-slate-900 px-2 py-1 font-bold text-white">Set limit</button></form></td>
             <td class="p-3"><div>{{ account.queued_jobs or 0 }} queued · {{ account.running_jobs or 0 }} running</div><div class="mt-1">{{ account.retry_jobs or 0 }} retry · <span class="font-bold text-rose-700">{{ account.failed_jobs or 0 }} failed</span></div></td>
             <td class="p-3">
               <form method="post" action="/admin/us-lacey/accounts/{{ account.organization_id }}/status" class="flex flex-wrap gap-1">
@@ -67,7 +67,7 @@
     <article class="rounded-2xl border border-slate-200 bg-white p-5 shadow-sm">
       <h2 class="text-lg font-bold text-slate-950">Users</h2>
       <p class="mt-1 text-xs text-slate-500">Global user inventory. Password administration is intentionally not exposed.</p>
-      <div class="mt-4 max-h-[28rem] divide-y divide-slate-100 overflow-auto">
+      <div class="mt-4 max-h-72 divide-y divide-slate-100 overflow-auto">
       {% for platform_user in users %}
         <div class="flex items-start justify-between gap-3 py-3">
           <div class="min-w-0"><p class="break-all text-sm font-bold text-slate-950">{{ platform_user.email }}</p><p class="mt-1 text-xs text-slate-500">{{ platform_user.organization_name }} · {{ platform_user.role }} · user {{ platform_user.user_id }}</p></div>
@@ -83,7 +83,7 @@
     <article class="rounded-2xl border border-slate-200 bg-white p-5 shadow-sm">
       <h2 class="text-lg font-bold text-slate-950">Processing / errors</h2>
       <p class="mt-1 text-xs text-slate-500">Recent failed document-processing jobs across tenants.</p>
-      <div class="mt-4 max-h-[28rem] divide-y divide-slate-100 overflow-auto">
+      <div class="mt-4 max-h-72 divide-y divide-slate-100 overflow-auto">
       {% for job in failed_jobs %}
         <div class="py-3"><p class="text-sm font-bold text-slate-950">{{ job.organization_name }}</p><p class="mt-1 text-xs font-semibold text-rose-700">{{ job.error_code or 'FAILED' }}</p><p class="mt-1 text-xs leading-5 text-slate-500">{{ job.error_message }}</p></div>
       {% else %}<p class="py-4 text-sm text-slate-500">No failed jobs.</p>{% endfor %}

--- a/src/litoral_trace/templates/us_lacey/admin.html
+++ b/src/litoral_trace/templates/us_lacey/admin.html
@@ -1,0 +1,96 @@
+{% extends "us_lacey/base.html" %}
+{% block lacey_title %}Platform Admin{% endblock %}
+{% block lacey_content %}
+<section class="space-y-6">
+  <div class="rounded-2xl border border-slate-200 bg-white p-6 shadow-sm">
+    <div class="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
+      <div>
+        <div class="mb-2 flex flex-wrap items-center gap-2">
+          <span class="rounded-full border border-purple-200 bg-purple-50 px-2.5 py-1 text-xs font-bold text-purple-800"><i class="fa-solid fa-crown mr-1" aria-hidden="true"></i>Global Platform Admin</span>
+          <span class="text-xs font-semibold text-slate-500">Superadmin only</span>
+        </div>
+        <h1 class="text-2xl font-bold tracking-tight text-slate-950">U.S. Lacey owner control plane</h1>
+        <p class="mt-2 max-w-3xl text-sm leading-6 text-slate-600">Cross-tenant account status, usage, users and processing failures. Mutations below use the audited capability-scoped PostgreSQL control plane.</p>
+      </div>
+      <a href="/operations" class="inline-flex items-center justify-center rounded-xl border border-slate-300 bg-white px-4 py-2.5 text-sm font-bold text-slate-700 hover:bg-slate-50">Back to operations</a>
+    </div>
+  </div>
+
+  {% if notice %}
+  <div class="rounded-xl border border-emerald-200 bg-emerald-50 px-4 py-3 text-sm font-semibold text-emerald-800">{{ notice }}</div>
+  {% endif %}
+
+  <div class="grid grid-cols-2 gap-3 lg:grid-cols-4">
+    <div class="rounded-xl border border-slate-200 bg-white p-4"><p class="text-[10px] font-bold uppercase tracking-wide text-slate-500">Active</p><p class="mt-1 text-2xl font-bold text-slate-950">{{ active_count }}</p></div>
+    <div class="rounded-xl border border-slate-200 bg-white p-4"><p class="text-[10px] font-bold uppercase tracking-wide text-slate-500">Pilot</p><p class="mt-1 text-2xl font-bold text-slate-950">{{ pilot_count }}</p></div>
+    <div class="rounded-xl border border-slate-200 bg-white p-4"><p class="text-[10px] font-bold uppercase tracking-wide text-slate-500">Pending</p><p class="mt-1 text-2xl font-bold text-slate-950">{{ pending_count }}</p></div>
+    <div class="rounded-xl border border-slate-200 bg-white p-4"><p class="text-[10px] font-bold uppercase tracking-wide text-slate-500">Failed jobs</p><p class="mt-1 text-2xl font-bold text-slate-950">{{ failed_job_count }}</p></div>
+  </div>
+
+  <article class="overflow-hidden rounded-2xl border border-slate-200 bg-white shadow-sm">
+    <div class="border-b border-slate-200 px-5 py-4"><h2 class="text-lg font-bold text-slate-950">Accounts</h2><p class="mt-1 text-xs text-slate-500">{{ account_count }} U.S. Lacey account(s)</p></div>
+    <div class="overflow-x-auto">
+      <table class="w-full min-w-[1050px] text-left text-xs">
+        <thead class="bg-slate-50 uppercase text-slate-600"><tr><th class="p-3">Account</th><th class="p-3">Status</th><th class="p-3">Payment</th><th class="p-3">Usage</th><th class="p-3">Jobs</th><th class="p-3">Controls</th></tr></thead>
+        <tbody class="divide-y divide-slate-200 text-slate-700">
+        {% for account in accounts %}
+          <tr class="align-top">
+            <td class="p-3"><div class="font-bold text-slate-950">{{ account.legal_name }}</div><div class="mt-1 text-slate-500">{{ account.admin_contact_email or '—' }} · Org {{ account.organization_id }}</div></td>
+            <td class="p-3"><span class="rounded-full bg-slate-100 px-2 py-1 font-bold text-slate-800">{{ account.account_status }}</span></td>
+            <td class="p-3"><div class="font-semibold">{{ account.payment_provider or '—' }} · {{ account.payment_status or '—' }}</div><div class="mt-1 text-slate-500">Subscription: {{ account.subscription_status or '—' }}</div></td>
+            <td class="p-3"><div class="font-bold">{{ account.used_operations or 0 }} / {{ account.monthly_operation_limit or 0 }}</div><form method="post" action="/admin/us-lacey/accounts/{{ account.organization_id }}/operation-limit" class="mt-2 flex gap-2"><input type="hidden" name="csrf_token" value="{{ limit_csrf[account.organization_id] }}"><input type="number" name="monthly_operation_limit" min="1" max="100000" value="{{ account.monthly_operation_limit or 25 }}" class="w-24 rounded border border-slate-300 px-2 py-1"><button class="rounded bg-slate-900 px-2 py-1 font-bold text-white">Set limit</button></form></td>
+            <td class="p-3"><div>{{ account.queued_jobs or 0 }} queued · {{ account.running_jobs or 0 }} running</div><div class="mt-1">{{ account.retry_jobs or 0 }} retry · <span class="font-bold text-rose-700">{{ account.failed_jobs or 0 }} failed</span></div></td>
+            <td class="p-3">
+              <form method="post" action="/admin/us-lacey/accounts/{{ account.organization_id }}/status" class="flex flex-wrap gap-1">
+                <input type="hidden" name="csrf_token" value="{{ status_csrf[account.organization_id] }}">
+                <button name="account_status" value="PILOT" class="rounded bg-purple-100 px-2 py-1 font-bold text-purple-800">PILOT</button>
+                <button name="account_status" value="SUSPENDED" class="rounded bg-rose-100 px-2 py-1 font-bold text-rose-800">Suspend</button>
+                <button name="account_status" value="ACTIVE" class="rounded bg-emerald-100 px-2 py-1 font-bold text-emerald-800">Activate</button>
+              </form>
+              {% if account.account_status == 'PILOT' %}
+              <form method="post" action="/admin/us-lacey/accounts/{{ account.organization_id }}/reset-pilot" class="mt-2" onsubmit="return confirm('Reset only this PILOT account test data?');">
+                <input type="hidden" name="csrf_token" value="{{ reset_csrf[account.organization_id] }}">
+                <button class="rounded bg-amber-100 px-2 py-1 font-bold text-amber-800">Reset test data</button>
+              </form>
+              {% endif %}
+            </td>
+          </tr>
+        {% else %}
+          <tr><td colspan="6" class="p-6 text-center text-slate-500">No U.S. Lacey accounts found.</td></tr>
+        {% endfor %}
+        </tbody>
+      </table>
+    </div>
+  </article>
+
+  <div class="grid gap-6 lg:grid-cols-2">
+    <article class="rounded-2xl border border-slate-200 bg-white p-5 shadow-sm">
+      <h2 class="text-lg font-bold text-slate-950">Users</h2>
+      <p class="mt-1 text-xs text-slate-500">Global user inventory. Password administration is intentionally not exposed.</p>
+      <div class="mt-4 max-h-[28rem] divide-y divide-slate-100 overflow-auto">
+      {% for platform_user in users %}
+        <div class="flex items-start justify-between gap-3 py-3">
+          <div class="min-w-0"><p class="break-all text-sm font-bold text-slate-950">{{ platform_user.email }}</p><p class="mt-1 text-xs text-slate-500">{{ platform_user.organization_name }} · {{ platform_user.role }} · user {{ platform_user.user_id }}</p></div>
+          <form method="post" action="/admin/users/{{ platform_user.user_id }}/revoke-sessions" onsubmit="return confirm('Revoke all active sessions for this user?');">
+            <input type="hidden" name="csrf_token" value="{{ revoke_csrf[platform_user.user_id] }}">
+            <button class="shrink-0 rounded border border-slate-300 bg-white px-2 py-1 text-[10px] font-bold text-slate-700">Revoke sessions</button>
+          </form>
+        </div>
+      {% else %}<p class="py-4 text-sm text-slate-500">No users found.</p>{% endfor %}
+      </div>
+    </article>
+
+    <article class="rounded-2xl border border-slate-200 bg-white p-5 shadow-sm">
+      <h2 class="text-lg font-bold text-slate-950">Processing / errors</h2>
+      <p class="mt-1 text-xs text-slate-500">Recent failed document-processing jobs across tenants.</p>
+      <div class="mt-4 max-h-[28rem] divide-y divide-slate-100 overflow-auto">
+      {% for job in failed_jobs %}
+        <div class="py-3"><p class="text-sm font-bold text-slate-950">{{ job.organization_name }}</p><p class="mt-1 text-xs font-semibold text-rose-700">{{ job.error_code or 'FAILED' }}</p><p class="mt-1 text-xs leading-5 text-slate-500">{{ job.error_message }}</p></div>
+      {% else %}<p class="py-4 text-sm text-slate-500">No failed jobs.</p>{% endfor %}
+      </div>
+    </article>
+  </div>
+
+  <div class="rounded-xl border border-amber-200 bg-amber-50 px-4 py-3 text-xs leading-5 text-amber-900">This owner console does not submit data to ACE or LAWGS and does not create or verify payments. PILOT reset remains blocked for accounts with verified Lemon commercial history.</div>
+</section>
+{% endblock %}

--- a/src/litoral_trace/templates/us_lacey/admin_message.html
+++ b/src/litoral_trace/templates/us_lacey/admin_message.html
@@ -1,0 +1,18 @@
+{% extends "us_lacey/base.html" %}
+{% block lacey_title %}{{ title }}{% endblock %}
+{% block lacey_content %}
+<section class="mx-auto max-w-3xl">
+  <div class="rounded-2xl border border-slate-200 bg-white p-6 shadow-sm">
+    <div class="flex items-start gap-3">
+      <span class="flex h-10 w-10 shrink-0 items-center justify-center rounded-xl bg-slate-100 text-slate-700" aria-hidden="true">
+        <i class="fa-solid fa-shield-halved"></i>
+      </span>
+      <div>
+        <h1 class="text-xl font-bold text-slate-950">{{ title }}</h1>
+        <p class="mt-2 text-sm leading-6 text-slate-600">{{ message }}</p>
+        <a href="{{ return_href }}" class="mt-5 inline-flex items-center justify-center rounded-xl border border-slate-300 bg-white px-4 py-2.5 text-sm font-bold text-slate-700 hover:bg-slate-50">{{ return_label }}</a>
+      </div>
+    </div>
+  </div>
+</section>
+{% endblock %}

--- a/src/litoral_trace/web/us_lacey_platform_admin.py
+++ b/src/litoral_trace/web/us_lacey_platform_admin.py
@@ -51,6 +51,7 @@ def _login_redirect(*, clear_cookie: bool = False) -> RedirectResponse:
 
 def _admin_message(
     *,
+    request: Request,
     title: str,
     message: str,
     return_href: str,
@@ -58,6 +59,7 @@ def _admin_message(
     status_code: int,
 ) -> HTMLResponse:
     content = templates.get_template("us_lacey/admin_message.html").render(
+        request=request,
         authenticated=True,
         title=title,
         message=message,
@@ -71,8 +73,9 @@ def _admin_message(
     )
 
 
-def _access_denied() -> HTMLResponse:
+def _access_denied(request: Request) -> HTMLResponse:
     return _admin_message(
+        request=request,
         title="Access denied",
         message="This account does not have platform-administration access.",
         return_href="/operations",
@@ -81,8 +84,14 @@ def _access_denied() -> HTMLResponse:
     )
 
 
-def _safe_error(message: str, *, status_code: int = 400) -> HTMLResponse:
+def _safe_error(
+    request: Request,
+    message: str,
+    *,
+    status_code: int = 400,
+) -> HTMLResponse:
     return _admin_message(
+        request=request,
         title="Admin action unavailable",
         message=message,
         return_href="/admin",
@@ -334,12 +343,13 @@ def platform_admin_page(
         return _login_redirect(clear_cookie=bool(us_session))
     except HTTPException as exc:
         if exc.status_code == status.HTTP_403_FORBIDDEN:
-            return _access_denied()
+            return _access_denied(request)
         raise
 
 
 @router.post("/admin/us-lacey/accounts/{organization_id}/status")
 def platform_admin_set_status(
+    request: Request,
     organization_id: int,
     account_status: str = Form(...),
     csrf_token: str = Form(...),
@@ -359,6 +369,7 @@ def platform_admin_set_status(
             and organization_id == identity.organization_id
         ):
             return _safe_error(
+                request,
                 "You cannot suspend the organization that owns your current admin session.",
                 status_code=status.HTTP_409_CONFLICT,
             )
@@ -374,11 +385,16 @@ def platform_admin_set_status(
     except UsLaceyPortalAuthError:
         return _login_redirect(clear_cookie=bool(us_session))
     except UsLaceyCsrfError:
-        return _safe_error("The admin form expired. Refresh and try again.", status_code=403)
+        return _safe_error(
+            request,
+            "The admin form expired. Refresh and try again.",
+            status_code=403,
+        )
 
 
 @router.post("/admin/us-lacey/accounts/{organization_id}/operation-limit")
 def platform_admin_set_limit(
+    request: Request,
     organization_id: int,
     monthly_operation_limit: int = Form(...),
     csrf_token: str = Form(...),
@@ -404,11 +420,16 @@ def platform_admin_set_limit(
     except UsLaceyPortalAuthError:
         return _login_redirect(clear_cookie=bool(us_session))
     except UsLaceyCsrfError:
-        return _safe_error("The admin form expired. Refresh and try again.", status_code=403)
+        return _safe_error(
+            request,
+            "The admin form expired. Refresh and try again.",
+            status_code=403,
+        )
 
 
 @router.post("/admin/us-lacey/accounts/{organization_id}/reset-pilot")
 def platform_admin_reset_pilot(
+    request: Request,
     organization_id: int,
     csrf_token: str = Form(...),
     us_session: str | None = Cookie(None, alias=US_LACEY_SESSION_COOKIE),
@@ -432,11 +453,16 @@ def platform_admin_reset_pilot(
     except UsLaceyPortalAuthError:
         return _login_redirect(clear_cookie=bool(us_session))
     except UsLaceyCsrfError:
-        return _safe_error("The admin form expired. Refresh and try again.", status_code=403)
+        return _safe_error(
+            request,
+            "The admin form expired. Refresh and try again.",
+            status_code=403,
+        )
 
 
 @router.post("/admin/users/{user_id}/revoke-sessions")
 def platform_admin_revoke_sessions(
+    request: Request,
     user_id: int,
     csrf_token: str = Form(...),
     us_session: str | None = Cookie(None, alias=US_LACEY_SESSION_COOKIE),
@@ -460,4 +486,8 @@ def platform_admin_revoke_sessions(
     except UsLaceyPortalAuthError:
         return _login_redirect(clear_cookie=bool(us_session))
     except UsLaceyCsrfError:
-        return _safe_error("The admin form expired. Refresh and try again.", status_code=403)
+        return _safe_error(
+            request,
+            "The admin form expired. Refresh and try again.",
+            status_code=403,
+        )

--- a/src/litoral_trace/web/us_lacey_platform_admin.py
+++ b/src/litoral_trace/web/us_lacey_platform_admin.py
@@ -49,33 +49,45 @@ def _login_redirect(*, clear_cookie: bool = False) -> RedirectResponse:
     return response
 
 
-def _access_denied() -> HTMLResponse:
+def _admin_message(
+    *,
+    title: str,
+    message: str,
+    return_href: str,
+    return_label: str,
+    status_code: int,
+) -> HTMLResponse:
+    content = templates.get_template("us_lacey/admin_message.html").render(
+        authenticated=True,
+        title=title,
+        message=message,
+        return_href=return_href,
+        return_label=return_label,
+    )
     return HTMLResponse(
-        status_code=status.HTTP_403_FORBIDDEN,
-        content=(
-            "<!doctype html><html><head><meta charset='utf-8'>"
-            "<title>Access denied</title></head><body>"
-            "<h1>Access denied</h1>"
-            "<p>This account does not have platform-administration access.</p>"
-            "<p><a href='/operations'>Return to operations</a></p>"
-            "</body></html>"
-        ),
+        status_code=status_code,
+        content=content,
         headers={"Cache-Control": "no-store, max-age=0"},
     )
 
 
+def _access_denied() -> HTMLResponse:
+    return _admin_message(
+        title="Access denied",
+        message="This account does not have platform-administration access.",
+        return_href="/operations",
+        return_label="Return to operations",
+        status_code=status.HTTP_403_FORBIDDEN,
+    )
+
+
 def _safe_error(message: str, *, status_code: int = 400) -> HTMLResponse:
-    return HTMLResponse(
+    return _admin_message(
+        title="Admin action unavailable",
+        message=message,
+        return_href="/admin",
+        return_label="Return to admin",
         status_code=status_code,
-        content=(
-            "<!doctype html><html><head><meta charset='utf-8'>"
-            "<title>Admin action unavailable</title></head><body>"
-            "<h1>Admin action unavailable</h1>"
-            f"<p>{message}</p>"
-            "<p><a href='/admin'>Return to admin</a></p>"
-            "</body></html>"
-        ),
-        headers={"Cache-Control": "no-store, max-age=0"},
     )
 
 

--- a/src/litoral_trace/web/us_lacey_platform_admin.py
+++ b/src/litoral_trace/web/us_lacey_platform_admin.py
@@ -1,25 +1,22 @@
 """Superadmin-only control surface on the deployed U.S. Lacey hostname.
 
-The U.S. portal keeps its opaque-session authentication boundary. For each admin
-request we verify that opaque session, verify the persisted platform role inside
-the tenant, create a short-lived internal generic refresh session only long
-enough to call the already-reviewed SECURITY DEFINER control-plane functions,
-and revoke that bridge session before returning.
+The U.S. portal keeps its opaque-session authentication boundary. Migration 037
+stores that opaque session in ``public.user_sessions``, the same persistent
+session table validated by the 042/044 platform control plane. Admin requests
+therefore verify the U.S. session, verify the persisted platform role inside the
+tenant, and pass that same opaque token server-side to the reviewed
+SECURITY DEFINER capabilities.
 
-No generic JWT is issued to the browser and no cross-tenant table access is
-performed directly in application code.
+No generic JWT or synthetic bridge session is issued, and no cross-tenant table
+access is performed directly in application code.
 """
 from __future__ import annotations
-
-from contextlib import contextmanager
-from typing import Iterator
 
 from fastapi import APIRouter, Cookie, Form, HTTPException, Request, status
 from fastapi.responses import HTMLResponse, RedirectResponse
 from sqlalchemy import select
 
 from litoral_trace.auth.rbac import Permission, has_permission
-from litoral_trace.auth.sessions import create_user_session, revoke_session
 from litoral_trace.db.models import Organization, User
 from litoral_trace.db.tenant import set_tenant_db_context
 from litoral_trace.services.us_lacey_admin import (
@@ -111,57 +108,15 @@ def _verified_platform_admin(us_session: str):
                 status_code=status.HTTP_403_FORBIDDEN,
                 detail="Platform administration is not available for this account.",
             )
-        return identity, user, organization
+        return identity
     finally:
         db.close()
 
 
-@contextmanager
-def _platform_admin_refresh_token(us_session: str) -> Iterator[str]:
-    """Create and always revoke an internal bridge session for one admin request."""
-    identity = resolve_us_lacey_session(us_session)
-    db = get_us_lacey_db_session()
-    issued = None
-    try:
-        set_tenant_db_context(db, identity.organization_id)
-        user = db.execute(
-            select(User).where(
-                User.id == identity.user_id,
-                User.organization_id == identity.organization_id,
-            )
-        ).scalar_one_or_none()
-        organization = db.execute(
-            select(Organization).where(Organization.id == identity.organization_id)
-        ).scalar_one_or_none()
-        if (
-            user is None
-            or organization is None
-            or not user.is_active
-            or not organization.is_active
-            or not has_permission(user.role, Permission.PLATFORM_ADMIN)
-        ):
-            raise HTTPException(
-                status_code=status.HTTP_403_FORBIDDEN,
-                detail="Platform administration is not available for this account.",
-            )
-
-        issued = create_user_session(
-            db,
-            user=user,
-            organization=organization,
-            created_ip=None,
-            user_agent="us-lacey-platform-admin-bridge",
-        )
-        db.commit()
-        yield issued.refresh_token
-    finally:
-        if issued is not None:
-            try:
-                revoke_session(db, refresh_token=issued.refresh_token)
-                db.commit()
-            except Exception:
-                db.rollback()
-        db.close()
+def _platform_admin_refresh_token(us_session: str) -> str:
+    """Return the already-persisted U.S. opaque session after role verification."""
+    _verified_platform_admin(us_session)
+    return us_session
 
 
 def _require_us_session(us_session: str | None) -> str:
@@ -172,10 +127,10 @@ def _require_us_session(us_session: str | None) -> str:
 
 
 def _admin_context(*, request: Request, us_session: str, notice: str | None = None):
-    with _platform_admin_refresh_token(us_session) as refresh_token:
-        accounts = list_us_lacey_accounts_superadmin(refresh_token=refresh_token)
-        users = list_platform_users_superadmin(refresh_token=refresh_token)
-        failed_jobs = list_failed_jobs_superadmin(refresh_token=refresh_token)
+    refresh_token = _platform_admin_refresh_token(us_session)
+    accounts = list_us_lacey_accounts_superadmin(refresh_token=refresh_token)
+    users = list_platform_users_superadmin(refresh_token=refresh_token)
+    failed_jobs = list_failed_jobs_superadmin(refresh_token=refresh_token)
 
     active_count = sum(1 for account in accounts if account.get("account_status") == "ACTIVE")
     pilot_count = sum(1 for account in accounts if account.get("account_status") == "PILOT")
@@ -236,7 +191,6 @@ def platform_admin_page(
 ):
     try:
         session_token = _require_us_session(us_session)
-        _verified_platform_admin(session_token)
         context = _admin_context(
             request=request,
             us_session=session_token,
@@ -270,12 +224,12 @@ def platform_admin_set_status(
             purpose=f"platform-admin-status:{organization_id}",
             submitted_token=csrf_token,
         )
-        with _platform_admin_refresh_token(session_token) as refresh_token:
-            set_us_lacey_account_status_superadmin(
-                refresh_token=refresh_token,
-                organization_id=organization_id,
-                account_status=account_status,
-            )
+        refresh_token = _platform_admin_refresh_token(session_token)
+        set_us_lacey_account_status_superadmin(
+            refresh_token=refresh_token,
+            organization_id=organization_id,
+            account_status=account_status,
+        )
         return RedirectResponse(
             "/admin?notice=Account%20status%20updated",
             status_code=status.HTTP_303_SEE_OTHER,
@@ -300,12 +254,12 @@ def platform_admin_set_limit(
             purpose=f"platform-admin-limit:{organization_id}",
             submitted_token=csrf_token,
         )
-        with _platform_admin_refresh_token(session_token) as refresh_token:
-            set_us_lacey_operation_limit_superadmin(
-                refresh_token=refresh_token,
-                organization_id=organization_id,
-                monthly_operation_limit=monthly_operation_limit,
-            )
+        refresh_token = _platform_admin_refresh_token(session_token)
+        set_us_lacey_operation_limit_superadmin(
+            refresh_token=refresh_token,
+            organization_id=organization_id,
+            monthly_operation_limit=monthly_operation_limit,
+        )
         return RedirectResponse(
             "/admin?notice=Operation%20limit%20updated",
             status_code=status.HTTP_303_SEE_OTHER,
@@ -329,11 +283,11 @@ def platform_admin_reset_pilot(
             purpose=f"platform-admin-reset:{organization_id}",
             submitted_token=csrf_token,
         )
-        with _platform_admin_refresh_token(session_token) as refresh_token:
-            reset_pilot_account_superadmin(
-                refresh_token=refresh_token,
-                organization_id=organization_id,
-            )
+        refresh_token = _platform_admin_refresh_token(session_token)
+        reset_pilot_account_superadmin(
+            refresh_token=refresh_token,
+            organization_id=organization_id,
+        )
         return RedirectResponse(
             "/admin?notice=Pilot%20test%20data%20reset",
             status_code=status.HTTP_303_SEE_OTHER,
@@ -357,11 +311,11 @@ def platform_admin_revoke_sessions(
             purpose=f"platform-admin-revoke:{user_id}",
             submitted_token=csrf_token,
         )
-        with _platform_admin_refresh_token(session_token) as refresh_token:
-            revoke_user_sessions_superadmin(
-                refresh_token=refresh_token,
-                user_id=user_id,
-            )
+        refresh_token = _platform_admin_refresh_token(session_token)
+        revoke_user_sessions_superadmin(
+            refresh_token=refresh_token,
+            user_id=user_id,
+        )
         return RedirectResponse(
             "/admin?notice=User%20sessions%20revoked",
             status_code=status.HTTP_303_SEE_OTHER,

--- a/src/litoral_trace/web/us_lacey_platform_admin.py
+++ b/src/litoral_trace/web/us_lacey_platform_admin.py
@@ -1,32 +1,29 @@
 """Superadmin-only control surface on the deployed U.S. Lacey hostname.
 
-The U.S. portal keeps its opaque-session authentication boundary. Migration 037
-stores that opaque session in ``public.user_sessions``, the same persistent
-session table validated by the 042/044 platform control plane. Admin requests
-therefore verify the U.S. session, verify the persisted platform role inside the
-tenant, and pass that same opaque token server-side to the reviewed
-SECURITY DEFINER capabilities.
+Migration 037 stores the U.S. opaque session in ``public.user_sessions``, the
+same persistent session table validated by the 042/044 platform control plane.
+Admin requests verify that U.S. session and the persisted PLATFORM_ADMIN role,
+then invoke only the reviewed SECURITY DEFINER capabilities through the existing
+isolated U.S. runtime database session.
 
-No generic JWT or synthetic bridge session is issued, and no cross-tenant table
-access is performed directly in application code.
+No generic DATABASE_URL alias, generic JWT, synthetic bridge session, or direct
+cross-tenant table access is introduced.
 """
 from __future__ import annotations
 
+from typing import Any
+
 from fastapi import APIRouter, Cookie, Form, HTTPException, Request, status
 from fastapi.responses import HTMLResponse, RedirectResponse
-from sqlalchemy import select
+from sqlalchemy import select, text
+from sqlalchemy.exc import DBAPIError
 
 from litoral_trace.auth.rbac import Permission, has_permission
 from litoral_trace.db.models import Organization, User
 from litoral_trace.db.tenant import set_tenant_db_context
-from litoral_trace.services.us_lacey_admin import (
-    list_failed_jobs_superadmin,
-    list_platform_users_superadmin,
-    list_us_lacey_accounts_superadmin,
-    reset_pilot_account_superadmin,
-    revoke_user_sessions_superadmin,
-    set_us_lacey_account_status_superadmin,
-    set_us_lacey_operation_limit_superadmin,
+from litoral_trace.services.admin import (
+    _map_platform_db_error,
+    _require_platform_refresh_token_hash,
 )
 from litoral_trace.us_lacey.csrf import (
     UsLaceyCsrfError,
@@ -114,9 +111,128 @@ def _verified_platform_admin(us_session: str):
 
 
 def _platform_admin_refresh_token(us_session: str) -> str:
-    """Return the already-persisted U.S. opaque session after role verification."""
+    """Return the persisted U.S. opaque session after platform-role verification."""
     _verified_platform_admin(us_session)
     return us_session
+
+
+def _control_plane_call(
+    *,
+    refresh_token: str,
+    statement: str,
+    values: dict[str, Any] | None = None,
+    commit: bool = False,
+) -> list[dict[str, Any]]:
+    """Invoke one 042/044 capability through the isolated U.S. runtime session."""
+    db = get_us_lacey_db_session()
+    try:
+        token_hash = _require_platform_refresh_token_hash(refresh_token)
+        parameters = {
+            **(values or {}),
+            "actor_refresh_token_hash": token_hash,
+        }
+        rows = db.execute(text(statement), parameters).mappings().all()
+        if commit:
+            db.commit()
+        return [dict(row) for row in rows]
+    except DBAPIError as exc:
+        db.rollback()
+        _map_platform_db_error(exc)
+        raise
+    finally:
+        db.close()
+
+
+def list_us_lacey_accounts_superadmin(*, refresh_token: str) -> list[dict[str, Any]]:
+    return _control_plane_call(
+        refresh_token=refresh_token,
+        statement=(
+            "SELECT * FROM public.platform_us_lacey_account_overview("
+            ":actor_refresh_token_hash) ORDER BY organization_id"
+        ),
+    )
+
+
+def list_platform_users_superadmin(*, refresh_token: str) -> list[dict[str, Any]]:
+    return _control_plane_call(
+        refresh_token=refresh_token,
+        statement=(
+            "SELECT * FROM public.platform_admin_users("
+            ":actor_refresh_token_hash)"
+        ),
+    )
+
+
+def list_failed_jobs_superadmin(*, refresh_token: str) -> list[dict[str, Any]]:
+    return _control_plane_call(
+        refresh_token=refresh_token,
+        statement=(
+            "SELECT * FROM public.platform_admin_failed_jobs("
+            ":actor_refresh_token_hash)"
+        ),
+    )
+
+
+def set_us_lacey_account_status_superadmin(
+    *, refresh_token: str, organization_id: int, account_status: str
+) -> dict[str, Any]:
+    return _control_plane_call(
+        refresh_token=refresh_token,
+        statement=(
+            "SELECT * FROM public.platform_admin_set_us_lacey_account_status("
+            ":actor_refresh_token_hash, :organization_id, :account_status)"
+        ),
+        values={
+            "organization_id": organization_id,
+            "account_status": account_status,
+        },
+        commit=True,
+    )[0]
+
+
+def set_us_lacey_operation_limit_superadmin(
+    *, refresh_token: str, organization_id: int, monthly_operation_limit: int
+) -> dict[str, Any]:
+    return _control_plane_call(
+        refresh_token=refresh_token,
+        statement=(
+            "SELECT * FROM public.platform_admin_set_us_lacey_operation_limit("
+            ":actor_refresh_token_hash, :organization_id, :monthly_operation_limit)"
+        ),
+        values={
+            "organization_id": organization_id,
+            "monthly_operation_limit": monthly_operation_limit,
+        },
+        commit=True,
+    )[0]
+
+
+def reset_pilot_account_superadmin(
+    *, refresh_token: str, organization_id: int
+) -> dict[str, Any]:
+    return _control_plane_call(
+        refresh_token=refresh_token,
+        statement=(
+            "SELECT * FROM public.platform_admin_reset_pilot_account("
+            ":actor_refresh_token_hash, :organization_id)"
+        ),
+        values={"organization_id": organization_id},
+        commit=True,
+    )[0]
+
+
+def revoke_user_sessions_superadmin(
+    *, refresh_token: str, user_id: int
+) -> dict[str, Any]:
+    return _control_plane_call(
+        refresh_token=refresh_token,
+        statement=(
+            "SELECT * FROM public.platform_admin_revoke_user_sessions("
+            ":actor_refresh_token_hash, :user_id)"
+        ),
+        values={"user_id": user_id},
+        commit=True,
+    )[0]
 
 
 def _require_us_session(us_session: str | None) -> str:

--- a/src/litoral_trace/web/us_lacey_platform_admin.py
+++ b/src/litoral_trace/web/us_lacey_platform_admin.py
@@ -353,6 +353,15 @@ def platform_admin_set_status(
             submitted_token=csrf_token,
         )
         refresh_token = _platform_admin_refresh_token(session_token)
+        identity = resolve_us_lacey_session(session_token)
+        if (
+            account_status.strip().upper() == "SUSPENDED"
+            and organization_id == identity.organization_id
+        ):
+            return _safe_error(
+                "You cannot suspend the organization that owns your current admin session.",
+                status_code=status.HTTP_409_CONFLICT,
+            )
         set_us_lacey_account_status_superadmin(
             refresh_token=refresh_token,
             organization_id=organization_id,

--- a/src/litoral_trace/web/us_lacey_platform_admin.py
+++ b/src/litoral_trace/web/us_lacey_platform_admin.py
@@ -1,0 +1,372 @@
+"""Superadmin-only control surface on the deployed U.S. Lacey hostname.
+
+The U.S. portal keeps its opaque-session authentication boundary. For each admin
+request we verify that opaque session, verify the persisted platform role inside
+the tenant, create a short-lived internal generic refresh session only long
+enough to call the already-reviewed SECURITY DEFINER control-plane functions,
+and revoke that bridge session before returning.
+
+No generic JWT is issued to the browser and no cross-tenant table access is
+performed directly in application code.
+"""
+from __future__ import annotations
+
+from contextlib import contextmanager
+from typing import Iterator
+
+from fastapi import APIRouter, Cookie, Form, HTTPException, Request, status
+from fastapi.responses import HTMLResponse, RedirectResponse
+from sqlalchemy import select
+
+from litoral_trace.auth.rbac import Permission, has_permission
+from litoral_trace.auth.sessions import create_user_session, revoke_session
+from litoral_trace.db.models import Organization, User
+from litoral_trace.db.tenant import set_tenant_db_context
+from litoral_trace.services.us_lacey_admin import (
+    list_failed_jobs_superadmin,
+    list_platform_users_superadmin,
+    list_us_lacey_accounts_superadmin,
+    reset_pilot_account_superadmin,
+    revoke_user_sessions_superadmin,
+    set_us_lacey_account_status_superadmin,
+    set_us_lacey_operation_limit_superadmin,
+)
+from litoral_trace.us_lacey.csrf import (
+    UsLaceyCsrfError,
+    us_lacey_csrf_token,
+    verify_us_lacey_csrf,
+)
+from litoral_trace.us_lacey.db import get_us_lacey_db_session
+from litoral_trace.us_lacey.portal_auth import (
+    US_LACEY_SESSION_COOKIE,
+    UsLaceyPortalAuthError,
+    resolve_us_lacey_session,
+)
+from litoral_trace.web.templates import templates
+
+
+router = APIRouter(tags=["Platform Admin"])
+
+
+def _login_redirect(*, clear_cookie: bool = False) -> RedirectResponse:
+    response = RedirectResponse("/login", status_code=status.HTTP_303_SEE_OTHER)
+    if clear_cookie:
+        response.delete_cookie(US_LACEY_SESSION_COOKIE, path="/")
+    return response
+
+
+def _access_denied() -> HTMLResponse:
+    return HTMLResponse(
+        status_code=status.HTTP_403_FORBIDDEN,
+        content=(
+            "<!doctype html><html><head><meta charset='utf-8'>"
+            "<title>Access denied</title></head><body>"
+            "<h1>Access denied</h1>"
+            "<p>This account does not have platform-administration access.</p>"
+            "<p><a href='/operations'>Return to operations</a></p>"
+            "</body></html>"
+        ),
+        headers={"Cache-Control": "no-store, max-age=0"},
+    )
+
+
+def _safe_error(message: str, *, status_code: int = 400) -> HTMLResponse:
+    return HTMLResponse(
+        status_code=status_code,
+        content=(
+            "<!doctype html><html><head><meta charset='utf-8'>"
+            "<title>Admin action unavailable</title></head><body>"
+            "<h1>Admin action unavailable</h1>"
+            f"<p>{message}</p>"
+            "<p><a href='/admin'>Return to admin</a></p>"
+            "</body></html>"
+        ),
+        headers={"Cache-Control": "no-store, max-age=0"},
+    )
+
+
+def _verified_platform_admin(us_session: str):
+    """Resolve the U.S. session and verify persisted PLATFORM_ADMIN capability."""
+    identity = resolve_us_lacey_session(us_session)
+    db = get_us_lacey_db_session()
+    try:
+        set_tenant_db_context(db, identity.organization_id)
+        user = db.execute(
+            select(User).where(
+                User.id == identity.user_id,
+                User.organization_id == identity.organization_id,
+            )
+        ).scalar_one_or_none()
+        organization = db.execute(
+            select(Organization).where(Organization.id == identity.organization_id)
+        ).scalar_one_or_none()
+        if (
+            user is None
+            or organization is None
+            or not user.is_active
+            or not organization.is_active
+            or not has_permission(user.role, Permission.PLATFORM_ADMIN)
+        ):
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail="Platform administration is not available for this account.",
+            )
+        return identity, user, organization
+    finally:
+        db.close()
+
+
+@contextmanager
+def _platform_admin_refresh_token(us_session: str) -> Iterator[str]:
+    """Create and always revoke an internal bridge session for one admin request."""
+    identity = resolve_us_lacey_session(us_session)
+    db = get_us_lacey_db_session()
+    issued = None
+    try:
+        set_tenant_db_context(db, identity.organization_id)
+        user = db.execute(
+            select(User).where(
+                User.id == identity.user_id,
+                User.organization_id == identity.organization_id,
+            )
+        ).scalar_one_or_none()
+        organization = db.execute(
+            select(Organization).where(Organization.id == identity.organization_id)
+        ).scalar_one_or_none()
+        if (
+            user is None
+            or organization is None
+            or not user.is_active
+            or not organization.is_active
+            or not has_permission(user.role, Permission.PLATFORM_ADMIN)
+        ):
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail="Platform administration is not available for this account.",
+            )
+
+        issued = create_user_session(
+            db,
+            user=user,
+            organization=organization,
+            created_ip=None,
+            user_agent="us-lacey-platform-admin-bridge",
+        )
+        db.commit()
+        yield issued.refresh_token
+    finally:
+        if issued is not None:
+            try:
+                revoke_session(db, refresh_token=issued.refresh_token)
+                db.commit()
+            except Exception:
+                db.rollback()
+        db.close()
+
+
+def _require_us_session(us_session: str | None) -> str:
+    if not us_session:
+        raise UsLaceyPortalAuthError("Sign in to continue.", code="session_invalid")
+    resolve_us_lacey_session(us_session)
+    return us_session
+
+
+def _admin_context(*, request: Request, us_session: str, notice: str | None = None):
+    with _platform_admin_refresh_token(us_session) as refresh_token:
+        accounts = list_us_lacey_accounts_superadmin(refresh_token=refresh_token)
+        users = list_platform_users_superadmin(refresh_token=refresh_token)
+        failed_jobs = list_failed_jobs_superadmin(refresh_token=refresh_token)
+
+    active_count = sum(1 for account in accounts if account.get("account_status") == "ACTIVE")
+    pilot_count = sum(1 for account in accounts if account.get("account_status") == "PILOT")
+    pending_count = sum(
+        1
+        for account in accounts
+        if account.get("account_status") in {"PENDING_EMAIL", "PAYMENT_PENDING"}
+    )
+    failed_job_count = sum(int(account.get("failed_jobs") or 0) for account in accounts)
+
+    return {
+        "request": request,
+        "authenticated": True,
+        "accounts": accounts,
+        "account_count": len(accounts),
+        "active_count": active_count,
+        "pilot_count": pilot_count,
+        "pending_count": pending_count,
+        "failed_job_count": failed_job_count,
+        "users": users,
+        "failed_jobs": failed_jobs,
+        "notice": notice,
+        "status_csrf": {
+            int(account["organization_id"]): us_lacey_csrf_token(
+                session_token=us_session,
+                purpose=f"platform-admin-status:{int(account['organization_id'])}",
+            )
+            for account in accounts
+        },
+        "limit_csrf": {
+            int(account["organization_id"]): us_lacey_csrf_token(
+                session_token=us_session,
+                purpose=f"platform-admin-limit:{int(account['organization_id'])}",
+            )
+            for account in accounts
+        },
+        "reset_csrf": {
+            int(account["organization_id"]): us_lacey_csrf_token(
+                session_token=us_session,
+                purpose=f"platform-admin-reset:{int(account['organization_id'])}",
+            )
+            for account in accounts
+        },
+        "revoke_csrf": {
+            int(user["user_id"]): us_lacey_csrf_token(
+                session_token=us_session,
+                purpose=f"platform-admin-revoke:{int(user['user_id'])}",
+            )
+            for user in users
+        },
+    }
+
+
+@router.get("/admin", response_class=HTMLResponse)
+def platform_admin_page(
+    request: Request,
+    us_session: str | None = Cookie(None, alias=US_LACEY_SESSION_COOKIE),
+):
+    try:
+        session_token = _require_us_session(us_session)
+        _verified_platform_admin(session_token)
+        context = _admin_context(
+            request=request,
+            us_session=session_token,
+            notice=request.query_params.get("notice"),
+        )
+        content = templates.get_template("us_lacey/admin.html").render(**context)
+        return HTMLResponse(
+            content=content,
+            status_code=status.HTTP_200_OK,
+            headers={"Cache-Control": "no-store, max-age=0"},
+        )
+    except UsLaceyPortalAuthError:
+        return _login_redirect(clear_cookie=bool(us_session))
+    except HTTPException as exc:
+        if exc.status_code == status.HTTP_403_FORBIDDEN:
+            return _access_denied()
+        raise
+
+
+@router.post("/admin/us-lacey/accounts/{organization_id}/status")
+def platform_admin_set_status(
+    organization_id: int,
+    account_status: str = Form(...),
+    csrf_token: str = Form(...),
+    us_session: str | None = Cookie(None, alias=US_LACEY_SESSION_COOKIE),
+):
+    try:
+        session_token = _require_us_session(us_session)
+        verify_us_lacey_csrf(
+            session_token=session_token,
+            purpose=f"platform-admin-status:{organization_id}",
+            submitted_token=csrf_token,
+        )
+        with _platform_admin_refresh_token(session_token) as refresh_token:
+            set_us_lacey_account_status_superadmin(
+                refresh_token=refresh_token,
+                organization_id=organization_id,
+                account_status=account_status,
+            )
+        return RedirectResponse(
+            "/admin?notice=Account%20status%20updated",
+            status_code=status.HTTP_303_SEE_OTHER,
+        )
+    except UsLaceyPortalAuthError:
+        return _login_redirect(clear_cookie=bool(us_session))
+    except UsLaceyCsrfError:
+        return _safe_error("The admin form expired. Refresh and try again.", status_code=403)
+
+
+@router.post("/admin/us-lacey/accounts/{organization_id}/operation-limit")
+def platform_admin_set_limit(
+    organization_id: int,
+    monthly_operation_limit: int = Form(...),
+    csrf_token: str = Form(...),
+    us_session: str | None = Cookie(None, alias=US_LACEY_SESSION_COOKIE),
+):
+    try:
+        session_token = _require_us_session(us_session)
+        verify_us_lacey_csrf(
+            session_token=session_token,
+            purpose=f"platform-admin-limit:{organization_id}",
+            submitted_token=csrf_token,
+        )
+        with _platform_admin_refresh_token(session_token) as refresh_token:
+            set_us_lacey_operation_limit_superadmin(
+                refresh_token=refresh_token,
+                organization_id=organization_id,
+                monthly_operation_limit=monthly_operation_limit,
+            )
+        return RedirectResponse(
+            "/admin?notice=Operation%20limit%20updated",
+            status_code=status.HTTP_303_SEE_OTHER,
+        )
+    except UsLaceyPortalAuthError:
+        return _login_redirect(clear_cookie=bool(us_session))
+    except UsLaceyCsrfError:
+        return _safe_error("The admin form expired. Refresh and try again.", status_code=403)
+
+
+@router.post("/admin/us-lacey/accounts/{organization_id}/reset-pilot")
+def platform_admin_reset_pilot(
+    organization_id: int,
+    csrf_token: str = Form(...),
+    us_session: str | None = Cookie(None, alias=US_LACEY_SESSION_COOKIE),
+):
+    try:
+        session_token = _require_us_session(us_session)
+        verify_us_lacey_csrf(
+            session_token=session_token,
+            purpose=f"platform-admin-reset:{organization_id}",
+            submitted_token=csrf_token,
+        )
+        with _platform_admin_refresh_token(session_token) as refresh_token:
+            reset_pilot_account_superadmin(
+                refresh_token=refresh_token,
+                organization_id=organization_id,
+            )
+        return RedirectResponse(
+            "/admin?notice=Pilot%20test%20data%20reset",
+            status_code=status.HTTP_303_SEE_OTHER,
+        )
+    except UsLaceyPortalAuthError:
+        return _login_redirect(clear_cookie=bool(us_session))
+    except UsLaceyCsrfError:
+        return _safe_error("The admin form expired. Refresh and try again.", status_code=403)
+
+
+@router.post("/admin/users/{user_id}/revoke-sessions")
+def platform_admin_revoke_sessions(
+    user_id: int,
+    csrf_token: str = Form(...),
+    us_session: str | None = Cookie(None, alias=US_LACEY_SESSION_COOKIE),
+):
+    try:
+        session_token = _require_us_session(us_session)
+        verify_us_lacey_csrf(
+            session_token=session_token,
+            purpose=f"platform-admin-revoke:{user_id}",
+            submitted_token=csrf_token,
+        )
+        with _platform_admin_refresh_token(session_token) as refresh_token:
+            revoke_user_sessions_superadmin(
+                refresh_token=refresh_token,
+                user_id=user_id,
+            )
+        return RedirectResponse(
+            "/admin?notice=User%20sessions%20revoked",
+            status_code=status.HTTP_303_SEE_OTHER,
+        )
+    except UsLaceyPortalAuthError:
+        return _login_redirect(clear_cookie=bool(us_session))
+    except UsLaceyCsrfError:
+        return _safe_error("The admin form expired. Refresh and try again.", status_code=403)

--- a/src/litoral_trace/web/us_lacey_unified_app.py
+++ b/src/litoral_trace/web/us_lacey_unified_app.py
@@ -10,18 +10,6 @@ plus /admin for an authenticated persisted platform superadmin.
 """
 from __future__ import annotations
 
-import os
-
-# The U.S. deployment intentionally stores its runtime URL under the isolated
-# US_LACEY_* namespace. The reviewed 042/044 owner-control services reuse the
-# generic PostgreSQL session factory, so on this unified process only we alias
-# the already-present runtime URL internally. No secret leaves the process and
-# no migration/owner credential is introduced.
-if not os.environ.get("DATABASE_URL") and os.environ.get("US_LACEY_DATABASE_URL"):
-    os.environ["DATABASE_URL"] = os.environ["US_LACEY_DATABASE_URL"]
-if not os.environ.get("ENVIRONMENT") and os.environ.get("US_LACEY_ENVIRONMENT"):
-    os.environ["ENVIRONMENT"] = os.environ["US_LACEY_ENVIRONMENT"]
-
 from fastapi import Request, Response
 
 from litoral_trace.us_lacey.portal_auth import US_LACEY_SESSION_COOKIE
@@ -32,7 +20,9 @@ from litoral_trace.web.us_lacey_platform_admin import router as platform_admin_r
 
 
 # Public marketing/sample, payment-provider and superadmin routes are additive
-# and do not shadow the certified customer portal endpoints.
+# and do not shadow the certified customer portal endpoints. The admin router
+# uses get_us_lacey_db_session() directly so DATABASE_URL remains untouched and
+# the existing U.S.-vs-generic database collision sentinel keeps working.
 app.include_router(lacey_router)
 app.include_router(lemon_billing_router)
 app.include_router(platform_admin_router)

--- a/src/litoral_trace/web/us_lacey_unified_app.py
+++ b/src/litoral_trace/web/us_lacey_unified_app.py
@@ -1,15 +1,26 @@
 """Unified free-tier entrypoint for the customer-facing U.S. Lacey product.
 
 This module composes the already-certified private portal/inline-worker runtime
-with the public U.S. Lacey marketing, synthetic-demo and hosted-billing routes.
-It deliberately keeps the operational application unchanged: authenticated
-traffic, PostgreSQL RLS, S3 probes, worker lifecycle and review routes continue
-to be owned by ``us_lacey_free_app``.
+with the public U.S. Lacey marketing, synthetic-demo, hosted-billing and
+superadmin-only owner-control routes.
 
 The composition exists so one customer-facing hostname can serve the full flow:
-landing -> sample -> signup -> verification -> login -> billing -> operations.
+landing -> sample -> signup -> verification -> login -> billing -> operations,
+plus /admin for an authenticated persisted platform superadmin.
 """
 from __future__ import annotations
+
+import os
+
+# The U.S. deployment intentionally stores its runtime URL under the isolated
+# US_LACEY_* namespace. The reviewed 042/044 owner-control services reuse the
+# generic PostgreSQL session factory, so on this unified process only we alias
+# the already-present runtime URL internally. No secret leaves the process and
+# no migration/owner credential is introduced.
+if not os.environ.get("DATABASE_URL") and os.environ.get("US_LACEY_DATABASE_URL"):
+    os.environ["DATABASE_URL"] = os.environ["US_LACEY_DATABASE_URL"]
+if not os.environ.get("ENVIRONMENT") and os.environ.get("US_LACEY_ENVIRONMENT"):
+    os.environ["ENVIRONMENT"] = os.environ["US_LACEY_ENVIRONMENT"]
 
 from fastapi import Request, Response
 
@@ -17,12 +28,14 @@ from litoral_trace.us_lacey.portal_auth import US_LACEY_SESSION_COOKIE
 from litoral_trace.web.lacey_gtm import render_lacey_landing, router as lacey_router
 from litoral_trace.web.us_lacey_free_app import app
 from litoral_trace.web.us_lacey_lemon_billing import router as lemon_billing_router
+from litoral_trace.web.us_lacey_platform_admin import router as platform_admin_router
 
 
-# Public marketing/sample and payment-provider routes are additive and do not
-# shadow the certified portal endpoints (/signup, /login, /billing, ...).
+# Public marketing/sample, payment-provider and superadmin routes are additive
+# and do not shadow the certified customer portal endpoints.
 app.include_router(lacey_router)
 app.include_router(lemon_billing_router)
+app.include_router(platform_admin_router)
 
 
 @app.head("/health", include_in_schema=False)

--- a/tests/test_us_lacey_platform_admin_session_contract.py
+++ b/tests/test_us_lacey_platform_admin_session_contract.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def test_us_lacey_opaque_session_uses_platform_user_sessions_table():
+    migration = Path(
+        "alembic/versions/037_add_us_lacey_portal_auth_functions.py"
+    ).read_text(encoding="utf-8")
+    assert "INSERT INTO public.user_sessions" in migration
+    assert "FROM public.user_sessions AS sessions" in migration
+    assert "us_lacey_portal_session_lookup" in migration
+
+
+def test_control_plane_consumes_hash_of_the_same_raw_session_token():
+    service = Path("src/litoral_trace/services/us_lacey_admin.py").read_text(
+        encoding="utf-8"
+    )
+    assert "_require_platform_refresh_token_hash(refresh_token)" in service
+    assert "actor_refresh_token_hash" in service

--- a/tests/test_us_lacey_platform_admin_surface.py
+++ b/tests/test_us_lacey_platform_admin_surface.py
@@ -1,0 +1,204 @@
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+
+from fastapi import HTTPException
+from fastapi.testclient import TestClient
+
+from litoral_trace.us_lacey.csrf import us_lacey_csrf_token
+from litoral_trace.us_lacey.portal_auth import US_LACEY_SESSION_COOKIE
+import litoral_trace.web.us_lacey_platform_admin as admin_surface
+from litoral_trace.web.us_lacey_unified_app import app
+
+
+client = TestClient(app)
+SESSION = "opaque-us-lacey-superadmin-session"
+
+
+def _identity():
+    return SimpleNamespace(user_id=12, organization_id=14, account_status="PILOT")
+
+
+def _account():
+    return {
+        "organization_id": 14,
+        "legal_name": "Founder Test Organization",
+        "business_type": "IMPORTER",
+        "admin_contact_email": "owner@example.test",
+        "account_status": "PILOT",
+        "payment_provider": "LEMON_SQUEEZY",
+        "payment_status": "PENDING",
+        "subscription_status": "PENDING",
+        "monthly_operation_limit": 25,
+        "used_operations": 0,
+        "queued_jobs": 0,
+        "running_jobs": 0,
+        "retry_jobs": 0,
+        "failed_jobs": 0,
+        "last_payment_event_at": None,
+    }
+
+
+def _user():
+    return {
+        "user_id": 12,
+        "organization_id": 14,
+        "organization_name": "Founder Test Organization",
+        "full_name": "Founder",
+        "email": "owner@example.test",
+        "role": "superadmin",
+        "is_active": True,
+        "created_at": None,
+        "last_login_at": None,
+    }
+
+
+def _patch_admin_reads(monkeypatch, seen_tokens: list[str]):
+    monkeypatch.setattr(admin_surface, "resolve_us_lacey_session", lambda token: _identity())
+
+    def verified_token(token: str) -> str:
+        seen_tokens.append(token)
+        return token
+
+    monkeypatch.setattr(admin_surface, "_platform_admin_refresh_token", verified_token)
+    monkeypatch.setattr(
+        admin_surface,
+        "list_us_lacey_accounts_superadmin",
+        lambda *, refresh_token: [_account()],
+    )
+    monkeypatch.setattr(
+        admin_surface,
+        "list_platform_users_superadmin",
+        lambda *, refresh_token: [_user()],
+    )
+    monkeypatch.setattr(
+        admin_surface,
+        "list_failed_jobs_superadmin",
+        lambda *, refresh_token: [],
+    )
+
+
+def test_admin_without_us_session_redirects_to_portal_login():
+    client.cookies.clear()
+    response = client.get("/admin", follow_redirects=False)
+    assert response.status_code == 303
+    assert response.headers["location"] == "/login"
+
+
+def test_admin_non_superadmin_is_forbidden(monkeypatch):
+    monkeypatch.setattr(admin_surface, "resolve_us_lacey_session", lambda token: _identity())
+
+    def deny(_token: str) -> str:
+        raise HTTPException(status_code=403, detail="not platform admin")
+
+    monkeypatch.setattr(admin_surface, "_platform_admin_refresh_token", deny)
+    client.cookies.set(US_LACEY_SESSION_COOKIE, SESSION)
+    try:
+        response = client.get("/admin", follow_redirects=False)
+    finally:
+        client.cookies.delete(US_LACEY_SESSION_COOKIE)
+    assert response.status_code == 403
+    assert "Access denied" in response.text
+
+
+def test_superadmin_page_reuses_same_us_session_for_control_plane(monkeypatch):
+    seen_tokens: list[str] = []
+    _patch_admin_reads(monkeypatch, seen_tokens)
+    client.cookies.set(US_LACEY_SESSION_COOKIE, SESSION)
+    try:
+        response = client.get("/admin")
+    finally:
+        client.cookies.delete(US_LACEY_SESSION_COOKIE)
+
+    assert response.status_code == 200
+    assert response.headers["cache-control"] == "no-store, max-age=0"
+    assert "Global Platform Admin" in response.text
+    assert "Founder Test Organization" in response.text
+    assert "Processing / errors" in response.text
+    assert seen_tokens == [SESSION]
+
+
+def test_admin_status_mutation_requires_valid_session_bound_csrf(monkeypatch):
+    monkeypatch.setattr(admin_surface, "resolve_us_lacey_session", lambda token: _identity())
+    monkeypatch.setattr(admin_surface, "_platform_admin_refresh_token", lambda token: token)
+    calls: list[tuple[str, int, str]] = []
+
+    def set_status(*, refresh_token: str, organization_id: int, account_status: str):
+        calls.append((refresh_token, organization_id, account_status))
+        return {"organization_id": organization_id, "account_status": account_status}
+
+    monkeypatch.setattr(admin_surface, "set_us_lacey_account_status_superadmin", set_status)
+    client.cookies.set(US_LACEY_SESSION_COOKIE, SESSION)
+    try:
+        invalid = client.post(
+            "/admin/us-lacey/accounts/14/status",
+            data={"account_status": "PILOT", "csrf_token": "invalid"},
+            follow_redirects=False,
+        )
+        valid = client.post(
+            "/admin/us-lacey/accounts/14/status",
+            data={
+                "account_status": "PILOT",
+                "csrf_token": us_lacey_csrf_token(
+                    session_token=SESSION,
+                    purpose="platform-admin-status:14",
+                ),
+            },
+            follow_redirects=False,
+        )
+    finally:
+        client.cookies.delete(US_LACEY_SESSION_COOKIE)
+
+    assert invalid.status_code == 403
+    assert calls == [(SESSION, 14, "PILOT")]
+    assert valid.status_code == 303
+    assert valid.headers["location"].startswith("/admin?notice=")
+
+
+def test_admin_reset_uses_reviewed_control_plane_with_same_session(monkeypatch):
+    monkeypatch.setattr(admin_surface, "resolve_us_lacey_session", lambda token: _identity())
+    monkeypatch.setattr(admin_surface, "_platform_admin_refresh_token", lambda token: token)
+    calls: list[tuple[str, int]] = []
+
+    def reset(*, refresh_token: str, organization_id: int):
+        calls.append((refresh_token, organization_id))
+        return {"operations_deleted": 1, "jobs_deleted": 1}
+
+    monkeypatch.setattr(admin_surface, "reset_pilot_account_superadmin", reset)
+    client.cookies.set(US_LACEY_SESSION_COOKIE, SESSION)
+    try:
+        response = client.post(
+            "/admin/us-lacey/accounts/14/reset-pilot",
+            data={
+                "csrf_token": us_lacey_csrf_token(
+                    session_token=SESSION,
+                    purpose="platform-admin-reset:14",
+                )
+            },
+            follow_redirects=False,
+        )
+    finally:
+        client.cookies.delete(US_LACEY_SESSION_COOKIE)
+
+    assert response.status_code == 303
+    assert calls == [(SESSION, 14)]
+
+
+def test_admin_surface_does_not_create_synthetic_generic_sessions():
+    source = Path("src/litoral_trace/web/us_lacey_platform_admin.py").read_text(
+        encoding="utf-8"
+    )
+    assert "create_user_session" not in source
+    assert "revoke_session" not in source
+    assert "session_jwt" not in source
+
+
+def test_unified_entrypoint_aliases_existing_us_runtime_database_without_literal_secret():
+    source = Path("src/litoral_trace/web/us_lacey_unified_app.py").read_text(
+        encoding="utf-8"
+    )
+    assert 'os.environ["DATABASE_URL"] = os.environ["US_LACEY_DATABASE_URL"]' in source
+    assert 'os.environ["ENVIRONMENT"] = os.environ["US_LACEY_ENVIRONMENT"]' in source
+    assert "postgresql://" not in source
+    assert "MIGRATION_DATABASE_URL" not in source

--- a/tests/test_us_lacey_platform_admin_surface.py
+++ b/tests/test_us_lacey_platform_admin_surface.py
@@ -156,6 +156,37 @@ def test_admin_status_mutation_requires_valid_session_bound_csrf(monkeypatch):
     assert valid.headers["location"].startswith("/admin?notice=")
 
 
+def test_admin_rejects_suspending_acting_admin_organization(monkeypatch):
+    monkeypatch.setattr(admin_surface, "resolve_us_lacey_session", lambda token: _identity())
+    monkeypatch.setattr(admin_surface, "_platform_admin_refresh_token", lambda token: token)
+    calls: list[tuple[str, int, str]] = []
+
+    def set_status(*, refresh_token: str, organization_id: int, account_status: str):
+        calls.append((refresh_token, organization_id, account_status))
+        return {"organization_id": organization_id, "account_status": account_status}
+
+    monkeypatch.setattr(admin_surface, "set_us_lacey_account_status_superadmin", set_status)
+    client.cookies.set(US_LACEY_SESSION_COOKIE, SESSION)
+    try:
+        response = client.post(
+            "/admin/us-lacey/accounts/14/status",
+            data={
+                "account_status": "SUSPENDED",
+                "csrf_token": us_lacey_csrf_token(
+                    session_token=SESSION,
+                    purpose="platform-admin-status:14",
+                ),
+            },
+            follow_redirects=False,
+        )
+    finally:
+        client.cookies.delete(US_LACEY_SESSION_COOKIE)
+
+    assert response.status_code == 409
+    assert "cannot suspend" in response.text.lower()
+    assert calls == []
+
+
 def test_admin_reset_uses_reviewed_control_plane_with_same_session(monkeypatch):
     monkeypatch.setattr(admin_surface, "resolve_us_lacey_session", lambda token: _identity())
     monkeypatch.setattr(admin_surface, "_platform_admin_refresh_token", lambda token: token)

--- a/tests/test_us_lacey_platform_admin_surface.py
+++ b/tests/test_us_lacey_platform_admin_surface.py
@@ -194,11 +194,16 @@ def test_admin_surface_does_not_create_synthetic_generic_sessions():
     assert "session_jwt" not in source
 
 
-def test_unified_entrypoint_aliases_existing_us_runtime_database_without_literal_secret():
-    source = Path("src/litoral_trace/web/us_lacey_unified_app.py").read_text(
+def test_admin_surface_preserves_us_database_collision_sentinel():
+    unified = Path("src/litoral_trace/web/us_lacey_unified_app.py").read_text(
         encoding="utf-8"
     )
-    assert 'os.environ["DATABASE_URL"] = os.environ["US_LACEY_DATABASE_URL"]' in source
-    assert 'os.environ["ENVIRONMENT"] = os.environ["US_LACEY_ENVIRONMENT"]' in source
-    assert "postgresql://" not in source
-    assert "MIGRATION_DATABASE_URL" not in source
+    admin = Path("src/litoral_trace/web/us_lacey_platform_admin.py").read_text(
+        encoding="utf-8"
+    )
+    assert 'os.environ["DATABASE_URL"]' not in unified
+    assert "US_LACEY_DATABASE_URL" not in unified
+    assert "get_us_lacey_db_session" in admin
+    assert "get_db_session" not in admin
+    assert "MIGRATION_DATABASE_URL" not in unified
+    assert "postgresql://" not in unified

--- a/tests/test_us_lacey_platform_admin_surface.py
+++ b/tests/test_us_lacey_platform_admin_surface.py
@@ -190,8 +190,9 @@ def test_admin_surface_does_not_create_synthetic_generic_sessions():
         encoding="utf-8"
     )
     assert "create_user_session" not in source
-    assert "revoke_session" not in source
     assert "session_jwt" not in source
+    assert "from litoral_trace.auth.sessions" not in source
+    assert "get_db_session" not in source
 
 
 def test_admin_surface_preserves_us_database_collision_sentinel():


### PR DESCRIPTION
## Summary
- Exposes a SuperAdmin-only `/admin` surface on the existing deployed U.S. Lacey hostname.
- Reuses the existing U.S. opaque session stored in `public.user_sessions`; no generic JWT or synthetic bridge session is issued.
- Verifies persisted `PLATFORM_ADMIN` role before any owner-control query or mutation.
- Reuses the reviewed 042/044 SECURITY DEFINER control-plane functions for cross-tenant reads and guarded mutations.
- Adds session-bound U.S. CSRF protection for status, limit, PILOT reset and session-revocation actions.
- Executes those capabilities through the existing isolated `get_us_lacey_db_session()` runtime; `DATABASE_URL` remains untouched so the U.S./generic collision sentinel is preserved.

## Scope
- No migration changes.
- No billing changes.
- No ACE/LAWGS/Gate 3.3 changes.
- No new Render service or secret.

## Tests
- Anonymous `/admin` redirects to `/login`.
- Non-superadmin is denied.
- Superadmin page uses the same U.S. opaque session token for the control plane.
- Mutations require valid session-bound CSRF.
- No synthetic generic session creation.
- Contract test proves Migration 037 stores U.S. portal sessions in `public.user_sessions`.
- Isolation contract proves the unified entrypoint does not alias `US_LACEY_DATABASE_URL` into `DATABASE_URL`.