### PR TITLE
fix(admin): keep owner authorization inside control-plane capabilities

### DIFF
--- a/src/litoral_trace/web/us_lacey_platform_admin.py
+++ b/src/litoral_trace/web/us_lacey_platform_admin.py
@@ -2,12 +2,14 @@
 
 Migration 037 stores the U.S. opaque session in ``public.user_sessions``, the
 same persistent session table validated by the 042/044 platform control plane.
-Admin requests verify that U.S. session and the persisted PLATFORM_ADMIN role,
-then invoke only the reviewed SECURITY DEFINER capabilities through the existing
-isolated U.S. runtime database session.
+Admin requests reuse that U.S. session and invoke only the reviewed
+SECURITY DEFINER capabilities through the existing isolated U.S. runtime
+database session. Those capabilities validate the persisted platform-admin role
+before returning cross-tenant data or applying a mutation.
 
-No generic DATABASE_URL alias, generic JWT, synthetic bridge session, or direct
-cross-tenant table access is introduced.
+No generic DATABASE_URL alias, generic JWT, synthetic bridge session, direct
+cross-tenant table access, or direct runtime SELECT on protected identity tables
+is introduced.
 """
 from __future__ import annotations
 
@@ -15,12 +17,9 @@ from typing import Any
 
 from fastapi import APIRouter, Cookie, Form, HTTPException, Request, status
 from fastapi.responses import HTMLResponse, RedirectResponse
-from sqlalchemy import select, text
+from sqlalchemy import text
 from sqlalchemy.exc import DBAPIError
 
-from litoral_trace.auth.rbac import Permission, has_permission
-from litoral_trace.db.models import Organization, User
-from litoral_trace.db.tenant import set_tenant_db_context
 from litoral_trace.services.admin import (
     _map_platform_db_error,
     _require_platform_refresh_token_hash,
@@ -100,40 +99,9 @@ def _safe_error(
     )
 
 
-def _verified_platform_admin(us_session: str):
-    """Resolve the U.S. session and verify persisted PLATFORM_ADMIN capability."""
-    identity = resolve_us_lacey_session(us_session)
-    db = get_us_lacey_db_session()
-    try:
-        set_tenant_db_context(db, identity.organization_id)
-        user = db.execute(
-            select(User).where(
-                User.id == identity.user_id,
-                User.organization_id == identity.organization_id,
-            )
-        ).scalar_one_or_none()
-        organization = db.execute(
-            select(Organization).where(Organization.id == identity.organization_id)
-        ).scalar_one_or_none()
-        if (
-            user is None
-            or organization is None
-            or not user.is_active
-            or not organization.is_active
-            or not has_permission(user.role, Permission.PLATFORM_ADMIN)
-        ):
-            raise HTTPException(
-                status_code=status.HTTP_403_FORBIDDEN,
-                detail="Platform administration is not available for this account.",
-            )
-        return identity
-    finally:
-        db.close()
-
-
 def _platform_admin_refresh_token(us_session: str) -> str:
-    """Return the persisted U.S. opaque session after platform-role verification."""
-    _verified_platform_admin(us_session)
+    """Reuse a valid U.S. session; DB capabilities enforce PLATFORM_ADMIN."""
+    resolve_us_lacey_session(us_session)
     return us_session
 
 

--- a/tests/test_us_lacey_platform_admin_runtime_auth_contract.py
+++ b/tests/test_us_lacey_platform_admin_runtime_auth_contract.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+ADMIN_SURFACE = Path("src/litoral_trace/web/us_lacey_platform_admin.py")
+
+
+def test_admin_runtime_authorization_stays_inside_security_definer_capabilities():
+    source = ADMIN_SURFACE.read_text(encoding="utf-8")
+
+    assert "get_us_lacey_db_session" in source
+    assert "platform_us_lacey_account_overview" in source
+    assert "platform_admin_users" in source
+    assert "platform_admin_failed_jobs" in source
+
+    # The production U.S. runtime role intentionally has no direct SELECT on
+    # protected identity tables. Authorization must therefore be enforced by
+    # the 042/044 SECURITY DEFINER control-plane capabilities, not ORM reads.
+    assert "select(User)" not in source
+    assert "select(Organization)" not in source
+    assert "from litoral_trace.db.models" not in source
+    assert "set_tenant_db_context" not in source
+    assert "Permission.PLATFORM_ADMIN" not in source
+    assert "has_permission" not in source
+
+
+def test_admin_runtime_does_not_bypass_database_isolation_or_session_boundary():
+    source = ADMIN_SURFACE.read_text(encoding="utf-8")
+
+    assert "resolve_us_lacey_session(us_session)" in source
+    assert "_require_platform_refresh_token_hash" in source
+    assert "DATABASE_URL" in source  # only the explicit no-alias/no-direct-access documentation
+    assert 'os.environ["DATABASE_URL"]' not in source
+    assert "get_db_session" not in source
+    assert "create_user_session" not in source


### PR DESCRIPTION
## Production hotfix

The first deployed `/admin` build exposed a runtime privilege mismatch: the U.S. application role correctly has no direct `SELECT` privilege on `public.users`, but the HTTP admin surface performed an ORM identity read before invoking the reviewed 042/044 control-plane capabilities. Authenticated founder requests therefore returned HTTP 500 with `permission denied for table users`.

This hotfix:
- removes direct runtime reads of protected `users` / `organizations` identity tables from the admin surface;
- keeps the existing opaque U.S. portal session boundary;
- leaves platform-role authorization inside the existing audited `SECURITY DEFINER` control-plane capabilities, which validate the actor before returning cross-tenant data or mutating state;
- preserves the U.S. database isolation sentinel, CSRF controls, self-suspension guard, billing behavior, migrations, and Gate 3.2;
- adds a regression contract forbidding protected ORM identity reads from the U.S. admin runtime.

No migration, billing, Lemon, ACE/LAWGS, Gate 3.3, or Render configuration changes.