### PR TITLE
feat(ai): add extraction shadow v1

### DIFF
--- a/src/litoral_trace/lacey_engine/ai_providers.py
+++ b/src/litoral_trace/lacey_engine/ai_providers.py
@@ -1,0 +1,293 @@
+"""Provider adapters for AI Extraction Shadow v1.
+
+Provider choice is runtime configuration only. Qwen/Ollama is the free local path;
+Mistral OCR is the low-cost hosted path. Neither adapter mutates operational data.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+import base64
+from io import BytesIO
+import json
+import mimetypes
+import os
+import time
+from urllib.error import HTTPError, URLError
+from urllib.request import Request, urlopen
+
+from .ai_shadow import (
+    AI_FIELDS,
+    AIExtractionResult,
+    AIShadowError,
+    extraction_result_from_payload,
+)
+
+
+AI_SHADOW_OFF = "OFF"
+AI_SHADOW_SHADOW = "SHADOW"
+PROVIDER_QWEN_OLLAMA = "qwen_ollama"
+PROVIDER_MISTRAL_OCR = "mistral_ocr"
+
+
+@dataclass(frozen=True, slots=True)
+class AIProviderConfig:
+    mode: str
+    provider: str
+    model: str
+    base_url: str
+    api_key: str | None
+    timeout_seconds: float
+    max_pages: int
+    allow_external: bool
+
+    @classmethod
+    def from_env(cls) -> "AIProviderConfig":
+        mode = os.getenv("US_LACEY_AI_SHADOW_MODE", "off").strip().upper()
+        if mode not in {AI_SHADOW_OFF, AI_SHADOW_SHADOW}:
+            mode = AI_SHADOW_OFF
+        provider = os.getenv("US_LACEY_AI_PROVIDER", PROVIDER_QWEN_OLLAMA).strip().lower()
+        if provider == PROVIDER_MISTRAL_OCR:
+            default_model = "mistral-ocr-latest"
+            default_url = "https://api.mistral.ai/v1/ocr"
+        else:
+            provider = PROVIDER_QWEN_OLLAMA
+            default_model = "qwen2.5vl:7b"
+            default_url = "http://127.0.0.1:11434/api/chat"
+        model = os.getenv("US_LACEY_AI_MODEL", default_model).strip() or default_model
+        base_url = os.getenv("US_LACEY_AI_BASE_URL", default_url).strip() or default_url
+        api_key = os.getenv("US_LACEY_AI_API_KEY", "").strip() or None
+        try:
+            timeout_seconds = max(5.0, min(float(os.getenv("US_LACEY_AI_TIMEOUT_SECONDS", "90")), 300.0))
+        except ValueError:
+            timeout_seconds = 90.0
+        try:
+            max_pages = max(1, min(int(os.getenv("US_LACEY_AI_MAX_PAGES", "8")), 32))
+        except ValueError:
+            max_pages = 8
+        allow_external = os.getenv("US_LACEY_AI_ALLOW_EXTERNAL", "0").strip().lower() in {"1", "true", "yes", "on"}
+        return cls(mode, provider, model, base_url, api_key, timeout_seconds, max_pages, allow_external)
+
+
+def ai_shadow_enabled(config: AIProviderConfig | None = None) -> bool:
+    return (config or AIProviderConfig.from_env()).mode == AI_SHADOW_SHADOW
+
+
+def ai_shadow_engine_version(config: AIProviderConfig) -> str:
+    raw = f"ai-shadow-v1:{config.provider}:{config.model}"
+    return raw[:100]
+
+
+_CANDIDATE_SCHEMA = {
+    "type": "object",
+    "additionalProperties": False,
+    "properties": {
+        "candidates": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "additionalProperties": False,
+                "properties": {
+                    "field_key": {"type": "string", "enum": list(AI_FIELDS)},
+                    "value": {"type": "string"},
+                    "evidence_class": {"type": "string", "enum": ["EXPLICIT", "DERIVED", "INFERRED"]},
+                    "page": {"type": "integer", "minimum": 1},
+                    "source_text": {"type": "string"},
+                    "confidence": {"type": "number", "minimum": 0, "maximum": 1},
+                    "bbox": {
+                        "anyOf": [
+                            {"type": "array", "minItems": 4, "maxItems": 4, "items": {"type": "number"}},
+                            {"type": "null"},
+                        ]
+                    },
+                    "reason": {"anyOf": [{"type": "string"}, {"type": "null"}]},
+                },
+                "required": ["field_key", "value", "evidence_class", "page", "source_text", "confidence", "bbox", "reason"],
+            },
+        }
+    },
+    "required": ["candidates"],
+}
+
+_PROMPT = """Extract candidate values for a U.S. Lacey Act declaration review from the supplied document.
+Return only fields supported by the document and only the JSON schema requested.
+Rules:
+- Every candidate needs the exact source text and 1-indexed page number.
+- EXPLICIT means the value is stated in the document.
+- DERIVED is allowed only for a deterministic transformation of explicit text.
+- INFERRED means reasoning beyond explicit evidence; mark it INFERRED even if plausible.
+- Never infer country_of_harvest from country of origin, exporter address, manufacturer address, port of lading, vessel route, or shipper location.
+- Never use shipment gross weight as plant_quantity unless the document explicitly identifies it as the quantity of plant material for the declaration.
+- Never invent HTS, MID/manufacturer_id, filing entry reference, or importer information.
+- Generic labels such as Seal Number, Equipment Description, City, State Province, Zip Code, Marks and Numbers, or a URL are not container_number, consignee_name, or description values.
+- Prefer exact documentary evidence over contextual guesses.
+- If a field is absent, emit no candidate for that field.
+"""
+
+
+def _post_json(*, url: str, payload: dict[str, object], timeout: float, headers: dict[str, str] | None = None) -> dict[str, object]:
+    body = json.dumps(payload).encode("utf-8")
+    merged_headers = {"Content-Type": "application/json", "Accept": "application/json"}
+    if headers:
+        merged_headers.update(headers)
+    request = Request(url, data=body, headers=merged_headers, method="POST")
+    try:
+        with urlopen(request, timeout=timeout) as response:
+            raw = response.read()
+    except HTTPError as exc:
+        raise AIShadowError(f"AI provider returned HTTP {exc.code}.") from exc
+    except (URLError, TimeoutError, OSError) as exc:
+        raise AIShadowError("AI provider request failed.") from exc
+    try:
+        parsed = json.loads(raw.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise AIShadowError("AI provider returned invalid JSON.") from exc
+    if not isinstance(parsed, dict):
+        raise AIShadowError("AI provider returned an invalid response object.")
+    return parsed
+
+
+def _render_pdf_pages(content: bytes, max_pages: int) -> list[bytes]:
+    try:
+        import pypdfium2 as pdfium
+    except ImportError as exc:
+        raise AIShadowError("PDF vision rendering is unavailable.") from exc
+    try:
+        document = pdfium.PdfDocument(content)
+        rendered: list[bytes] = []
+        for index in range(min(len(document), max_pages)):
+            page = document[index]
+            bitmap = page.render(scale=1.5)
+            image = bitmap.to_pil()
+            stream = BytesIO()
+            image.save(stream, format="PNG")
+            rendered.append(stream.getvalue())
+        return rendered
+    except Exception as exc:
+        raise AIShadowError("Unable to render PDF pages for local vision extraction.") from exc
+
+
+def _document_images(filename: str, content: bytes, max_pages: int) -> list[bytes]:
+    lower = filename.casefold()
+    if content.startswith(b"%PDF") or lower.endswith(".pdf"):
+        return _render_pdf_pages(content, max_pages)
+    if lower.endswith((".png", ".jpg", ".jpeg", ".webp")):
+        return [content]
+    raise AIShadowError("Qwen/Ollama shadow v1 supports PDF and image documents only.")
+
+
+class QwenOllamaProvider:
+    name = PROVIDER_QWEN_OLLAMA
+
+    def __init__(self, config: AIProviderConfig) -> None:
+        self.config = config
+        self.model = config.model
+
+    def extract(self, *, filename: str, content: bytes) -> AIExtractionResult:
+        images = _document_images(filename, content, self.config.max_pages)
+        candidates: list[dict[str, object]] = []
+        started = time.monotonic()
+        for page_number, image in enumerate(images, start=1):
+            payload = {
+                "model": self.model,
+                "stream": False,
+                "format": _CANDIDATE_SCHEMA,
+                "options": {"temperature": 0},
+                "messages": [
+                    {
+                        "role": "user",
+                        "content": _PROMPT + f"\nThis image is page {page_number}. Every candidate page must be {page_number}.",
+                        "images": [base64.b64encode(image).decode("ascii")],
+                    }
+                ],
+            }
+            response = _post_json(url=self.config.base_url, payload=payload, timeout=self.config.timeout_seconds)
+            message = response.get("message")
+            if not isinstance(message, dict):
+                raise AIShadowError("Ollama response is missing message content.")
+            content_text = message.get("content")
+            if not isinstance(content_text, str):
+                raise AIShadowError("Ollama response content is invalid.")
+            try:
+                page_payload = json.loads(content_text)
+            except json.JSONDecodeError as exc:
+                raise AIShadowError("Ollama structured output is invalid JSON.") from exc
+            if not isinstance(page_payload, dict) or not isinstance(page_payload.get("candidates"), list):
+                raise AIShadowError("Ollama structured output is missing candidates.")
+            for item in page_payload["candidates"]:
+                if isinstance(item, dict):
+                    item = dict(item)
+                    item["page"] = page_number
+                    candidates.append(item)
+        elapsed = int((time.monotonic() - started) * 1000)
+        return extraction_result_from_payload(
+            payload={"candidates": candidates}, provider=self.name, model=self.model,
+            page_count=len(images), latency_ms=elapsed,
+        )
+
+
+class MistralOcrProvider:
+    name = PROVIDER_MISTRAL_OCR
+
+    def __init__(self, config: AIProviderConfig) -> None:
+        if not config.allow_external:
+            raise AIShadowError("External AI provider is disabled by policy.")
+        if not config.api_key:
+            raise AIShadowError("Mistral OCR requires US_LACEY_AI_API_KEY.")
+        self.config = config
+        self.model = config.model
+
+    def extract(self, *, filename: str, content: bytes) -> AIExtractionResult:
+        mime = mimetypes.guess_type(filename)[0] or ("application/pdf" if content.startswith(b"%PDF") else "application/octet-stream")
+        data_url = f"data:{mime};base64,{base64.b64encode(content).decode('ascii')}"
+        payload = {
+            "model": self.model,
+            "document": {"type": "document_url", "document_url": data_url},
+            "include_blocks": True,
+            "confidence_scores_granularity": "block",
+            "document_annotation_prompt": _PROMPT,
+            "document_annotation_format": {
+                "type": "json_schema",
+                "json_schema": {"name": "lacey_ai_shadow_v1", "schema": _CANDIDATE_SCHEMA, "strict": True},
+            },
+        }
+        # Document annotations are limited to eight pages. For PDFs, send only
+        # valid 0-indexed pages so short documents never receive out-of-range
+        # page requests and long documents remain fail-bounded in v1.
+        if content.startswith(b"%PDF") or filename.casefold().endswith(".pdf"):
+            try:
+                from pypdf import PdfReader
+                page_count = len(PdfReader(BytesIO(content)).pages)
+            except Exception as exc:
+                raise AIShadowError("Unable to inspect PDF pages for Mistral OCR.") from exc
+            payload["pages"] = list(range(min(page_count, self.config.max_pages, 8)))
+            if not payload["pages"]:
+                raise AIShadowError("PDF contains no processable pages.")
+        started = time.monotonic()
+        response = _post_json(
+            url=self.config.base_url, payload=payload, timeout=self.config.timeout_seconds,
+            headers={"Authorization": f"Bearer {self.config.api_key}"},
+        )
+        annotation = response.get("document_annotation")
+        if isinstance(annotation, str):
+            try:
+                annotation = json.loads(annotation)
+            except json.JSONDecodeError as exc:
+                raise AIShadowError("Mistral document annotation is invalid JSON.") from exc
+        if not isinstance(annotation, dict):
+            raise AIShadowError("Mistral OCR response is missing document_annotation.")
+        elapsed = int((time.monotonic() - started) * 1000)
+        pages = response.get("pages")
+        page_count = len(pages) if isinstance(pages, list) else None
+        return extraction_result_from_payload(
+            payload=annotation, provider=self.name, model=self.model,
+            page_count=page_count, latency_ms=elapsed,
+        )
+
+
+def build_ai_provider(config: AIProviderConfig | None = None):
+    config = config or AIProviderConfig.from_env()
+    if config.mode != AI_SHADOW_SHADOW:
+        return None
+    if config.provider == PROVIDER_MISTRAL_OCR:
+        return MistralOcrProvider(config)
+    return QwenOllamaProvider(config)

--- a/src/litoral_trace/lacey_engine/ai_providers.py
+++ b/src/litoral_trace/lacey_engine/ai_providers.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 import base64
+import hashlib
 from io import BytesIO
 import json
 import mimetypes
@@ -14,6 +15,7 @@ import os
 import time
 from urllib.error import HTTPError, URLError
 from urllib.request import Request, urlopen
+from urllib.parse import urlparse
 
 from .ai_shadow import (
     AI_FIELDS,
@@ -73,8 +75,17 @@ def ai_shadow_enabled(config: AIProviderConfig | None = None) -> bool:
 
 
 def ai_shadow_engine_version(config: AIProviderConfig) -> str:
-    raw = f"ai-shadow-v1:{config.provider}:{config.model}"
-    return raw[:100]
+    # This is a bounded cache identity, not a customer-visible version. Never
+    # include endpoints, credentials, or document data in it.
+    identity = f"v1|{config.provider}|{config.model}|pages={config.max_pages}|schema=lacey_ai_shadow_v1"
+    return f"ai-shadow-v1:{hashlib.sha256(identity.encode('utf-8')).hexdigest()[:32]}"
+
+
+def _is_loopback_qwen_target(base_url: str) -> bool:
+    parsed = urlparse(base_url)
+    if parsed.scheme not in {"http", "https"} or not parsed.hostname:
+        return False
+    return parsed.hostname.casefold() == "localhost" or parsed.hostname in {"127.0.0.1", "::1"}
 
 
 _CANDIDATE_SCHEMA = {
@@ -179,6 +190,8 @@ class QwenOllamaProvider:
     name = PROVIDER_QWEN_OLLAMA
 
     def __init__(self, config: AIProviderConfig) -> None:
+        if not config.allow_external and not _is_loopback_qwen_target(config.base_url):
+            raise AIShadowError("External AI provider is disabled by policy.")
         self.config = config
         self.model = config.model
 

--- a/src/litoral_trace/lacey_engine/ai_shadow.py
+++ b/src/litoral_trace/lacey_engine/ai_shadow.py
@@ -1,0 +1,333 @@
+"""AI Extraction Shadow v1: provider-neutral evidence extraction and Engine 2 comparison.
+
+This module is deliberately infrastructure-independent. AI output is never authoritative:
+it is validated against Engine 2 page text, INFERRED candidates are excluded from trusted
+comparison, and reconciliation produces metrics only.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, replace
+from enum import Enum
+import json
+import re
+import unicodedata
+from typing import Mapping, Protocol
+
+from .domain import BoundingBox, DocumentResolution, EvidenceClass, FieldStatus
+
+AI_SHADOW_SCHEMA_VERSION = "lacey_ai_shadow_v1"
+AI_FIELDS = (
+    "estimated_arrival_date", "bill_of_lading", "container_number", "consignee_name",
+    "consignee_address", "description", "species", "genus", "filing_entry_reference",
+    "manufacturer_id", "hts_code", "country_of_harvest", "plant_quantity", "metric_unit",
+)
+
+class AIShadowError(RuntimeError):
+    """Safe AI-shadow failure."""
+
+class ReconciliationStatus(str, Enum):
+    AGREEMENT = "AGREEMENT"
+    ENGINE2_ONLY = "ENGINE2_ONLY"
+    AI_ONLY = "AI_ONLY"
+    CONFLICT = "CONFLICT"
+    BOTH_MISSING = "BOTH_MISSING"
+    AI_AMBIGUOUS = "AI_AMBIGUOUS"
+    ENGINE2_CONFLICT = "ENGINE2_CONFLICT"
+    AI_REJECTED = "AI_REJECTED"
+
+@dataclass(frozen=True, slots=True)
+class AICandidate:
+    field_key: str
+    value: str
+    normalized_value: str
+    evidence_class: EvidenceClass
+    page: int
+    source_text: str
+    confidence: float
+    provider: str
+    model: str
+    bbox: BoundingBox | None = None
+    reason: str | None = None
+    evidence_verified: bool = False
+
+@dataclass(frozen=True, slots=True)
+class AIExtractionResult:
+    provider: str
+    model: str
+    schema_version: str
+    candidates: tuple[AICandidate, ...]
+    page_count: int | None = None
+    latency_ms: int | None = None
+
+@dataclass(frozen=True, slots=True)
+class ReconciledField:
+    field_key: str
+    status: ReconciliationStatus
+    engine2_value: str | None
+    ai_value: str | None
+    ai_candidate_count: int
+    rejected_ai_candidate_count: int
+
+@dataclass(frozen=True, slots=True)
+class AIShadowComparison:
+    provider: str
+    model: str
+    schema_version: str
+    fields: tuple[ReconciledField, ...]
+    verified_evidence_rate: float
+    inferred_candidate_rate: float
+
+    def field(self, key: str) -> ReconciledField:
+        return next(item for item in self.fields if item.field_key == key)
+
+@dataclass(frozen=True, slots=True)
+class GoldenMetrics:
+    engine2_precision: float
+    engine2_recall: float
+    ai_precision: float
+    ai_recall: float
+    agreement_rate: float
+    ai_false_candidate_rate: float
+    ai_unverified_evidence_rate: float
+    ai_inferred_candidate_rate: float
+    reconciliation_conflicts: int
+    evaluated_fields: int
+
+class AIExtractionProvider(Protocol):
+    name: str
+    model: str
+    def extract(self, *, filename: str, content: bytes) -> AIExtractionResult: ...
+
+_IDENTIFIER_FIELDS = {"bill_of_lading", "container_number", "filing_entry_reference", "manufacturer_id", "hts_code"}
+_CASE_INSENSITIVE_FIELDS = {"consignee_name", "consignee_address", "description", "species", "genus", "country_of_harvest", "metric_unit"}
+
+def _fold(value: str) -> str:
+    text = unicodedata.normalize("NFKD", str(value or ""))
+    text = "".join(ch for ch in text if not unicodedata.combining(ch))
+    return re.sub(r"[^a-z0-9]+", " ", text.casefold()).strip()
+
+def normalize_ai_value(field_key: str, value: str) -> str:
+    text = " ".join(str(value or "").split()).strip()
+    if not text:
+        raise AIShadowError("AI candidate value is empty.")
+    if field_key in _IDENTIFIER_FIELDS:
+        return re.sub(r"[^A-Z0-9.-]+", "", text.upper())
+    return text
+
+def comparison_key(field_key: str, value: str | None) -> str | None:
+    if value is None:
+        return None
+    normalized = normalize_ai_value(field_key, value)
+    return normalized.upper() if field_key in _IDENTIFIER_FIELDS else _fold(normalized)
+
+def _bbox_from_payload(payload: object) -> BoundingBox | None:
+    if payload is None:
+        return None
+    if not isinstance(payload, (list, tuple)) or len(payload) != 4:
+        raise AIShadowError("AI candidate bbox must contain four numbers.")
+    try:
+        x0, top, x1, bottom = (float(item) for item in payload)
+    except (TypeError, ValueError) as exc:
+        raise AIShadowError("AI candidate bbox contains an invalid coordinate.") from exc
+    if x1 < x0 or bottom < top:
+        raise AIShadowError("AI candidate bbox is inverted.")
+    return BoundingBox(x0=x0, top=top, x1=x1, bottom=bottom)
+
+def candidate_from_payload(*, payload: Mapping[str, object], provider: str, model: str) -> AICandidate:
+    field_key = str(payload.get("field_key") or "").strip()
+    if field_key not in AI_FIELDS:
+        raise AIShadowError(f"Unsupported AI field: {field_key or '<empty>'}")
+    value = str(payload.get("value") or "").strip()
+    if not value:
+        raise AIShadowError("AI candidate value is empty.")
+    try:
+        evidence_class = EvidenceClass(str(payload.get("evidence_class") or ""))
+    except ValueError as exc:
+        raise AIShadowError("AI candidate evidence_class is invalid.") from exc
+    try:
+        page = int(payload.get("page") or 0)
+    except (TypeError, ValueError) as exc:
+        raise AIShadowError("AI candidate page is invalid.") from exc
+    if page < 1:
+        raise AIShadowError("AI candidate page must be 1-indexed.")
+    source_text = " ".join(str(payload.get("source_text") or "").split()).strip()
+    if not source_text:
+        raise AIShadowError("AI candidate requires exact source_text.")
+    try:
+        confidence = float(payload.get("confidence", 0.0))
+    except (TypeError, ValueError) as exc:
+        raise AIShadowError("AI candidate confidence is invalid.") from exc
+    if not 0.0 <= confidence <= 1.0:
+        raise AIShadowError("AI candidate confidence must be between 0 and 1.")
+    return AICandidate(
+        field_key=field_key, value=value, normalized_value=normalize_ai_value(field_key, value),
+        evidence_class=evidence_class, page=page, source_text=source_text, confidence=confidence,
+        provider=provider, model=model, bbox=_bbox_from_payload(payload.get("bbox")),
+        reason=str(payload.get("reason") or "").strip() or None,
+    )
+
+def extraction_result_from_payload(*, payload: Mapping[str, object], provider: str, model: str, page_count: int | None = None, latency_ms: int | None = None) -> AIExtractionResult:
+    raw_candidates = payload.get("candidates")
+    if not isinstance(raw_candidates, list):
+        raise AIShadowError("AI response must contain a candidates array.")
+    if not all(isinstance(item, Mapping) for item in raw_candidates):
+        raise AIShadowError("AI response contains a non-object candidate.")
+    candidates = tuple(candidate_from_payload(payload=item, provider=provider, model=model) for item in raw_candidates)
+    return AIExtractionResult(provider, model, AI_SHADOW_SCHEMA_VERSION, candidates, page_count, latency_ms)
+
+def verify_ai_evidence(*, engine2: DocumentResolution, ai: AIExtractionResult) -> AIExtractionResult:
+    page_blocks: dict[int, list[object]] = {}
+    for block in engine2.layout.blocks:
+        if block.page >= 1:
+            page_blocks.setdefault(block.page, []).append(block)
+    verified: list[AICandidate] = []
+    for candidate in ai.candidates:
+        source = _fold(candidate.source_text)
+        blocks = page_blocks.get(candidate.page, [])
+        page_text = _fold("\n".join(block.text for block in blocks))
+        evidence_verified = bool(source) and bool(page_text) and source in page_text
+        # Provider-supplied coordinates are never trusted. When the exact source
+        # text maps to one Engine 2 layout block, inherit that deterministic bbox;
+        # otherwise keep the evidence text verified but expose no rectangle.
+        source_block = next((block for block in blocks if source and source in _fold(block.text)), None)
+        bbox = source_block.bbox if evidence_verified and source_block is not None else None
+        verified.append(replace(candidate, evidence_verified=evidence_verified, bbox=bbox))
+    return replace(ai, candidates=tuple(verified))
+
+def _engine2_value(engine2: DocumentResolution, field_key: str) -> tuple[str | None, bool]:
+    field = engine2.fields.get(field_key)
+    if field is None or field.status is FieldStatus.MISSING:
+        return None, False
+    if field.status is FieldStatus.CONFLICT:
+        return None, True
+    return field.effective_value, False
+
+def _ai_resolution(candidates: tuple[AICandidate, ...], field_key: str) -> tuple[str | None, bool, int, int]:
+    relevant = [candidate for candidate in candidates if candidate.field_key == field_key]
+    trusted = [candidate for candidate in relevant if candidate.evidence_verified and candidate.evidence_class is not EvidenceClass.INFERRED]
+    rejected = len(relevant) - len(trusted)
+    distinct: dict[str, list[AICandidate]] = {}
+    for candidate in trusted:
+        key = comparison_key(field_key, candidate.normalized_value)
+        if key is not None:
+            distinct.setdefault(key, []).append(candidate)
+    if len(distinct) > 1:
+        return None, True, len(relevant), rejected
+    if not distinct:
+        return None, False, len(relevant), rejected
+    winner = max(next(iter(distinct.values())), key=lambda candidate: candidate.confidence)
+    return winner.normalized_value, False, len(relevant), rejected
+
+def reconcile_engine2_with_ai(*, engine2: DocumentResolution, ai: AIExtractionResult) -> AIShadowComparison:
+    ai = verify_ai_evidence(engine2=engine2, ai=ai)
+    rows: list[ReconciledField] = []
+    for field_key in AI_FIELDS:
+        engine_value, engine_conflict = _engine2_value(engine2, field_key)
+        ai_value, ai_ambiguous, candidate_count, rejected_count = _ai_resolution(ai.candidates, field_key)
+        if engine_conflict:
+            status = ReconciliationStatus.ENGINE2_CONFLICT
+        elif ai_ambiguous:
+            status = ReconciliationStatus.AI_AMBIGUOUS
+        elif engine_value is not None and ai_value is not None:
+            status = ReconciliationStatus.AGREEMENT if comparison_key(field_key, engine_value) == comparison_key(field_key, ai_value) else ReconciliationStatus.CONFLICT
+        elif engine_value is not None:
+            status = ReconciliationStatus.ENGINE2_ONLY
+        elif ai_value is not None:
+            status = ReconciliationStatus.AI_ONLY
+        elif candidate_count and rejected_count == candidate_count:
+            status = ReconciliationStatus.AI_REJECTED
+        else:
+            status = ReconciliationStatus.BOTH_MISSING
+        rows.append(ReconciledField(field_key, status, engine_value, ai_value, candidate_count, rejected_count))
+    total = len(ai.candidates)
+    verified = sum(candidate.evidence_verified for candidate in ai.candidates)
+    inferred = sum(candidate.evidence_class is EvidenceClass.INFERRED for candidate in ai.candidates)
+    return AIShadowComparison(ai.provider, ai.model, AI_SHADOW_SCHEMA_VERSION, tuple(rows), verified / total if total else 0.0, inferred / total if total else 0.0)
+
+def _precision_and_recall(*, expected: Mapping[str, str | None], values: Mapping[str, str | None]) -> tuple[float, float, int, int]:
+    claims = correct = expected_present = 0
+    for field_key, expected_value in expected.items():
+        actual = values.get(field_key)
+        if expected_value is not None:
+            expected_present += 1
+        if actual is not None:
+            claims += 1
+            if expected_value is not None and comparison_key(field_key, actual) == comparison_key(field_key, expected_value):
+                correct += 1
+    return (correct / claims if claims else 0.0, correct / expected_present if expected_present else 1.0, claims, correct)
+
+def evaluate_golden(*, engine2: DocumentResolution, ai: AIExtractionResult, expected: Mapping[str, str | None]) -> GoldenMetrics:
+    unknown = set(expected) - set(AI_FIELDS)
+    if unknown:
+        raise AIShadowError(f"Golden expectation contains unsupported fields: {sorted(unknown)}")
+    verified_ai = verify_ai_evidence(engine2=engine2, ai=ai)
+    comparison = reconcile_engine2_with_ai(engine2=engine2, ai=verified_ai)
+    engine_values = {key: _engine2_value(engine2, key)[0] for key in expected}
+    ai_values = {key: _ai_resolution(verified_ai.candidates, key)[0] for key in expected}
+    engine_precision, engine_recall, _, _ = _precision_and_recall(expected=expected, values=engine_values)
+    ai_precision, ai_recall, ai_claims, ai_correct = _precision_and_recall(expected=expected, values=ai_values)
+    comparable = [row for row in comparison.fields if row.field_key in expected and row.engine2_value is not None and row.ai_value is not None]
+    agreements = sum(row.status is ReconciliationStatus.AGREEMENT for row in comparable)
+    all_candidates = [candidate for candidate in verified_ai.candidates if candidate.field_key in expected]
+    unverified = sum(not candidate.evidence_verified for candidate in all_candidates)
+    inferred = sum(candidate.evidence_class is EvidenceClass.INFERRED for candidate in all_candidates)
+    conflicts = sum(row.field_key in expected and row.status in {ReconciliationStatus.CONFLICT, ReconciliationStatus.AI_AMBIGUOUS, ReconciliationStatus.ENGINE2_CONFLICT} for row in comparison.fields)
+    return GoldenMetrics(
+        engine_precision, engine_recall, ai_precision, ai_recall,
+        agreements / len(comparable) if comparable else 0.0,
+        (ai_claims - ai_correct) / ai_claims if ai_claims else 0.0,
+        unverified / len(all_candidates) if all_candidates else 0.0,
+        inferred / len(all_candidates) if all_candidates else 0.0,
+        conflicts, len(expected),
+    )
+
+def serialize_ai_shadow_run(*, ai: AIExtractionResult, comparison: AIShadowComparison) -> dict[str, object]:
+    return {
+        "schema_version": AI_SHADOW_SCHEMA_VERSION,
+        "provider": ai.provider,
+        "model": ai.model,
+        "page_count": ai.page_count,
+        "latency_ms": ai.latency_ms,
+        "candidates": [
+            {
+                "field_key": c.field_key, "value": c.value, "normalized_value": c.normalized_value,
+                "evidence_class": c.evidence_class.value, "page": c.page, "source_text": c.source_text,
+                "confidence": c.confidence,
+                "bbox": [c.bbox.x0, c.bbox.top, c.bbox.x1, c.bbox.bottom] if c.bbox else None,
+                "reason": c.reason, "evidence_verified": c.evidence_verified,
+            } for c in ai.candidates
+        ],
+        "reconciliation": [
+            {
+                "field_key": row.field_key, "status": row.status.value,
+                "engine2_value": row.engine2_value, "ai_value": row.ai_value,
+                "ai_candidate_count": row.ai_candidate_count,
+                "rejected_ai_candidate_count": row.rejected_ai_candidate_count,
+            } for row in comparison.fields
+        ],
+        "summary": {
+            "verified_evidence_rate": comparison.verified_evidence_rate,
+            "inferred_candidate_rate": comparison.inferred_candidate_rate,
+            "agreement_count": sum(row.status is ReconciliationStatus.AGREEMENT for row in comparison.fields),
+            "conflict_count": sum(row.status is ReconciliationStatus.CONFLICT for row in comparison.fields),
+            "ai_only_count": sum(row.status is ReconciliationStatus.AI_ONLY for row in comparison.fields),
+            "engine2_only_count": sum(row.status is ReconciliationStatus.ENGINE2_ONLY for row in comparison.fields),
+        },
+    }
+
+def golden_metrics_to_dict(metrics: GoldenMetrics) -> dict[str, object]:
+    return {
+        "engine2_precision": round(metrics.engine2_precision, 6),
+        "engine2_recall": round(metrics.engine2_recall, 6),
+        "ai_precision": round(metrics.ai_precision, 6),
+        "ai_recall": round(metrics.ai_recall, 6),
+        "agreement_rate": round(metrics.agreement_rate, 6),
+        "ai_false_candidate_rate": round(metrics.ai_false_candidate_rate, 6),
+        "ai_unverified_evidence_rate": round(metrics.ai_unverified_evidence_rate, 6),
+        "ai_inferred_candidate_rate": round(metrics.ai_inferred_candidate_rate, 6),
+        "reconciliation_conflicts": metrics.reconciliation_conflicts,
+        "evaluated_fields": metrics.evaluated_fields,
+    }
+
+def dump_golden_metrics(metrics: GoldenMetrics) -> str:
+    return json.dumps(golden_metrics_to_dict(metrics), indent=2, sort_keys=True)

--- a/src/litoral_trace/lacey_engine/ai_shadow.py
+++ b/src/litoral_trace/lacey_engine/ai_shadow.py
@@ -11,6 +11,7 @@ from enum import Enum
 import json
 import re
 import unicodedata
+from datetime import datetime
 from typing import Mapping, Protocol
 
 from .domain import BoundingBox, DocumentResolution, EvidenceClass, FieldStatus
@@ -118,6 +119,12 @@ def comparison_key(field_key: str, value: str | None) -> str | None:
     if value is None:
         return None
     normalized = normalize_ai_value(field_key, value)
+    if field_key == "estimated_arrival_date":
+        for pattern in ("%Y-%m-%d", "%m/%d/%Y", "%m-%d-%Y"):
+            try:
+                return datetime.strptime(normalized, pattern).date().isoformat()
+            except ValueError:
+                pass
     return normalized.upper() if field_key in _IDENTIFIER_FIELDS else _fold(normalized)
 
 def _bbox_from_payload(payload: object) -> BoundingBox | None:

--- a/src/litoral_trace/lacey_engine/ai_shadow_cli.py
+++ b/src/litoral_trace/lacey_engine/ai_shadow_cli.py
@@ -1,0 +1,56 @@
+"""CLI for private/local AI-shadow golden evaluation.
+
+Example:
+  python -m litoral_trace.lacey_engine.ai_shadow_cli \
+    --file tests/fixtures/import_info_wood_brokerage_real.pdf \
+    --expected /path/to/private-golden-expectations.json \
+    --role SUPPLIER_SHEET
+"""
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+import sys
+
+from .ai_providers import AIProviderConfig, build_ai_provider
+from .ai_shadow import dump_golden_metrics, evaluate_golden, reconcile_engine2_with_ai
+from .pipeline import process_document
+
+
+def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Evaluate AI Extraction Shadow v1 against an Engine 2 golden document.")
+    parser.add_argument("--file", required=True, help="Private source document path. The file is not persisted by this CLI.")
+    parser.add_argument("--expected", required=True, help="Private JSON file containing {\"expected\": {field: value|null}}.")
+    parser.add_argument("--role", default=None, help="Optional Engine 2 role hint.")
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parse_args(argv)
+    source_path = Path(args.file)
+    expected_path = Path(args.expected)
+    expected_payload = json.loads(expected_path.read_text(encoding="utf-8"))
+    expected = expected_payload.get("expected")
+    if not isinstance(expected, dict):
+        raise SystemExit("Expected JSON must contain an 'expected' object.")
+    content = source_path.read_bytes()
+    engine2 = process_document(filename=source_path.name, content=content, role_hint=args.role)
+    config = AIProviderConfig.from_env()
+    provider = build_ai_provider(config)
+    if provider is None:
+        raise SystemExit("AI shadow is OFF. Set US_LACEY_AI_SHADOW_MODE=SHADOW.")
+    ai = provider.extract(filename=source_path.name, content=content)
+    comparison = reconcile_engine2_with_ai(engine2=engine2, ai=ai)
+    metrics = evaluate_golden(engine2=engine2, ai=ai, expected=expected)
+    print(dump_golden_metrics(metrics))
+    print(json.dumps({
+        "provider": comparison.provider,
+        "model": comparison.model,
+        "reconciliation": {row.field_key: row.status.value for row in comparison.fields if row.field_key in expected},
+    }, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/litoral_trace/us_lacey/lacey_engine_service.py
+++ b/src/litoral_trace/us_lacey/lacey_engine_service.py
@@ -1,63 +1,379 @@
-"""Tenant-scoped, non-authoritative Engine 2 shadow aggregation."""
+"""Tenant-scoped, non-authoritative Engine 2 and AI extraction shadow aggregation."""
 from __future__ import annotations
+
+from dataclasses import dataclass
 import hashlib
 import json
+import logging
 import os
-from dataclasses import dataclass
+
 from sqlalchemy import select
 from sqlalchemy.orm import Session
-from litoral_trace.db.models import AssuranceDocument, UsLaceyEngineDocumentRun, UsLaceyEngineShipmentRun, UsLaceyOperationDocument, VaultDocument
+
+from litoral_trace.db.models import (
+    AssuranceDocument,
+    UsLaceyEngineDocumentRun,
+    UsLaceyEngineShipmentRun,
+    UsLaceyOperationDocument,
+    VaultDocument,
+)
 from litoral_trace.db.tenant import set_tenant_db_context
+from litoral_trace.lacey_engine.ai_providers import (
+    AIProviderConfig,
+    ai_shadow_enabled,
+    ai_shadow_engine_version,
+    build_ai_provider,
+)
+from litoral_trace.lacey_engine.ai_shadow import (
+    AI_SHADOW_SCHEMA_VERSION,
+    reconcile_engine2_with_ai,
+    serialize_ai_shadow_run,
+    verify_ai_evidence,
+)
 from litoral_trace.lacey_engine.pipeline import ENGINE_VERSION, process_document
-from litoral_trace.lacey_engine.serialization import DOCUMENT_RESOLUTION_SCHEMA_VERSION, SHIPMENT_RESOLUTION_SCHEMA_VERSION, deserialize_document_resolution, serialize_document_resolution, serialize_shipment_resolution
+from litoral_trace.lacey_engine.serialization import (
+    DOCUMENT_RESOLUTION_SCHEMA_VERSION,
+    SHIPMENT_RESOLUTION_SCHEMA_VERSION,
+    deserialize_document_resolution,
+    serialize_document_resolution,
+    serialize_shipment_resolution,
+)
 from litoral_trace.lacey_engine.shipment import LaceyRuleset, ShipmentDocumentInput, process_shipment
 from litoral_trace.services.vault import VaultService
 from litoral_trace.us_lacey.db import get_us_lacey_db_session
 
-ENGINE2_OFF = "OFF"; ENGINE2_SHADOW = "SHADOW"
+ENGINE2_OFF = "OFF"
+ENGINE2_SHADOW = "SHADOW"
+LOGGER = logging.getLogger(__name__)
+
 
 def engine2_mode() -> str:
-    return ENGINE2_SHADOW if os.getenv("US_LACEY_ENGINE2_MODE", "off").strip().upper() == ENGINE2_SHADOW else ENGINE2_OFF
+    return (
+        ENGINE2_SHADOW
+        if os.getenv("US_LACEY_ENGINE2_MODE", "off").strip().upper() == ENGINE2_SHADOW
+        else ENGINE2_OFF
+    )
+
 
 @dataclass(frozen=True, slots=True)
 class ShadowAggregationResult:
     status: str
     shipment_run_id: int | None = None
 
-def source_set_fingerprint(*, organization_id: int, operation_id: int, documents: list[tuple[UsLaceyOperationDocument, VaultDocument]], ruleset_version: str = "lacey_ruleset_2026_01", engine_version: str = ENGINE_VERSION, shipment_schema_version: str = SHIPMENT_RESOLUTION_SCHEMA_VERSION) -> str:
-    items = [{"operation_document_id": link.id, "assurance_document_id": link.assurance_document_id, "version": link.version_number, "sha256": vault.sha256} for link, vault in sorted(documents, key=lambda pair: pair[0].id)]
-    encoded = json.dumps({"organization_id": organization_id, "operation_id": operation_id, "documents": items, "engine_version": engine_version, "ruleset_version": ruleset_version, "shipment_schema_version": shipment_schema_version}, sort_keys=True, separators=(",", ":")).encode()
+
+def source_set_fingerprint(
+    *,
+    organization_id: int,
+    operation_id: int,
+    documents: list[tuple[UsLaceyOperationDocument, VaultDocument]],
+    ruleset_version: str = "lacey_ruleset_2026_01",
+    engine_version: str = ENGINE_VERSION,
+    shipment_schema_version: str = SHIPMENT_RESOLUTION_SCHEMA_VERSION,
+) -> str:
+    items = [
+        {
+            "operation_document_id": link.id,
+            "assurance_document_id": link.assurance_document_id,
+            "version": link.version_number,
+            "sha256": vault.sha256,
+        }
+        for link, vault in sorted(documents, key=lambda pair: pair[0].id)
+    ]
+    encoded = json.dumps(
+        {
+            "organization_id": organization_id,
+            "operation_id": operation_id,
+            "documents": items,
+            "engine_version": engine_version,
+            "ruleset_version": ruleset_version,
+            "shipment_schema_version": shipment_schema_version,
+        },
+        sort_keys=True,
+        separators=(",", ":"),
+    ).encode()
     return hashlib.sha256(encoded).hexdigest()
 
-class UsLaceyEngine2Service:
-    def __init__(self, *, session_factory=get_us_lacey_db_session, vault_service: VaultService,
-                 engine_version: str = ENGINE_VERSION, ruleset: LaceyRuleset = LaceyRuleset()) -> None:
-        self._session_factory = session_factory; self._vault = vault_service
-        self._engine_version = engine_version; self._ruleset = ruleset
 
-    def resolve_operation_with_engine2(self, *, organization_id: int, operation_id: int) -> ShadowAggregationResult:
-        session: Session = self._session_factory(); set_tenant_db_context(session, organization_id)
+class UsLaceyEngine2Service:
+    def __init__(
+        self,
+        *,
+        session_factory=get_us_lacey_db_session,
+        vault_service: VaultService,
+        engine_version: str = ENGINE_VERSION,
+        ruleset: LaceyRuleset = LaceyRuleset(),
+    ) -> None:
+        self._session_factory = session_factory
+        self._vault = vault_service
+        self._engine_version = engine_version
+        self._ruleset = ruleset
+
+    def _run_ai_shadow_document(
+        self,
+        *,
+        config: AIProviderConfig,
+        organization_id: int,
+        operation_id: int,
+        link: UsLaceyOperationDocument,
+        assurance: AssuranceDocument,
+        vault: VaultDocument,
+        engine2_resolution,
+    ) -> None:
+        """Best-effort AI comparison; never changes Engine 2 or authoritative workflow state."""
+        if not ai_shadow_enabled(config):
+            return
+
+        ai_engine_version = ai_shadow_engine_version(config)
+        session: Session = self._session_factory()
         try:
-            rows = session.execute(select(UsLaceyOperationDocument, AssuranceDocument, VaultDocument).join(AssuranceDocument, (AssuranceDocument.id == UsLaceyOperationDocument.assurance_document_id) & (AssuranceDocument.organization_id == UsLaceyOperationDocument.organization_id)).join(VaultDocument, (VaultDocument.id == AssuranceDocument.vault_document_id) & (VaultDocument.organization_id == AssuranceDocument.organization_id)).where(UsLaceyOperationDocument.organization_id == organization_id, UsLaceyOperationDocument.operation_id == operation_id, UsLaceyOperationDocument.is_current.is_(True)).order_by(UsLaceyOperationDocument.id)).all()
+            set_tenant_db_context(session, organization_id)
+            succeeded = session.scalar(
+                select(UsLaceyEngineDocumentRun).where(
+                    UsLaceyEngineDocumentRun.organization_id == organization_id,
+                    UsLaceyEngineDocumentRun.assurance_document_id == assurance.id,
+                    UsLaceyEngineDocumentRun.source_sha256 == vault.sha256,
+                    UsLaceyEngineDocumentRun.engine_version == ai_engine_version,
+                    UsLaceyEngineDocumentRun.schema_version == AI_SHADOW_SCHEMA_VERSION,
+                    UsLaceyEngineDocumentRun.role_hint == link.document_role,
+                    UsLaceyEngineDocumentRun.status == "SUCCEEDED",
+                )
+            )
+            if succeeded is not None:
+                return
+
+            provider = build_ai_provider(config)
+            if provider is None:
+                return
+            with self._vault.materialize_verified_download(
+                organization_id=organization_id,
+                document_id=vault.public_id,
+            ) as download:
+                content = b"".join(download.iter_chunks())
+            ai_result = provider.extract(filename=vault.original_filename, content=content)
+            verified_ai = verify_ai_evidence(engine2=engine2_resolution, ai=ai_result)
+            comparison = reconcile_engine2_with_ai(engine2=engine2_resolution, ai=verified_ai)
+            session.add(
+                UsLaceyEngineDocumentRun(
+                    organization_id=organization_id,
+                    operation_id=operation_id,
+                    operation_document_id=link.id,
+                    assurance_document_id=assurance.id,
+                    engine_version=ai_engine_version,
+                    schema_version=AI_SHADOW_SCHEMA_VERSION,
+                    source_sha256=vault.sha256,
+                    role_hint=link.document_role,
+                    status="SUCCEEDED",
+                    resolution_json=serialize_ai_shadow_run(ai=verified_ai, comparison=comparison),
+                )
+            )
+            session.commit()
+        except Exception:
+            session.rollback()
+            LOGGER.exception(
+                "Lacey AI extraction shadow failed",
+                extra={
+                    "organization_id": organization_id,
+                    "operation_id": operation_id,
+                    "assurance_document_id": assurance.id,
+                    "ai_provider": config.provider,
+                    "ai_model": config.model,
+                },
+            )
+            # Persist one safe failure snapshot for observability. The unique identity
+            # includes status, so a later successful retry can coexist immutably.
+            try:
+                set_tenant_db_context(session, organization_id)
+                failed = session.scalar(
+                    select(UsLaceyEngineDocumentRun).where(
+                        UsLaceyEngineDocumentRun.organization_id == organization_id,
+                        UsLaceyEngineDocumentRun.assurance_document_id == assurance.id,
+                        UsLaceyEngineDocumentRun.source_sha256 == vault.sha256,
+                        UsLaceyEngineDocumentRun.engine_version == ai_engine_version,
+                        UsLaceyEngineDocumentRun.schema_version == AI_SHADOW_SCHEMA_VERSION,
+                        UsLaceyEngineDocumentRun.role_hint == link.document_role,
+                        UsLaceyEngineDocumentRun.status == "FAILED",
+                    )
+                )
+                if failed is None:
+                    session.add(
+                        UsLaceyEngineDocumentRun(
+                            organization_id=organization_id,
+                            operation_id=operation_id,
+                            operation_document_id=link.id,
+                            assurance_document_id=assurance.id,
+                            engine_version=ai_engine_version,
+                            schema_version=AI_SHADOW_SCHEMA_VERSION,
+                            source_sha256=vault.sha256,
+                            role_hint=link.document_role,
+                            status="FAILED",
+                            safe_error_code="AI_EXTRACTION_SHADOW_FAILED",
+                            safe_error_message="AI extraction shadow did not complete.",
+                        )
+                    )
+                    session.commit()
+            except Exception:
+                session.rollback()
+                LOGGER.exception(
+                    "Unable to persist Lacey AI extraction shadow failure",
+                    extra={
+                        "organization_id": organization_id,
+                        "operation_id": operation_id,
+                        "assurance_document_id": assurance.id,
+                    },
+                )
+        finally:
+            session.close()
+
+    def resolve_operation_with_engine2(
+        self,
+        *,
+        organization_id: int,
+        operation_id: int,
+    ) -> ShadowAggregationResult:
+        session: Session = self._session_factory()
+        set_tenant_db_context(session, organization_id)
+        try:
+            rows = session.execute(
+                select(UsLaceyOperationDocument, AssuranceDocument, VaultDocument)
+                .join(
+                    AssuranceDocument,
+                    (AssuranceDocument.id == UsLaceyOperationDocument.assurance_document_id)
+                    & (AssuranceDocument.organization_id == UsLaceyOperationDocument.organization_id),
+                )
+                .join(
+                    VaultDocument,
+                    (VaultDocument.id == AssuranceDocument.vault_document_id)
+                    & (VaultDocument.organization_id == AssuranceDocument.organization_id),
+                )
+                .where(
+                    UsLaceyOperationDocument.organization_id == organization_id,
+                    UsLaceyOperationDocument.operation_id == operation_id,
+                    UsLaceyOperationDocument.is_current.is_(True),
+                )
+                .order_by(UsLaceyOperationDocument.id)
+            ).all()
             pairs = [(row[0], row[2]) for row in rows]
-            fingerprint = source_set_fingerprint(organization_id=organization_id, operation_id=operation_id, documents=pairs, engine_version=self._engine_version, ruleset_version=self._ruleset.version)
-            existing = session.scalar(select(UsLaceyEngineShipmentRun).where(UsLaceyEngineShipmentRun.organization_id == organization_id, UsLaceyEngineShipmentRun.operation_id == operation_id, UsLaceyEngineShipmentRun.source_set_fingerprint == fingerprint, UsLaceyEngineShipmentRun.schema_version == SHIPMENT_RESOLUTION_SCHEMA_VERSION))
-            if existing: return ShadowAggregationResult("SUCCEEDED", existing.id)
-            inputs = []
+            fingerprint = source_set_fingerprint(
+                organization_id=organization_id,
+                operation_id=operation_id,
+                documents=pairs,
+                engine_version=self._engine_version,
+                ruleset_version=self._ruleset.version,
+            )
+            existing = session.scalar(
+                select(UsLaceyEngineShipmentRun).where(
+                    UsLaceyEngineShipmentRun.organization_id == organization_id,
+                    UsLaceyEngineShipmentRun.operation_id == operation_id,
+                    UsLaceyEngineShipmentRun.source_set_fingerprint == fingerprint,
+                    UsLaceyEngineShipmentRun.schema_version == SHIPMENT_RESOLUTION_SCHEMA_VERSION,
+                )
+            )
+
+            ai_config = AIProviderConfig.from_env()
+            inputs: list[ShipmentDocumentInput] = []
             for link, assurance, vault in rows:
-                run = session.scalar(select(UsLaceyEngineDocumentRun).where(UsLaceyEngineDocumentRun.organization_id == organization_id, UsLaceyEngineDocumentRun.assurance_document_id == assurance.id, UsLaceyEngineDocumentRun.source_sha256 == vault.sha256, UsLaceyEngineDocumentRun.engine_version == self._engine_version, UsLaceyEngineDocumentRun.schema_version == DOCUMENT_RESOLUTION_SCHEMA_VERSION, UsLaceyEngineDocumentRun.role_hint == link.document_role, UsLaceyEngineDocumentRun.status == "SUCCEEDED"))
+                run = session.scalar(
+                    select(UsLaceyEngineDocumentRun).where(
+                        UsLaceyEngineDocumentRun.organization_id == organization_id,
+                        UsLaceyEngineDocumentRun.assurance_document_id == assurance.id,
+                        UsLaceyEngineDocumentRun.source_sha256 == vault.sha256,
+                        UsLaceyEngineDocumentRun.engine_version == self._engine_version,
+                        UsLaceyEngineDocumentRun.schema_version == DOCUMENT_RESOLUTION_SCHEMA_VERSION,
+                        UsLaceyEngineDocumentRun.role_hint == link.document_role,
+                        UsLaceyEngineDocumentRun.status == "SUCCEEDED",
+                    )
+                )
                 if run is None:
                     try:
-                        with self._vault.materialize_verified_download(organization_id=organization_id, document_id=vault.public_id) as download:
-                            resolution = process_document(filename=vault.original_filename, content=b"".join(download.iter_chunks()), role_hint=link.document_role)
-                        run = UsLaceyEngineDocumentRun(organization_id=organization_id, operation_id=operation_id, operation_document_id=link.id, assurance_document_id=assurance.id, engine_version=self._engine_version, schema_version=DOCUMENT_RESOLUTION_SCHEMA_VERSION, source_sha256=vault.sha256, role_hint=link.document_role, status="SUCCEEDED", resolution_json=serialize_document_resolution(resolution))
-                        session.add(run); session.flush()
+                        with self._vault.materialize_verified_download(
+                            organization_id=organization_id,
+                            document_id=vault.public_id,
+                        ) as download:
+                            resolution = process_document(
+                                filename=vault.original_filename,
+                                content=b"".join(download.iter_chunks()),
+                                role_hint=link.document_role,
+                            )
+                        run = UsLaceyEngineDocumentRun(
+                            organization_id=organization_id,
+                            operation_id=operation_id,
+                            operation_document_id=link.id,
+                            assurance_document_id=assurance.id,
+                            engine_version=self._engine_version,
+                            schema_version=DOCUMENT_RESOLUTION_SCHEMA_VERSION,
+                            source_sha256=vault.sha256,
+                            role_hint=link.document_role,
+                            status="SUCCEEDED",
+                            resolution_json=serialize_document_resolution(resolution),
+                        )
+                        session.add(run)
+                        session.flush()
                     except Exception:
-                        session.add(UsLaceyEngineDocumentRun(organization_id=organization_id, operation_id=operation_id, operation_document_id=link.id, assurance_document_id=assurance.id, engine_version=self._engine_version, schema_version=DOCUMENT_RESOLUTION_SCHEMA_VERSION, source_sha256=vault.sha256, role_hint=link.document_role, status="FAILED", safe_error_code="ENGINE2_SHADOW_FAILED", safe_error_message="Shadow document processing did not complete.")); session.commit(); return ShadowAggregationResult("FAILED")
-                inputs.append(ShipmentDocumentInput(str(link.id), vault.original_filename, role_hint=link.document_role, resolution=deserialize_document_resolution(run.resolution_json)))
+                        session.add(
+                            UsLaceyEngineDocumentRun(
+                                organization_id=organization_id,
+                                operation_id=operation_id,
+                                operation_document_id=link.id,
+                                assurance_document_id=assurance.id,
+                                engine_version=self._engine_version,
+                                schema_version=DOCUMENT_RESOLUTION_SCHEMA_VERSION,
+                                source_sha256=vault.sha256,
+                                role_hint=link.document_role,
+                                status="FAILED",
+                                safe_error_code="ENGINE2_SHADOW_FAILED",
+                                safe_error_message="Shadow document processing did not complete.",
+                            )
+                        )
+                        session.commit()
+                        return ShadowAggregationResult("FAILED")
+                else:
+                    resolution = deserialize_document_resolution(run.resolution_json)
+
+                # AI is a second non-authoritative extractor. Its own DB session and
+                # safe failure snapshots guarantee provider/network errors cannot poison
+                # Engine 2 persistence or the legacy authoritative workflow.
+                self._run_ai_shadow_document(
+                    config=ai_config,
+                    organization_id=organization_id,
+                    operation_id=operation_id,
+                    link=link,
+                    assurance=assurance,
+                    vault=vault,
+                    engine2_resolution=resolution,
+                )
+                inputs.append(
+                    ShipmentDocumentInput(
+                        str(link.id),
+                        vault.original_filename,
+                        role_hint=link.document_role,
+                        resolution=resolution,
+                    )
+                )
+
+            # Existing Engine 2 shipment snapshots are immutable/reusable, but the
+            # document loop above still lets a newly enabled AI shadow backfill its
+            # isolated document comparison without changing that shipment snapshot.
+            if existing is not None:
+                session.commit()
+                return ShadowAggregationResult("SUCCEEDED", existing.id)
+
             resolution = process_shipment(documents=inputs, ruleset=self._ruleset)
-            snapshot = UsLaceyEngineShipmentRun(organization_id=organization_id, operation_id=operation_id, engine_version=resolution.engine_version, ruleset_version=resolution.ruleset_version, schema_version=SHIPMENT_RESOLUTION_SCHEMA_VERSION, source_set_fingerprint=fingerprint, document_count=len(inputs), readiness=resolution.readiness.value, resolution_json=serialize_shipment_resolution(resolution))
-            session.add(snapshot); session.commit(); return ShadowAggregationResult("SUCCEEDED", snapshot.id)
+            snapshot = UsLaceyEngineShipmentRun(
+                organization_id=organization_id,
+                operation_id=operation_id,
+                engine_version=resolution.engine_version,
+                ruleset_version=resolution.ruleset_version,
+                schema_version=SHIPMENT_RESOLUTION_SCHEMA_VERSION,
+                source_set_fingerprint=fingerprint,
+                document_count=len(inputs),
+                readiness=resolution.readiness.value,
+                resolution_json=serialize_shipment_resolution(resolution),
+            )
+            session.add(snapshot)
+            session.commit()
+            return ShadowAggregationResult("SUCCEEDED", snapshot.id)
         except Exception:
-            session.rollback(); raise
-        finally: session.close()
+            session.rollback()
+            raise
+        finally:
+            session.close()

--- a/tests/lacey_engine/test_ai_extraction_shadow_v1.py
+++ b/tests/lacey_engine/test_ai_extraction_shadow_v1.py
@@ -1,0 +1,238 @@
+from __future__ import annotations
+
+import json
+from io import BytesIO
+
+import pytest
+
+from litoral_trace.lacey_engine.ai_providers import (
+    AIProviderConfig,
+    MistralOcrProvider,
+    QwenOllamaProvider,
+    build_ai_provider,
+)
+from litoral_trace.lacey_engine.ai_shadow import (
+    AI_SHADOW_SCHEMA_VERSION,
+    AIShadowError,
+    ReconciliationStatus,
+    candidate_from_payload,
+    evaluate_golden,
+    extraction_result_from_payload,
+    reconcile_engine2_with_ai,
+)
+from litoral_trace.lacey_engine.domain import (
+    AdmittedCandidate,
+    DocumentResolution,
+    DocumentType,
+    EvidenceClass,
+    FieldStatus,
+    LayoutBlock,
+    LayoutStructureType,
+    ParsedLayout,
+    Provenance,
+    RawCandidate,
+    ResolvedField,
+)
+
+
+def _matched(field_key: str, value: str, block: LayoutBlock) -> ResolvedField:
+    raw = RawCandidate(
+        field_key=field_key,
+        raw_text=value,
+        normalized_value=value,
+        source_block=block,
+        evidence_class=EvidenceClass.EXPLICIT,
+        extractor_name="test",
+        extractor_version="1",
+        label=field_key,
+    )
+    provenance = Provenance(
+        filename="fixture.pdf",
+        page=block.page,
+        bbox=block.bbox,
+        block_id=block.block_id,
+        source_text=block.text,
+        extractor_name="test",
+        extractor_version="1",
+        evidence_class=EvidenceClass.EXPLICIT,
+    )
+    admitted = AdmittedCandidate(raw=raw, provenance=provenance, score=100.0, document_type=DocumentType.WEB_PRINT_MANIFEST)
+    return ResolvedField(field_key, FieldStatus.MATCHED, value, admitted, (admitted,))
+
+
+def _engine2() -> DocumentResolution:
+    container_block = LayoutBlock(
+        block_id="p1-container",
+        page=1,
+        bbox=None,
+        text="Container Number MSKU9228574",
+        block_type="TEXT_LINE",
+        structure_type=LayoutStructureType.KEY_VALUE_TABLE,
+        key_text="Container Number",
+        value_text="MSKU9228574",
+    )
+    port_block = LayoutBlock(
+        block_id="p1-port",
+        page=1,
+        bbox=None,
+        text="Foreign Port of Lading PORT CHALMERS NEW ZEALAND",
+        block_type="TEXT_LINE",
+    )
+    description_block = LayoutBlock(
+        block_id="p2-description",
+        page=2,
+        bbox=None,
+        text="Cargo Description 1 SINGLE PACKS OF PINUS RADIATA TIMBER",
+        block_type="TEXT_LINE",
+    )
+    return DocumentResolution(
+        filename="fixture.pdf",
+        engine_version="lacey-engine-2.0.0",
+        document_type=DocumentType.WEB_PRINT_MANIFEST,
+        type_confidence=0.99,
+        layout=ParsedLayout((container_block, port_block, description_block), 2),
+        sections=(),
+        fields={
+            "container_number": _matched("container_number", "MSKU9228574", container_block),
+            "description": _matched("description", "SINGLE PACKS OF PINUS RADIATA TIMBER", description_block),
+            "country_of_harvest": ResolvedField("country_of_harvest", FieldStatus.MISSING, None, None, ()),
+        },
+    )
+
+
+def _candidate(field_key: str, value: str, source_text: str, *, page: int = 1, evidence: str = "EXPLICIT", confidence: float = 0.95):
+    return {
+        "field_key": field_key,
+        "value": value,
+        "evidence_class": evidence,
+        "page": page,
+        "source_text": source_text,
+        "confidence": confidence,
+        "bbox": None,
+        "reason": None,
+    }
+
+
+def test_reconciliation_agrees_and_rejects_inferred_regulatory_value():
+    engine2 = _engine2()
+    ai = extraction_result_from_payload(
+        payload={"candidates": [
+            _candidate("container_number", "MSKU9228574", "Container Number MSKU9228574"),
+            _candidate("country_of_harvest", "New Zealand", "Foreign Port of Lading PORT CHALMERS NEW ZEALAND", evidence="INFERRED"),
+        ]},
+        provider="qwen_ollama",
+        model="qwen2.5vl:7b",
+    )
+    comparison = reconcile_engine2_with_ai(engine2=engine2, ai=ai)
+    assert comparison.field("container_number").status is ReconciliationStatus.AGREEMENT
+    assert comparison.field("country_of_harvest").status is ReconciliationStatus.AI_REJECTED
+    assert comparison.inferred_candidate_rate == 0.5
+    assert comparison.verified_evidence_rate == 1.0
+
+
+def test_unverified_source_text_never_becomes_ai_only():
+    engine2 = _engine2()
+    ai = extraction_result_from_payload(
+        payload={"candidates": [_candidate("manufacturer_id", "ABC123", "Manufacturer ID ABC123")]},
+        provider="qwen_ollama",
+        model="qwen2.5vl:7b",
+    )
+    comparison = reconcile_engine2_with_ai(engine2=engine2, ai=ai)
+    row = comparison.field("manufacturer_id")
+    assert row.status is ReconciliationStatus.AI_REJECTED
+    assert row.ai_value is None
+    assert row.rejected_ai_candidate_count == 1
+
+
+def test_golden_metrics_measure_precision_without_treating_inference_as_autofill():
+    engine2 = _engine2()
+    ai = extraction_result_from_payload(
+        payload={"candidates": [
+            _candidate("container_number", "MSKU9228574", "Container Number MSKU9228574"),
+            _candidate("description", "WRONG DESCRIPTION", "Cargo Description 1 SINGLE PACKS OF PINUS RADIATA TIMBER", page=2),
+            _candidate("country_of_harvest", "New Zealand", "Foreign Port of Lading PORT CHALMERS NEW ZEALAND", evidence="INFERRED"),
+        ]},
+        provider="mistral_ocr",
+        model="mistral-ocr-latest",
+    )
+    metrics = evaluate_golden(
+        engine2=engine2,
+        ai=ai,
+        expected={
+            "container_number": "MSKU9228574",
+            "description": "SINGLE PACKS OF PINUS RADIATA TIMBER",
+            "country_of_harvest": None,
+        },
+    )
+    assert metrics.engine2_precision == 1.0
+    assert metrics.engine2_recall == 1.0
+    assert metrics.ai_precision == 0.5
+    assert metrics.ai_recall == 0.5
+    assert metrics.ai_false_candidate_rate == 0.5
+    assert metrics.ai_inferred_candidate_rate == pytest.approx(1 / 3)
+    assert metrics.reconciliation_conflicts == 1
+
+
+def test_candidate_contract_rejects_unknown_fields_and_requires_evidence():
+    with pytest.raises(AIShadowError):
+        candidate_from_payload(
+            payload=_candidate("not_a_lacey_field", "x", "source"), provider="qwen_ollama", model="qwen"
+        )
+    bad = _candidate("container_number", "MSKU9228574", "")
+    with pytest.raises(AIShadowError):
+        candidate_from_payload(payload=bad, provider="qwen_ollama", model="qwen")
+
+
+def test_provider_factory_switches_models_by_config_without_code_change():
+    qwen_config = AIProviderConfig("SHADOW", "qwen_ollama", "qwen2.5vl:7b", "http://localhost:11434/api/chat", None, 30, 8, False)
+    assert isinstance(build_ai_provider(qwen_config), QwenOllamaProvider)
+    mistral_config = AIProviderConfig("SHADOW", "mistral_ocr", "mistral-ocr-latest", "https://api.mistral.ai/v1/ocr", "test-key", 30, 8, True)
+    assert isinstance(build_ai_provider(mistral_config), MistralOcrProvider)
+    assert build_ai_provider(AIProviderConfig("OFF", "qwen_ollama", "qwen", "http://localhost", None, 30, 8, False)) is None
+
+
+def test_mistral_requires_explicit_external_data_egress_opt_in():
+    config = AIProviderConfig("SHADOW", "mistral_ocr", "mistral-ocr-latest", "https://api.mistral.ai/v1/ocr", "test-key", 30, 8, False)
+    with pytest.raises(AIShadowError, match="disabled by policy"):
+        MistralOcrProvider(config)
+
+
+def test_qwen_adapter_parses_structured_output_without_network(monkeypatch):
+    from litoral_trace.lacey_engine import ai_providers
+
+    config = AIProviderConfig("SHADOW", "qwen_ollama", "qwen2.5vl:7b", "http://localhost:11434/api/chat", None, 30, 8, False)
+    monkeypatch.setattr(ai_providers, "_document_images", lambda filename, content, max_pages: [b"image"])
+    monkeypatch.setattr(
+        ai_providers,
+        "_post_json",
+        lambda **kwargs: {"message": {"content": json.dumps({"candidates": [_candidate("container_number", "MSKU9228574", "Container Number MSKU9228574")]})}},
+    )
+    result = QwenOllamaProvider(config).extract(filename="fixture.pdf", content=b"pdf")
+    assert result.schema_version == AI_SHADOW_SCHEMA_VERSION
+    assert result.page_count == 1
+    assert result.candidates[0].field_key == "container_number"
+    assert result.candidates[0].page == 1
+
+
+def test_mistral_adapter_uses_document_annotation_schema_without_network(monkeypatch):
+    from litoral_trace.lacey_engine import ai_providers
+
+    captured = {}
+    def fake_post_json(**kwargs):
+        captured.update(kwargs)
+        return {
+            "document_annotation": {"candidates": [_candidate("container_number", "MSKU9228574", "Container Number MSKU9228574")]},
+            "pages": [{"index": 0}],
+        }
+    monkeypatch.setattr(ai_providers, "_post_json", fake_post_json)
+    config = AIProviderConfig("SHADOW", "mistral_ocr", "mistral-ocr-latest", "https://api.mistral.ai/v1/ocr", "test-key", 30, 8, True)
+    from pypdf import PdfWriter
+    stream = BytesIO()
+    writer = PdfWriter()
+    writer.add_blank_page(width=72, height=72)
+    writer.write(stream)
+    result = MistralOcrProvider(config).extract(filename="fixture.pdf", content=stream.getvalue())
+    payload = captured["payload"]
+    assert payload["document_annotation_format"]["type"] == "json_schema"
+    assert payload["document"]["document_url"].startswith("data:application/pdf;base64,")
+    assert result.candidates[0].value == "MSKU9228574"

--- a/tests/lacey_engine/test_ai_extraction_shadow_v1.py
+++ b/tests/lacey_engine/test_ai_extraction_shadow_v1.py
@@ -9,6 +9,7 @@ from litoral_trace.lacey_engine.ai_providers import (
     AIProviderConfig,
     MistralOcrProvider,
     QwenOllamaProvider,
+    ai_shadow_engine_version,
     build_ai_provider,
 )
 from litoral_trace.lacey_engine.ai_shadow import (
@@ -19,6 +20,7 @@ from litoral_trace.lacey_engine.ai_shadow import (
     evaluate_golden,
     extraction_result_from_payload,
     reconcile_engine2_with_ai,
+    comparison_key,
 )
 from litoral_trace.lacey_engine.domain import (
     AdmittedCandidate,
@@ -236,3 +238,30 @@ def test_mistral_adapter_uses_document_annotation_schema_without_network(monkeyp
     assert payload["document_annotation_format"]["type"] == "json_schema"
     assert payload["document"]["document_url"].startswith("data:application/pdf;base64,")
     assert result.candidates[0].value == "MSKU9228574"
+
+
+@pytest.mark.parametrize("url", ["http://localhost:11434/api/chat", "http://127.0.0.1:11434/api/chat", "http://[::1]:11434/api/chat"])
+def test_qwen_loopback_targets_are_allowed_without_external_opt_in(url):
+    assert isinstance(QwenOllamaProvider(AIProviderConfig("SHADOW", "qwen_ollama", "qwen", url, None, 30, 8, False)), QwenOllamaProvider)
+
+
+@pytest.mark.parametrize("url", ["https://example.com/api/chat", "http://10.0.0.8:11434/api/chat", "file:///tmp/chat", "not a url"])
+def test_qwen_non_loopback_or_invalid_targets_are_blocked_without_external_opt_in(url):
+    with pytest.raises(AIShadowError, match="disabled by policy"):
+        QwenOllamaProvider(AIProviderConfig("SHADOW", "qwen_ollama", "qwen", url, None, 30, 8, False))
+
+
+def test_qwen_remote_target_requires_and_honors_external_opt_in():
+    assert isinstance(QwenOllamaProvider(AIProviderConfig("SHADOW", "qwen_ollama", "qwen", "https://example.com/api/chat", None, 30, 8, True)), QwenOllamaProvider)
+
+
+def test_arrival_date_comparison_uses_the_engine2_unambiguous_date_contract():
+    assert comparison_key("estimated_arrival_date", "2026-09-05") == comparison_key("estimated_arrival_date", "09/05/2026")
+
+
+def test_ai_cache_identity_changes_for_page_coverage_and_is_idempotent():
+    base = AIProviderConfig("SHADOW", "qwen_ollama", "qwen", "http://localhost:11434/api/chat", None, 30, 1, False)
+    expanded = AIProviderConfig("SHADOW", "qwen_ollama", "qwen", "http://localhost:11434/api/chat", None, 30, 8, False)
+    assert ai_shadow_engine_version(base) != ai_shadow_engine_version(expanded)
+    assert ai_shadow_engine_version(base) == ai_shadow_engine_version(base)
+    assert len(ai_shadow_engine_version(base)) <= 100


### PR DESCRIPTION
## Scope
Adds a strictly non-authoritative AI Extraction Shadow v1 beside Engine 2.

- provider-neutral AI evidence contract and reconciliation
- free local `qwen_ollama` adapter and low-cost hosted `mistral_ocr` adapter
- provider/model switching by environment variables only
- evidence verification against Engine 2 page text; provider-supplied bboxes are not trusted
- `INFERRED` candidates never become trusted AI values
- AI results/failures reuse the existing isolated Engine 2 document-run table via distinct engine/schema versions; no migration
- AI/provider failure cannot fail Engine 2 or the authoritative legacy workflow
- private Golden CLI and synthetic precision/reconciliation tests; no private fixture committed

## Safety defaults
`US_LACEY_AI_SHADOW_MODE=OFF` by default.
External provider egress additionally requires `US_LACEY_AI_ALLOW_EXTERNAL=1` and an API key.

## Switch examples
Free/local: `US_LACEY_AI_PROVIDER=qwen_ollama`, model `qwen2.5vl:7b`.
Paid: `US_LACEY_AI_PROVIDER=mistral_ocr`, model `mistral-ocr-latest`.

No billing changes, no ACE/LAWGS submission, no Gate 3.3, no authoritative PPQ/review writes.