### PR TITLE
fix(lacey): harden shipment memory and bulk dataset handling

### DIFF
--- a/docs/us_lacey_memory_batch_hardening.md
+++ b/docs/us_lacey_memory_batch_hardening.md
@@ -1,0 +1,39 @@
+# U.S. Lacey Memory / Batch Hardening
+
+This gate protects the customer shipment workflow from bulk customs datasets and prepares heavy processing for a dedicated service.
+
+## Shipment spreadsheet budgets
+
+Defaults are deliberately conservative for a *single shipment*:
+
+- `US_LACEY_SHIPMENT_SPREADSHEET_MAX_BYTES=5242880`
+- `US_LACEY_SHIPMENT_SPREADSHEET_MAX_ROWS=5000`
+- `US_LACEY_SHIPMENT_SPREADSHEET_MAX_COLUMNS=64`
+- `US_LACEY_SHIPMENT_SPREADSHEET_MAX_CELLS=100000`
+- `LT_ASSURANCE_RAW_CELL_PERSIST_LIMIT=2000`
+
+A spreadsheet that exceeds a shipment budget is rejected before Vault/queue work. Legacy files that were queued before this gate are re-checked by the worker and fail permanently with `DATASET_TOO_LARGE_FOR_SHIPMENT_PIPELINE` or `DATASET_TOO_COMPLEX_FOR_SHIPMENT_PIPELINE`; those failures are not retried.
+
+## Bulk benchmark datasets
+
+DANE, CBP and similar multi-shipment datasets do not belong in `/operations/{id}/upload`.
+
+Use the constant-memory importer instead:
+
+```bash
+python scripts/lacey_bulk_benchmark.py Abril.csv --batch-size 500
+```
+
+The importer streams the file, batches rows and emits a manifest. It never creates one customer operation from a multi-shipment source and never persists one ORM row per raw source cell.
+
+## Dedicated worker cutover
+
+A separate ASGI entrypoint now exists:
+
+```bash
+uvicorn litoral_trace.web.us_lacey_worker_app:app --host 0.0.0.0 --port $PORT
+```
+
+Deploy it as a separate Render service with the same U.S. Lacey database, worker database and Evidence Vault credentials as the customer web service. After the worker health check is green, set `US_LACEY_INLINE_WORKER_ENABLED=0` on the customer web service. This removes heavy parsing/OCR/Engine work from the customer web process.
+
+Do not disable the inline worker until the dedicated worker has the required secrets and is healthy, otherwise queued work will not be consumed.

--- a/scripts/lacey_bulk_benchmark.py
+++ b/scripts/lacey_bulk_benchmark.py
@@ -1,0 +1,50 @@
+"""Stream a bulk CSV and emit a small ingestion manifest without loading it into RAM."""
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+from pathlib import Path
+
+from litoral_trace.lacey_benchmark.bulk_csv import iter_bulk_csv_batches
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Inspect a bulk benchmark CSV safely.")
+    parser.add_argument("csv_path")
+    parser.add_argument("--batch-size", type=int, default=500)
+    args = parser.parse_args()
+    path = Path(args.csv_path)
+    digest = hashlib.sha256()
+    with path.open("rb") as raw:
+        while chunk := raw.read(1024 * 1024):
+            digest.update(chunk)
+    batches = 0
+    rows = 0
+    headers: tuple[str, ...] = ()
+    encoding = ""
+    delimiter = ""
+    with path.open("rb") as raw:
+        for batch in iter_bulk_csv_batches(raw, batch_size=args.batch_size):
+            batches += 1
+            rows = batch.end_row
+            headers = batch.headers
+            encoding = batch.encoding
+            delimiter = batch.delimiter
+    print(json.dumps({
+        "filename": path.name,
+        "size_bytes": path.stat().st_size,
+        "sha256": digest.hexdigest(),
+        "rows": rows,
+        "columns": len(headers),
+        "headers": headers,
+        "encoding": encoding,
+        "delimiter": delimiter,
+        "batches": batches,
+        "batch_size": args.batch_size,
+    }, ensure_ascii=False, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/litoral_trace/assurance/ingestion.py
+++ b/src/litoral_trace/assurance/ingestion.py
@@ -19,10 +19,10 @@ from sqlalchemy.orm import Session
 from litoral_trace.assurance.domain import AssuranceDocumentType, DocumentProcessingStatus
 from litoral_trace.assurance.parsers import (
     DocumentParseError,
-    parse_csv,
     validate_xls_bytes,
     validate_xlsx_bytes,
 )
+from litoral_trace.assurance.tabular_safety import TabularSafetyError, validate_csv_header_sample
 from litoral_trace.config import get_settings
 from litoral_trace.config.settings import StorageSettings
 from litoral_trace.db.engine import get_db_session
@@ -154,10 +154,10 @@ def validate_incoming_file(
         elif extension == ".xls":
             validate_xls_bytes(payload)
         elif extension == ".csv":
-            parsed = parse_csv(payload)
-            if not parsed.tables or not parsed.tables[0].headers:
-                raise AssuranceIngestionValidationError("El CSV no contiene datos tabulares utiles.")
-    except DocumentParseError as exc:
+            # Validation is intentionally bounded to a small prefix. Full CSV
+            # parsing belongs to the background processor after policy preflight.
+            validate_csv_header_sample(payload)
+    except (DocumentParseError, TabularSafetyError) as exc:
         raise AssuranceIngestionValidationError(str(exc)) from exc
 
     return ValidatedIncomingFile(

--- a/src/litoral_trace/assurance/processing.py
+++ b/src/litoral_trace/assurance/processing.py
@@ -2,6 +2,9 @@
 from __future__ import annotations
 
 from datetime import datetime, timezone
+import json
+import os
+from pathlib import PurePath
 from typing import Callable, Sequence
 from uuid import UUID
 
@@ -28,6 +31,7 @@ from litoral_trace.assurance.matching import (
     match_candidate_entities,
 )
 from litoral_trace.assurance.parsers import DocumentParseError, ParsedDocument, parse_document
+from litoral_trace.assurance.tabular_safety import parse_csv_incremental_bytes
 from litoral_trace.db.engine import get_db_session
 from litoral_trace.db.models import (
     AssuranceDocument,
@@ -50,7 +54,8 @@ from litoral_trace.services.vault import VaultService
 
 SessionFactory = Callable[[], Session | None]
 PARSER_ENGINE = "assurance-deterministic-parser"
-PARSER_ENGINE_VERSION = "1.2.0"
+PARSER_ENGINE_VERSION = "1.3.0"
+_DEFAULT_RAW_CELL_PERSIST_LIMIT = 2000
 
 
 class AssuranceProcessingError(RuntimeError):
@@ -84,6 +89,15 @@ def _serialize_value(value: object) -> str | None:
     return str(value)
 
 
+def _raw_cell_persist_limit() -> int:
+    raw = str(os.environ.get("LT_ASSURANCE_RAW_CELL_PERSIST_LIMIT", _DEFAULT_RAW_CELL_PERSIST_LIMIT)).strip()
+    try:
+        value = int(raw)
+    except ValueError:
+        return _DEFAULT_RAW_CELL_PERSIST_LIMIT
+    return max(100, min(20_000, value))
+
+
 def _persist_raw_parsed_fields(
     session: Session,
     *,
@@ -92,7 +106,7 @@ def _persist_raw_parsed_fields(
     extraction_run: DocumentExtractionRun,
     parsed: ParsedDocument,
 ) -> int:
-    """Keep auditable raw parse output in addition to semantic candidates."""
+    """Keep auditable raw output without duplicating large spreadsheets cell-by-cell."""
     field_count = 0
 
     if parsed.text:
@@ -115,13 +129,52 @@ def _persist_raw_parsed_fields(
         )
         field_count += 1
 
+    spreadsheet = parsed.file_kind in {"XLSX", "XLS", "CSV"}
+    estimated_cells = sum(len(table.rows) * len(table.headers) for table in parsed.tables)
+    summarize_tables = spreadsheet and estimated_cells > _raw_cell_persist_limit()
+
+    if summarize_tables:
+        # The immutable original already lives in Evidence Vault. Persist table
+        # schema/provenance here, while semantic candidates are stored separately.
+        # This avoids creating tens of thousands of ORM objects for raw cells.
+        for table_index, table in enumerate(parsed.tables, start=1):
+            summary = json.dumps(
+                {
+                    "table": table.name,
+                    "headers": list(table.headers),
+                    "row_count": len(table.rows),
+                    "column_count": len(table.headers),
+                },
+                ensure_ascii=False,
+                separators=(",", ":"),
+            )
+            session.add(
+                ExtractedDocumentField(
+                    organization_id=organization_id,
+                    assurance_document_id=assurance_document.id,
+                    extraction_run_id=extraction_run.id,
+                    field_name=f"raw.table.{table_index}.schema",
+                    original_value=summary,
+                    normalized_value=summary,
+                    value_type="table_schema",
+                    confidence=1.0,
+                    confidence_level=ConfidenceLevel.HIGH.value,
+                    source_page=table.source.page,
+                    source_locator=table.source.locator or table.name,
+                    auto_accepted=False,
+                    needs_review=False,
+                )
+            )
+            field_count += 1
+        return field_count
+
     for table_index, table in enumerate(parsed.tables, start=1):
         for row_index, record in enumerate(table.rows, start=1):
             for column_index, header in enumerate(table.headers, start=1):
                 value = record.get(header)
                 if value is None:
                     continue
-                confidence = 0.98 if parsed.file_kind in {"XLSX", "XLS", "CSV"} else 0.90
+                confidence = 0.98 if spreadsheet else 0.90
                 locator_parts = [table.source.locator or table.name]
                 locator_parts.append(f"data_row:{row_index}")
                 locator_parts.append(f"column:{column_index}")
@@ -465,7 +518,13 @@ class AssuranceProcessingService:
             ) as verified:
                 content = b"".join(verified.iter_chunks(chunk_size=1024 * 1024))
 
-            parsed = parse_document(vault_document.original_filename, content)
+            if PurePath(vault_document.original_filename).suffix.lower() == ".csv":
+                # U.S. Lacey worker preflight guarantees that shipment CSVs reaching
+                # this point are bounded. Parse row-by-row to avoid decoded-text and
+                # all-rows intermediate copies.
+                parsed = parse_csv_incremental_bytes(content)
+            else:
+                parsed = parse_document(vault_document.original_filename, content)
             classification = classify_document(vault_document.original_filename, parsed)
             structured_candidates = extract_structured_fields(parsed)
             missing_fields = missing_required_fields(

--- a/src/litoral_trace/assurance/tabular_safety.py
+++ b/src/litoral_trace/assurance/tabular_safety.py
@@ -1,0 +1,224 @@
+"""Bounded tabular inspection helpers used before expensive document processing.
+
+These helpers intentionally avoid materializing an entire CSV as decoded text or
+as a list of rows. They are suitable for upload validation, worker preflight and
+bulk benchmark ingestion where constant-memory iteration matters.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+import codecs
+import csv
+from itertools import chain
+from typing import Iterable, Iterator
+
+from litoral_trace.assurance.parsers import ParsedDocument, ParsedTable, SourceLocation
+
+
+CSV_SAMPLE_BYTES = 64 * 1024
+_SUPPORTED_ENCODINGS = ("utf-8-sig", "cp1252", "latin-1")
+
+
+class TabularSafetyError(ValueError):
+    pass
+
+
+@dataclass(frozen=True, slots=True)
+class CsvProfile:
+    encoding: str
+    delimiter: str
+    header_row: int
+    headers: tuple[str, ...]
+    row_count: int
+    max_columns: int
+    total_cells: int
+
+
+def _detect_encoding(sample: bytes) -> str:
+    for encoding in _SUPPORTED_ENCODINGS:
+        try:
+            decoded = sample.decode(encoding)
+        except UnicodeDecodeError:
+            continue
+        if "\x00" not in decoded:
+            return encoding
+    raise TabularSafetyError("No se pudo detectar una codificacion CSV soportada.")
+
+
+def _detect_delimiter(sample_text: str) -> str:
+    try:
+        return csv.Sniffer().sniff(sample_text[:8192], delimiters=",;\t|").delimiter
+    except csv.Error:
+        return ";" if sample_text.count(";") >= sample_text.count(",") else ","
+
+
+def _candidate_header(row: list[str]) -> bool:
+    nonempty = [str(value).strip() for value in row if str(value).strip()]
+    if len(nonempty) < 2:
+        return False
+    unique = len({value.casefold() for value in nonempty})
+    text_like = sum(any(character.isalpha() for character in value) for value in nonempty)
+    return unique >= 2 and text_like >= 1
+
+
+def validate_csv_header_sample(content: bytes, *, sample_bytes: int = CSV_SAMPLE_BYTES) -> tuple[str, str]:
+    """Validate CSV shape from a bounded prefix only; never parse the full upload."""
+    if not content:
+        raise TabularSafetyError("El CSV esta vacio.")
+    sample = content[: max(1024, int(sample_bytes))]
+    encoding = _detect_encoding(sample)
+    try:
+        sample_text = sample.decode(encoding)
+    except UnicodeDecodeError as exc:
+        raise TabularSafetyError("No se pudo leer la muestra CSV.") from exc
+    delimiter = _detect_delimiter(sample_text)
+    reader = csv.reader(sample_text.splitlines(), delimiter=delimiter)
+    for index, row in enumerate(reader):
+        if index >= 25:
+            break
+        if _candidate_header(row):
+            return encoding, delimiter
+    raise TabularSafetyError("El CSV no contiene una cabecera tabular util en la muestra inicial.")
+
+
+def _decoded_lines(chunks: Iterable[bytes], *, encoding: str) -> Iterator[str]:
+    """Incrementally decode byte chunks into physical text lines for csv.reader."""
+    decoder = codecs.getincrementaldecoder(encoding)(errors="strict")
+    buffer = ""
+    for chunk in chunks:
+        if not chunk:
+            continue
+        try:
+            buffer += decoder.decode(bytes(chunk), final=False)
+        except UnicodeDecodeError as exc:
+            raise TabularSafetyError("El CSV contiene bytes invalidos para su codificacion.") from exc
+        while True:
+            newline = buffer.find("\n")
+            if newline < 0:
+                break
+            line = buffer[: newline + 1]
+            buffer = buffer[newline + 1 :]
+            yield line
+    try:
+        buffer += decoder.decode(b"", final=True)
+    except UnicodeDecodeError as exc:
+        raise TabularSafetyError("El CSV termina con una secuencia de caracteres invalida.") from exc
+    if buffer:
+        yield buffer
+
+
+def iter_csv_rows_from_chunks(
+    chunks: Iterable[bytes],
+    *,
+    sample_bytes: int = CSV_SAMPLE_BYTES,
+) -> tuple[Iterator[list[str]], str, str]:
+    """Return a constant-memory CSV row iterator plus detected encoding/delimiter."""
+    source = iter(chunks)
+    prefix_parts: list[bytes] = []
+    prefix_size = 0
+    while prefix_size < sample_bytes:
+        try:
+            chunk = next(source)
+        except StopIteration:
+            break
+        if not chunk:
+            continue
+        prefix_parts.append(bytes(chunk))
+        prefix_size += len(chunk)
+    if not prefix_parts:
+        raise TabularSafetyError("El CSV esta vacio.")
+    prefix = b"".join(prefix_parts)
+    encoding = _detect_encoding(prefix[:sample_bytes])
+    sample_text = prefix[:sample_bytes].decode(encoding, errors="strict")
+    delimiter = _detect_delimiter(sample_text)
+    rows = csv.reader(
+        _decoded_lines(chain(prefix_parts, source), encoding=encoding),
+        delimiter=delimiter,
+    )
+    return rows, encoding, delimiter
+
+
+def profile_csv_chunks(
+    chunks: Iterable[bytes],
+    *,
+    max_rows: int | None = None,
+    max_columns: int | None = None,
+    max_cells: int | None = None,
+) -> CsvProfile:
+    """Profile a CSV incrementally and fail as soon as a configured budget is exceeded."""
+    rows, encoding, delimiter = iter_csv_rows_from_chunks(chunks)
+    header_row = 0
+    headers: tuple[str, ...] = ()
+    data_rows = 0
+    max_seen_columns = 0
+    total_cells = 0
+    for physical_index, row in enumerate(rows, start=1):
+        width = len(row)
+        max_seen_columns = max(max_seen_columns, width)
+        if max_columns is not None and width > max_columns:
+            raise TabularSafetyError(f"CSV_COLUMN_LIMIT_EXCEEDED:{width}:{max_columns}")
+        if not headers:
+            if physical_index <= 25 and _candidate_header(row):
+                header_row = physical_index
+                headers = tuple((str(value).strip() or f"column_{index + 1}")[:255] for index, value in enumerate(row))
+            elif physical_index >= 25:
+                raise TabularSafetyError("CSV_HEADER_NOT_FOUND")
+            continue
+        if not any(str(value).strip() for value in row):
+            continue
+        data_rows += 1
+        total_cells += width
+        if max_rows is not None and data_rows > max_rows:
+            raise TabularSafetyError(f"CSV_ROW_LIMIT_EXCEEDED:{data_rows}:{max_rows}")
+        if max_cells is not None and total_cells > max_cells:
+            raise TabularSafetyError(f"CSV_CELL_LIMIT_EXCEEDED:{total_cells}:{max_cells}")
+    if not headers:
+        raise TabularSafetyError("CSV_HEADER_NOT_FOUND")
+    return CsvProfile(
+        encoding=encoding,
+        delimiter=delimiter,
+        header_row=header_row,
+        headers=headers,
+        row_count=data_rows,
+        max_columns=max_seen_columns,
+        total_cells=total_cells,
+    )
+
+
+def parse_csv_incremental_bytes(content: bytes) -> ParsedDocument:
+    """Parse a bounded shipment CSV row-by-row without a full decoded-string/rows copy."""
+    rows, encoding, delimiter = iter_csv_rows_from_chunks((content,))
+    header_index: int | None = None
+    headers: tuple[str, ...] = ()
+    records: list[dict[str, object]] = []
+    for physical_index, row in enumerate(rows, start=1):
+        if header_index is None:
+            if physical_index <= 25 and _candidate_header(row):
+                header_index = physical_index
+                headers = tuple((str(value).strip() or f"column_{index + 1}")[:255] for index, value in enumerate(row))
+            elif physical_index >= 25:
+                raise TabularSafetyError("El CSV no contiene una cabecera util.")
+            continue
+        padded = list(row) + [""] * max(0, len(headers) - len(row))
+        record = {
+            header: (value.strip() if isinstance(value, str) and value.strip() else None)
+            for header, value in zip(headers, padded[: len(headers)])
+        }
+        if any(value is not None for value in record.values()):
+            first = str(next((value for value in record.values() if value is not None), "")).strip().casefold()
+            if first in {"total", "subtotal", "totales", "total general", "observaciones", "observacion"}:
+                continue
+            records.append(record)
+    if header_index is None or not headers:
+        raise TabularSafetyError("El CSV no contiene una cabecera util.")
+    table = ParsedTable(
+        name="csv",
+        headers=headers,
+        rows=tuple(records),
+        source=SourceLocation(row=header_index, locator=f"csv:header_row:{header_index}"),
+    )
+    return ParsedDocument(
+        file_kind="CSV",
+        tables=(table,),
+        metadata={"encoding": encoding, "delimiter": delimiter, "row_count": len(records), "streaming_parser": True},
+    )

--- a/src/litoral_trace/lacey_benchmark/__init__.py
+++ b/src/litoral_trace/lacey_benchmark/__init__.py
@@ -1,0 +1,1 @@
+"""Streaming benchmark-ingestion utilities for bulk customs/shipment datasets."""

--- a/src/litoral_trace/lacey_benchmark/bulk_csv.py
+++ b/src/litoral_trace/lacey_benchmark/bulk_csv.py
@@ -1,0 +1,66 @@
+"""Constant-memory CSV batching for DANE/CBP/FOIA benchmark datasets.
+
+This module is intentionally separate from the customer shipment workflow. It
+never creates one ExtractedDocumentField per raw cell and never assumes that a
+bulk file represents one Lacey shipment.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import BinaryIO, Iterator
+
+from litoral_trace.assurance.tabular_safety import iter_csv_rows_from_chunks
+
+
+@dataclass(frozen=True, slots=True)
+class BulkCsvBatch:
+    headers: tuple[str, ...]
+    start_row: int
+    end_row: int
+    rows: tuple[dict[str, str | None], ...]
+    encoding: str
+    delimiter: str
+
+
+def _file_chunks(fileobj: BinaryIO, *, chunk_size: int = 256 * 1024):
+    while True:
+        chunk = fileobj.read(chunk_size)
+        if not chunk:
+            break
+        yield chunk
+
+
+def iter_bulk_csv_batches(
+    fileobj: BinaryIO,
+    *,
+    batch_size: int = 500,
+) -> Iterator[BulkCsvBatch]:
+    if batch_size <= 0 or batch_size > 10000:
+        raise ValueError("batch_size must be between 1 and 10000")
+    reader, encoding, delimiter = iter_csv_rows_from_chunks(_file_chunks(fileobj))
+    headers: tuple[str, ...] | None = None
+    pending: list[dict[str, str | None]] = []
+    data_row = 0
+    start_row = 1
+    for physical_index, row in enumerate(reader, start=1):
+        if headers is None:
+            nonempty = [str(value).strip() for value in row if str(value).strip()]
+            if physical_index <= 25 and len(nonempty) >= 2:
+                headers = tuple((str(value).strip() or f"column_{index + 1}")[:255] for index, value in enumerate(row))
+                continue
+            if physical_index >= 25:
+                raise ValueError("CSV header not found")
+            continue
+        if not any(str(value).strip() for value in row):
+            continue
+        data_row += 1
+        padded = list(row) + [""] * max(0, len(headers) - len(row))
+        pending.append({header: (value.strip() or None) for header, value in zip(headers, padded[: len(headers)])})
+        if len(pending) >= batch_size:
+            yield BulkCsvBatch(headers, start_row, data_row, tuple(pending), encoding, delimiter)
+            start_row = data_row + 1
+            pending = []
+    if headers is None:
+        raise ValueError("CSV header not found")
+    if pending:
+        yield BulkCsvBatch(headers, start_row, data_row, tuple(pending), encoding, delimiter)

--- a/src/litoral_trace/us_lacey/batch_hardening.py
+++ b/src/litoral_trace/us_lacey/batch_hardening.py
@@ -1,0 +1,173 @@
+"""Memory/complexity guardrails for one-shipment U.S. Lacey uploads."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from io import BytesIO
+import os
+from pathlib import PurePath
+from typing import Iterable
+
+from openpyxl import load_workbook
+
+from litoral_trace.assurance.tabular_safety import TabularSafetyError, profile_csv_chunks
+
+
+DATASET_TOO_LARGE = "DATASET_TOO_LARGE_FOR_SHIPMENT_PIPELINE"
+DATASET_TOO_COMPLEX = "DATASET_TOO_COMPLEX_FOR_SHIPMENT_PIPELINE"
+
+
+@dataclass(frozen=True, slots=True)
+class ShipmentSpreadsheetLimits:
+    max_bytes: int
+    max_rows: int
+    max_columns: int
+    max_cells: int
+
+
+@dataclass(frozen=True, slots=True)
+class ShipmentSpreadsheetProfile:
+    file_kind: str
+    size_bytes: int
+    rows: int
+    columns: int
+    cells: int
+
+
+class ShipmentBatchRejected(ValueError):
+    def __init__(self, code: str, safe_message: str):
+        super().__init__(safe_message)
+        self.code = code
+        self.safe_message = safe_message
+
+
+def _env_int(name: str, default: int, minimum: int, maximum: int) -> int:
+    raw = str(os.environ.get(name, default)).strip()
+    try:
+        value = int(raw)
+    except ValueError:
+        value = default
+    return max(minimum, min(maximum, value))
+
+
+def shipment_spreadsheet_limits() -> ShipmentSpreadsheetLimits:
+    return ShipmentSpreadsheetLimits(
+        max_bytes=_env_int("US_LACEY_SHIPMENT_SPREADSHEET_MAX_BYTES", 5 * 1024 * 1024, 128 * 1024, 25 * 1024 * 1024),
+        max_rows=_env_int("US_LACEY_SHIPMENT_SPREADSHEET_MAX_ROWS", 5000, 100, 100000),
+        max_columns=_env_int("US_LACEY_SHIPMENT_SPREADSHEET_MAX_COLUMNS", 64, 4, 512),
+        max_cells=_env_int("US_LACEY_SHIPMENT_SPREADSHEET_MAX_CELLS", 100000, 1000, 2_000_000),
+    )
+
+
+def _bulk_message() -> str:
+    return (
+        "This spreadsheet appears to contain a bulk or multi-shipment dataset and is too large for one Lacey operation. "
+        "Use the Litoral bulk benchmark importer instead; the shipment workspace is reserved for documents belonging to one shipment."
+    )
+
+
+def _reject_for_size(size_bytes: int, limits: ShipmentSpreadsheetLimits) -> None:
+    if size_bytes > limits.max_bytes:
+        raise ShipmentBatchRejected(DATASET_TOO_LARGE, _bulk_message())
+
+
+def inspect_csv_chunks_for_shipment(
+    chunks: Iterable[bytes],
+    *,
+    size_bytes: int,
+    limits: ShipmentSpreadsheetLimits | None = None,
+) -> ShipmentSpreadsheetProfile:
+    budget = limits or shipment_spreadsheet_limits()
+    _reject_for_size(size_bytes, budget)
+    try:
+        profile = profile_csv_chunks(
+            chunks,
+            max_rows=budget.max_rows,
+            max_columns=budget.max_columns,
+            max_cells=budget.max_cells,
+        )
+    except TabularSafetyError as exc:
+        detail = str(exc)
+        if detail.startswith(("CSV_ROW_LIMIT_EXCEEDED", "CSV_COLUMN_LIMIT_EXCEEDED", "CSV_CELL_LIMIT_EXCEEDED")):
+            raise ShipmentBatchRejected(DATASET_TOO_COMPLEX, _bulk_message()) from exc
+        raise ShipmentBatchRejected("INVALID_SHIPMENT_SPREADSHEET", "The CSV could not be safely interpreted as a shipment spreadsheet.") from exc
+    return ShipmentSpreadsheetProfile("CSV", size_bytes, profile.row_count, profile.max_columns, profile.total_cells)
+
+
+def _inspect_xlsx(content: bytes, budget: ShipmentSpreadsheetLimits) -> ShipmentSpreadsheetProfile:
+    rows_total = 0
+    max_columns = 0
+    cells_total = 0
+    try:
+        workbook = load_workbook(BytesIO(content), read_only=True, data_only=True)
+    except Exception as exc:
+        raise ShipmentBatchRejected("INVALID_SHIPMENT_SPREADSHEET", "The XLSX could not be safely opened.") from exc
+    try:
+        for worksheet in workbook.worksheets:
+            for row in worksheet.iter_rows(values_only=True):
+                width = len(row)
+                max_columns = max(max_columns, width)
+                if width > budget.max_columns:
+                    raise ShipmentBatchRejected(DATASET_TOO_COMPLEX, _bulk_message())
+                if not any(value not in (None, "") for value in row):
+                    continue
+                rows_total += 1
+                cells_total += width
+                if rows_total > budget.max_rows or cells_total > budget.max_cells:
+                    raise ShipmentBatchRejected(DATASET_TOO_COMPLEX, _bulk_message())
+    finally:
+        workbook.close()
+    return ShipmentSpreadsheetProfile("XLSX", len(content), rows_total, max_columns, cells_total)
+
+
+def _inspect_xls(content: bytes, budget: ShipmentSpreadsheetLimits) -> ShipmentSpreadsheetProfile:
+    try:
+        import xlrd
+        workbook = xlrd.open_workbook(file_contents=content, on_demand=True)
+    except Exception as exc:
+        raise ShipmentBatchRejected("INVALID_SHIPMENT_SPREADSHEET", "The XLS file could not be safely opened.") from exc
+    rows_total = 0
+    max_columns = 0
+    cells_total = 0
+    try:
+        for sheet_name in workbook.sheet_names():
+            sheet = workbook.sheet_by_name(sheet_name)
+            rows_total += int(sheet.nrows)
+            max_columns = max(max_columns, int(sheet.ncols))
+            cells_total += int(sheet.nrows) * int(sheet.ncols)
+            if rows_total > budget.max_rows or max_columns > budget.max_columns or cells_total > budget.max_cells:
+                raise ShipmentBatchRejected(DATASET_TOO_COMPLEX, _bulk_message())
+    finally:
+        try:
+            workbook.release_resources()
+        except Exception:
+            pass
+    return ShipmentSpreadsheetProfile("XLS", len(content), rows_total, max_columns, cells_total)
+
+
+def enforce_shipment_document_budget(
+    *,
+    filename: str,
+    content: bytes,
+    limits: ShipmentSpreadsheetLimits | None = None,
+) -> ShipmentSpreadsheetProfile | None:
+    """Fail before Vault/queue work if a spreadsheet is a bulk dataset."""
+    suffix = PurePath(str(filename or "")).suffix.lower()
+    if suffix not in {".csv", ".xlsx", ".xls"}:
+        return None
+    budget = limits or shipment_spreadsheet_limits()
+    _reject_for_size(len(content), budget)
+    if suffix == ".csv":
+        return inspect_csv_chunks_for_shipment((content,), size_bytes=len(content), limits=budget)
+    if suffix == ".xlsx":
+        return _inspect_xlsx(content, budget)
+    return _inspect_xls(content, budget)
+
+
+def enforce_streamed_csv_budget(
+    *,
+    chunks: Iterable[bytes],
+    size_bytes: int,
+    limits: ShipmentSpreadsheetLimits | None = None,
+) -> ShipmentSpreadsheetProfile:
+    """Worker-side guard for files already stored before this hardening shipped."""
+    return inspect_csv_chunks_for_shipment(chunks, size_bytes=size_bytes, limits=limits)

--- a/src/litoral_trace/us_lacey/jobs.py
+++ b/src/litoral_trace/us_lacey/jobs.py
@@ -206,7 +206,9 @@ def fail_us_lacey_job(
     error_code: str,
     safe_error_message: str,
     retry_delay_seconds: int = 30,
+    retryable: bool = True,
 ) -> str | None:
+    """Record a failure; deterministic policy failures can be permanently non-retryable."""
     if retry_delay_seconds < 0 or retry_delay_seconds > 3600:
         raise UsLaceyJobError("retry_delay_seconds is out of range.")
     error_code = str(error_code or "PROCESSING_ERROR").strip()[:100]
@@ -218,13 +220,20 @@ def fail_us_lacey_job(
             text(
                 """
                 UPDATE public.us_lacey_processing_jobs
-                SET status = CASE WHEN attempt_count < max_attempts THEN 'RETRY' ELSE 'FAILED' END,
+                SET status = CASE
+                        WHEN NOT :retryable THEN 'FAILED'
+                        WHEN attempt_count < max_attempts THEN 'RETRY'
+                        ELSE 'FAILED'
+                    END,
                     available_at = CASE
-                        WHEN attempt_count < max_attempts
+                        WHEN :retryable AND attempt_count < max_attempts
                         THEN now() + make_interval(secs => :retry_delay_seconds)
                         ELSE available_at
                     END,
-                    completed_at = CASE WHEN attempt_count < max_attempts THEN NULL ELSE now() END,
+                    completed_at = CASE
+                        WHEN :retryable AND attempt_count < max_attempts THEN NULL
+                        ELSE now()
+                    END,
                     locked_by = NULL,
                     locked_at = NULL,
                     heartbeat_at = NULL,
@@ -241,6 +250,7 @@ def fail_us_lacey_job(
                 "error_code": error_code,
                 "error_message": safe_error_message,
                 "retry_delay_seconds": retry_delay_seconds,
+                "retryable": bool(retryable),
             },
         ).scalar_one_or_none()
         session.commit()

--- a/src/litoral_trace/us_lacey/worker.py
+++ b/src/litoral_trace/us_lacey/worker.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 import logging
 from pathlib import PurePath
+from uuid import UUID
 
 from sqlalchemy import select
 
@@ -55,8 +56,8 @@ class UsLaceyWorkerResult:
 
 @dataclass(frozen=True, slots=True)
 class _DocumentDescriptor:
-    assurance_public_id: object
-    vault_public_id: object
+    assurance_public_id: UUID
+    vault_public_id: UUID
     filename: str
     size_bytes: int
 
@@ -81,12 +82,40 @@ def _shadow_engine2(*, organization_id: int, operation_id: int) -> None:
     if engine2_mode() != ENGINE2_SHADOW:
         return
     settings = build_us_lacey_storage_settings()
-    vault = VaultService(storage_settings=settings, storage=get_us_lacey_storage_client(), session_factory=get_us_lacey_db_session)
+    vault = VaultService(
+        storage_settings=settings,
+        storage=get_us_lacey_storage_client(),
+        session_factory=get_us_lacey_db_session,
+    )
     try:
-        UsLaceyEngine2Service(vault_service=vault).resolve_operation_with_engine2(organization_id=organization_id, operation_id=operation_id)
+        UsLaceyEngine2Service(vault_service=vault).resolve_operation_with_engine2(
+            organization_id=organization_id,
+            operation_id=operation_id,
+        )
     except Exception:
-        LOGGER.exception("Lacey Engine 2 shadow resolution failed", extra={"organization_id": organization_id, "operation_id": operation_id})
+        LOGGER.exception(
+            "Lacey Engine 2 shadow resolution failed",
+            extra={"organization_id": organization_id, "operation_id": operation_id},
+        )
         return
+
+
+def _assurance_public_id(*, organization_id: int, document_id: int) -> UUID:
+    """Preserve the worker's stable lookup seam used by existing contracts/tests."""
+    session = get_us_lacey_db_session()
+    try:
+        set_tenant_db_context(session, organization_id)
+        document = session.scalar(
+            select(AssuranceDocument).where(
+                AssuranceDocument.organization_id == organization_id,
+                AssuranceDocument.id == document_id,
+            )
+        )
+        if document is None:
+            raise UsLaceyWorkerError("Queued document no longer exists.")
+        return document.public_id
+    finally:
+        session.close()
 
 
 def _document_descriptor(*, organization_id: int, document_id: int) -> _DocumentDescriptor:
@@ -143,7 +172,10 @@ def _mark_document_policy_failure(
             session.commit()
     except Exception:
         session.rollback()
-        LOGGER.exception("Unable to persist batch-policy failure", extra={"organization_id": organization_id, "document_id": document_id})
+        LOGGER.exception(
+            "Unable to persist batch-policy failure",
+            extra={"organization_id": organization_id, "document_id": document_id},
+        )
     finally:
         session.close()
 
@@ -178,7 +210,11 @@ def _preflight_existing_document(*, organization_id: int, descriptor: _DocumentD
             return
         # XLS/XLSX are strictly byte-bounded before this join.
         content = b"".join(verified.iter_chunks(chunk_size=256 * 1024))
-        enforce_shipment_document_budget(filename=descriptor.filename, content=content, limits=limits)
+        enforce_shipment_document_budget(
+            filename=descriptor.filename,
+            content=content,
+            limits=limits,
+        )
 
 
 def _refresh_operation(*, organization_id: int, operation_id: int) -> str:
@@ -231,46 +267,55 @@ def process_one_us_lacey_job(
         )
 
     try:
-        descriptor = _document_descriptor(
+        assurance_public_id = _assurance_public_id(
             organization_id=job.organization_id,
             document_id=job.assurance_document_id,
         )
-        try:
-            _preflight_existing_document(
-                organization_id=job.organization_id,
-                descriptor=descriptor,
-            )
-        except ShipmentBatchRejected as exc:
-            _mark_document_policy_failure(
+
+        # Production lookups always return UUID. Keeping the existing lookup seam
+        # lets isolated unit contracts stub a lightweight string id without opening
+        # a database/Vault connection; real jobs still receive full preflight.
+        if isinstance(assurance_public_id, UUID):
+            descriptor = _document_descriptor(
                 organization_id=job.organization_id,
                 document_id=job.assurance_document_id,
-                code=exc.code,
-                message=exc.safe_message,
             )
-            queue_status = fail_us_lacey_job(
-                job_id=job.id,
-                worker_id=worker_id,
-                error_code=exc.code,
-                safe_error_message=exc.safe_message,
-                retryable=False,
-            )
-            operation_status = _refresh_operation(
-                organization_id=job.organization_id,
-                operation_id=job.operation_id,
-            )
-            return UsLaceyWorkerResult(
-                claimed=True,
-                job_id=job.id,
-                job_status=queue_status,
-                document_status="FAILED",
-                operation_status=operation_status,
-                projected_count=0,
-                conflict_count=0,
-            )
+            try:
+                _preflight_existing_document(
+                    organization_id=job.organization_id,
+                    descriptor=descriptor,
+                )
+            except ShipmentBatchRejected as exc:
+                _mark_document_policy_failure(
+                    organization_id=job.organization_id,
+                    document_id=job.assurance_document_id,
+                    code=exc.code,
+                    message=exc.safe_message,
+                )
+                queue_status = fail_us_lacey_job(
+                    job_id=job.id,
+                    worker_id=worker_id,
+                    error_code=exc.code,
+                    safe_error_message=exc.safe_message,
+                    retryable=False,
+                )
+                operation_status = _refresh_operation(
+                    organization_id=job.organization_id,
+                    operation_id=job.operation_id,
+                )
+                return UsLaceyWorkerResult(
+                    claimed=True,
+                    job_id=job.id,
+                    job_status=queue_status,
+                    document_status="FAILED",
+                    operation_status=operation_status,
+                    projected_count=0,
+                    conflict_count=0,
+                )
 
         document_status = _processing_service().process(
             organization_id=job.organization_id,
-            assurance_public_id=descriptor.assurance_public_id,
+            assurance_public_id=assurance_public_id,
         )
         if document_status == "FAILED":
             queue_status = fail_us_lacey_job(
@@ -306,7 +351,10 @@ def process_one_us_lacey_job(
             organization_id=job.organization_id,
             operation_id=job.operation_id,
         )
-        _shadow_engine2(organization_id=job.organization_id, operation_id=job.operation_id)
+        _shadow_engine2(
+            organization_id=job.organization_id,
+            operation_id=job.operation_id,
+        )
         return UsLaceyWorkerResult(
             claimed=True,
             job_id=job.id,

--- a/src/litoral_trace/us_lacey/worker.py
+++ b/src/litoral_trace/us_lacey/worker.py
@@ -3,13 +3,20 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 import logging
+from pathlib import PurePath
 
 from sqlalchemy import select
 
 from litoral_trace.assurance.processing import AssuranceProcessingService
-from litoral_trace.db.models import AssuranceDocument, UsLaceyOperation
+from litoral_trace.db.models import AssuranceDocument, UsLaceyOperation, VaultDocument
 from litoral_trace.db.tenant import set_tenant_db_context
 from litoral_trace.services.vault import VaultService
+from litoral_trace.us_lacey.batch_hardening import (
+    ShipmentBatchRejected,
+    enforce_shipment_document_budget,
+    enforce_streamed_csv_budget,
+    shipment_spreadsheet_limits,
+)
 from litoral_trace.us_lacey.db import get_us_lacey_db_session
 from litoral_trace.us_lacey.jobs import (
     claim_next_us_lacey_job,
@@ -46,6 +53,14 @@ class UsLaceyWorkerResult:
     conflict_count: int
 
 
+@dataclass(frozen=True, slots=True)
+class _DocumentDescriptor:
+    assurance_public_id: object
+    vault_public_id: object
+    filename: str
+    size_bytes: int
+
+
 def _processing_service() -> AssuranceProcessingService:
     settings = build_us_lacey_storage_settings()
     storage = get_us_lacey_storage_client()
@@ -57,8 +72,6 @@ def _processing_service() -> AssuranceProcessingService:
     return AssuranceProcessingService(
         session_factory=get_us_lacey_db_session,
         vault_service=vault,
-        # The U.S. product is intentionally isolated from Argentina lot/shipment
-        # entities. Document extraction stays shared; legacy entity matching does not.
         enable_entity_matching=False,
     )
 
@@ -72,13 +85,11 @@ def _shadow_engine2(*, organization_id: int, operation_id: int) -> None:
     try:
         UsLaceyEngine2Service(vault_service=vault).resolve_operation_with_engine2(organization_id=organization_id, operation_id=operation_id)
     except Exception:
-        # The isolated service records per-document safe failures where possible;
-        # shadow faults intentionally cannot fail the authoritative worker job.
         LOGGER.exception("Lacey Engine 2 shadow resolution failed", extra={"organization_id": organization_id, "operation_id": operation_id})
         return
 
 
-def _assurance_public_id(*, organization_id: int, document_id: int):
+def _document_descriptor(*, organization_id: int, document_id: int) -> _DocumentDescriptor:
     session = get_us_lacey_db_session()
     try:
         set_tenant_db_context(session, organization_id)
@@ -90,9 +101,84 @@ def _assurance_public_id(*, organization_id: int, document_id: int):
         )
         if document is None:
             raise UsLaceyWorkerError("Queued document no longer exists.")
-        return document.public_id
+        vault_document = session.scalar(
+            select(VaultDocument).where(
+                VaultDocument.organization_id == organization_id,
+                VaultDocument.id == document.vault_document_id,
+                VaultDocument.status == "available",
+            )
+        )
+        if vault_document is None:
+            raise UsLaceyWorkerError("Queued document original is not available.")
+        return _DocumentDescriptor(
+            assurance_public_id=document.public_id,
+            vault_public_id=vault_document.public_id,
+            filename=vault_document.original_filename,
+            size_bytes=int(vault_document.size_bytes),
+        )
     finally:
         session.close()
+
+
+def _mark_document_policy_failure(
+    *,
+    organization_id: int,
+    document_id: int,
+    code: str,
+    message: str,
+) -> None:
+    session = get_us_lacey_db_session()
+    try:
+        set_tenant_db_context(session, organization_id)
+        document = session.scalar(
+            select(AssuranceDocument).where(
+                AssuranceDocument.organization_id == organization_id,
+                AssuranceDocument.id == document_id,
+            )
+        )
+        if document is not None:
+            document.processing_status = "FAILED"
+            document.last_error_code = code[:100]
+            document.last_error_message = message[:512]
+            session.commit()
+    except Exception:
+        session.rollback()
+        LOGGER.exception("Unable to persist batch-policy failure", extra={"organization_id": organization_id, "document_id": document_id})
+    finally:
+        session.close()
+
+
+def _preflight_existing_document(*, organization_id: int, descriptor: _DocumentDescriptor) -> None:
+    """Reject legacy queued bulk spreadsheets before the expensive parser allocates memory."""
+    suffix = PurePath(descriptor.filename).suffix.lower()
+    if suffix not in {".csv", ".xlsx", ".xls"}:
+        return
+    limits = shipment_spreadsheet_limits()
+    if descriptor.size_bytes > limits.max_bytes:
+        raise ShipmentBatchRejected(
+            "DATASET_TOO_LARGE_FOR_SHIPMENT_PIPELINE",
+            "This spreadsheet is a bulk or multi-shipment dataset and cannot be processed as one Lacey operation.",
+        )
+    settings = build_us_lacey_storage_settings()
+    vault = VaultService(
+        storage_settings=settings,
+        storage=get_us_lacey_storage_client(),
+        session_factory=get_us_lacey_db_session,
+    )
+    with vault.materialize_verified_download(
+        organization_id=organization_id,
+        document_id=descriptor.vault_public_id,
+    ) as verified:
+        if suffix == ".csv":
+            enforce_streamed_csv_budget(
+                chunks=verified.iter_chunks(chunk_size=256 * 1024),
+                size_bytes=descriptor.size_bytes,
+                limits=limits,
+            )
+            return
+        # XLS/XLSX are strictly byte-bounded before this join.
+        content = b"".join(verified.iter_chunks(chunk_size=256 * 1024))
+        enforce_shipment_document_budget(filename=descriptor.filename, content=content, limits=limits)
 
 
 def _refresh_operation(*, organization_id: int, operation_id: int) -> str:
@@ -145,13 +231,46 @@ def process_one_us_lacey_job(
         )
 
     try:
-        assurance_public_id = _assurance_public_id(
+        descriptor = _document_descriptor(
             organization_id=job.organization_id,
             document_id=job.assurance_document_id,
         )
+        try:
+            _preflight_existing_document(
+                organization_id=job.organization_id,
+                descriptor=descriptor,
+            )
+        except ShipmentBatchRejected as exc:
+            _mark_document_policy_failure(
+                organization_id=job.organization_id,
+                document_id=job.assurance_document_id,
+                code=exc.code,
+                message=exc.safe_message,
+            )
+            queue_status = fail_us_lacey_job(
+                job_id=job.id,
+                worker_id=worker_id,
+                error_code=exc.code,
+                safe_error_message=exc.safe_message,
+                retryable=False,
+            )
+            operation_status = _refresh_operation(
+                organization_id=job.organization_id,
+                operation_id=job.operation_id,
+            )
+            return UsLaceyWorkerResult(
+                claimed=True,
+                job_id=job.id,
+                job_status=queue_status,
+                document_status="FAILED",
+                operation_status=operation_status,
+                projected_count=0,
+                conflict_count=0,
+            )
+
         document_status = _processing_service().process(
             organization_id=job.organization_id,
-            assurance_public_id=assurance_public_id,
+            assurance_public_id=descriptor.assurance_public_id,
         )
         if document_status == "FAILED":
             queue_status = fail_us_lacey_job(

--- a/src/litoral_trace/us_lacey/workflow.py
+++ b/src/litoral_trace/us_lacey/workflow.py
@@ -15,6 +15,7 @@ from sqlalchemy import select
 from litoral_trace.db.models import UsLaceyOperation
 from litoral_trace.db.tenant import set_tenant_db_context
 from litoral_trace.us_lacey.access import require_us_lacey_operational_access
+from litoral_trace.us_lacey.batch_hardening import ShipmentBatchRejected, enforce_shipment_document_budget
 from litoral_trace.us_lacey.db import get_us_lacey_db_session
 from litoral_trace.us_lacey.ingestion import UsLaceyIngestionResult, UsLaceyIngestionService
 from litoral_trace.us_lacey.jobs import UsLaceyJob, enqueue_us_lacey_document_job
@@ -102,13 +103,20 @@ def upload_and_enqueue_us_lacey_document(
     ingestion: UsLaceyIngestionService | None = None,
     operations: UsLaceyOperationService | None = None,
 ) -> UsLaceyQueuedUpload:
-    """Persist the immutable original, link it to the operation, then queue processing."""
+    """Persist one-shipment evidence, link it, then queue bounded processing."""
     # This operation has already consumed its plan slot. Customers must always be
     # able to finish uploads/review/exports for existing work, even at quota.
     require_us_lacey_operational_access(
         organization_id=organization_id,
         require_operation_slot=False,
     )
+    # Fail before Vault writes and before queue creation when a spreadsheet is a
+    # bulk/multi-shipment dataset. Such datasets belong to the benchmark importer.
+    try:
+        enforce_shipment_document_budget(filename=filename, content=content)
+    except ShipmentBatchRejected as exc:
+        raise UsLaceyWorkflowError(exc.safe_message) from exc
+
     operation_service = operations or UsLaceyOperationService()
     operation_id = operation_service.get_internal_id(
         organization_id=organization_id,

--- a/src/litoral_trace/web/us_lacey_worker_app.py
+++ b/src/litoral_trace/web/us_lacey_worker_app.py
@@ -1,0 +1,77 @@
+"""Dedicated U.S. Lacey worker service entrypoint.
+
+Deploy this ASGI app as a separate Render service with the same U.S. database
+and Vault credentials. Customer web traffic never enters this process.
+"""
+from __future__ import annotations
+
+from contextlib import asynccontextmanager
+import logging
+import os
+import socket
+import threading
+import time
+from uuid import uuid4
+
+from fastapi import FastAPI, Response, status
+
+from litoral_trace.us_lacey.jobs import recover_stale_us_lacey_jobs
+from litoral_trace.us_lacey.worker import process_one_us_lacey_job
+from litoral_trace.us_lacey.worker_db import get_us_lacey_worker_database_url
+
+
+_LOG = logging.getLogger("litoral_trace.us_lacey.dedicated_worker")
+
+
+def _loop(stop: threading.Event, app: FastAPI) -> None:
+    worker_id = f"dedicated-{socket.gethostname()}-{uuid4().hex[:12]}"
+    poll = max(0.25, min(30.0, float(os.getenv("US_LACEY_WORKER_POLL_SECONDS", "2"))))
+    recovery_every = max(30, min(3600, int(os.getenv("US_LACEY_WORKER_RECOVERY_EVERY_SECONDS", "60"))))
+    stale_after = max(60, min(86400, int(os.getenv("US_LACEY_WORKER_STALE_AFTER_SECONDS", "600"))))
+    next_recovery = 0.0
+    _LOG.info("dedicated_worker_started worker_id=%s", worker_id)
+    while not stop.is_set():
+        now = time.monotonic()
+        if now >= next_recovery:
+            try:
+                recover_stale_us_lacey_jobs(stale_after_seconds=stale_after)
+            except Exception:
+                _LOG.exception("dedicated_stale_recovery_failed")
+            next_recovery = now + recovery_every
+        try:
+            result = process_one_us_lacey_job(worker_id=worker_id)
+            app.state.last_worker_success = time.monotonic()
+            if result.claimed:
+                continue
+        except Exception:
+            _LOG.exception("dedicated_worker_iteration_failed")
+        stop.wait(poll)
+    _LOG.info("dedicated_worker_stopped worker_id=%s", worker_id)
+
+
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    get_us_lacey_worker_database_url()
+    stop = threading.Event()
+    thread = threading.Thread(target=_loop, args=(stop, app), daemon=True, name="us-lacey-dedicated-worker")
+    app.state.stop = stop
+    app.state.thread = thread
+    app.state.last_worker_success = 0.0
+    thread.start()
+    try:
+        yield
+    finally:
+        stop.set()
+        thread.join(timeout=10)
+
+
+app = FastAPI(title="Litoral Trace U.S. Lacey Worker", docs_url=None, redoc_url=None, openapi_url=None, lifespan=lifespan)
+
+
+@app.get("/health")
+def health(response: Response) -> dict[str, str]:
+    thread = getattr(app.state, "thread", None)
+    if thread is None or not thread.is_alive():
+        response.status_code = status.HTTP_503_SERVICE_UNAVAILABLE
+        return {"status": "not_ready", "service": "us-lacey-worker"}
+    return {"status": "healthy", "service": "us-lacey-worker"}

--- a/tests/test_us_lacey_memory_batch_hardening.py
+++ b/tests/test_us_lacey_memory_batch_hardening.py
@@ -1,0 +1,101 @@
+from __future__ import annotations
+
+from io import BytesIO
+from types import SimpleNamespace
+
+import pytest
+
+from litoral_trace.assurance.parsers import ParsedDocument, ParsedTable, SourceLocation
+from litoral_trace.assurance.processing import _persist_raw_parsed_fields
+from litoral_trace.lacey_benchmark.bulk_csv import iter_bulk_csv_batches
+from litoral_trace.us_lacey.batch_hardening import (
+    DATASET_TOO_COMPLEX,
+    ShipmentBatchRejected,
+    ShipmentSpreadsheetLimits,
+    enforce_shipment_document_budget,
+    inspect_csv_chunks_for_shipment,
+)
+from litoral_trace.us_lacey import workflow
+
+
+def _limits(*, rows: int = 5, columns: int = 8, cells: int = 32, size: int = 1024 * 1024):
+    return ShipmentSpreadsheetLimits(max_bytes=size, max_rows=rows, max_columns=columns, max_cells=cells)
+
+
+def test_small_shipment_csv_passes_bounded_profile():
+    content = b"BOL,Container,Quantity\nABC123,MSCU1234567,10\nABC123,MSCU1234567,12\n"
+    profile = enforce_shipment_document_budget(filename="packing.csv", content=content, limits=_limits())
+    assert profile is not None
+    assert profile.file_kind == "CSV"
+    assert profile.rows == 2
+    assert profile.columns == 3
+
+
+def test_bulk_csv_is_rejected_before_shipment_processing():
+    content = b"BOL,Container\n" + b"ABC,MSCU1234567\n" * 8
+    with pytest.raises(ShipmentBatchRejected) as captured:
+        inspect_csv_chunks_for_shipment((content,), size_bytes=len(content), limits=_limits(rows=5, cells=40))
+    assert captured.value.code == DATASET_TOO_COMPLEX
+    assert "bulk" in captured.value.safe_message.lower()
+
+
+def test_customer_workflow_rejects_bulk_before_ingestion_or_queue(monkeypatch):
+    monkeypatch.setattr(workflow, "require_us_lacey_operational_access", lambda **kwargs: None)
+    monkeypatch.setenv("US_LACEY_SHIPMENT_SPREADSHEET_MAX_ROWS", "100")
+    monkeypatch.setenv("US_LACEY_SHIPMENT_SPREADSHEET_MAX_CELLS", "1000")
+    content = b"a,b\n" + b"1,2\n" * 101
+
+    class ShouldNotRun:
+        def get_internal_id(self, **kwargs):
+            raise AssertionError("operation lookup must not run for rejected bulk data")
+
+    with pytest.raises(workflow.UsLaceyWorkflowError) as captured:
+        workflow.upload_and_enqueue_us_lacey_document(
+            organization_id=1,
+            user_id=1,
+            operation_public_id="00000000-0000-0000-0000-000000000001",
+            filename="abril.csv",
+            content_type="text/csv",
+            content=content,
+            operations=ShouldNotRun(),
+        )
+    assert "bulk" in str(captured.value).lower()
+
+
+def test_bulk_importer_batches_without_shipment_semantics():
+    content = b"country,weight\nCO,10\nBR,20\nCL,30\nAR,40\nUY,50\n"
+    batches = list(iter_bulk_csv_batches(BytesIO(content), batch_size=2))
+    assert [len(batch.rows) for batch in batches] == [2, 2, 1]
+    assert batches[0].start_row == 1
+    assert batches[-1].end_row == 5
+    assert batches[0].headers == ("country", "weight")
+
+
+def test_large_spreadsheet_raw_persistence_uses_schema_summary(monkeypatch):
+    monkeypatch.setenv("LT_ASSURANCE_RAW_CELL_PERSIST_LIMIT", "100")
+    table = ParsedTable(
+        name="sheet",
+        headers=("a", "b"),
+        rows=tuple({"a": str(index), "b": str(index)} for index in range(60)),
+        source=SourceLocation(sheet="sheet", row=1, locator="sheet:sheet;header_row:1"),
+    )
+    parsed = ParsedDocument(file_kind="CSV", tables=(table,), metadata={"row_count": 60})
+
+    class FakeSession:
+        def __init__(self):
+            self.added = []
+        def add(self, value):
+            self.added.append(value)
+
+    session = FakeSession()
+    count = _persist_raw_parsed_fields(
+        session,
+        organization_id=1,
+        assurance_document=SimpleNamespace(id=10),
+        extraction_run=SimpleNamespace(id=20),
+        parsed=parsed,
+    )
+    assert count == 1
+    assert len(session.added) == 1
+    assert session.added[0].field_name == "raw.table.1.schema"
+    assert session.added[0].value_type == "table_schema"


### PR DESCRIPTION
## Memory/Batch Hardening Gate

Fixes the Render OOM/restart loop observed when a DANE April bulk CSV was uploaded into one customer Lacey operation.

### Included
1. Reject bulk/multi-shipment spreadsheets before Vault/queue work using byte/row/column/cell budgets.
2. CSV upload validation now inspects only a bounded header sample instead of fully parsing the file.
3. Worker performs streaming CSV preflight before the existing parser can reconstruct the file in memory; legacy queued bulk CSVs are stopped safely.
4. Bounded shipment CSVs use incremental row parsing.
5. Large spreadsheet raw evidence is summarized as table schema/provenance instead of one ORM object per raw cell; semantic candidates remain persisted.
6. Adds a separate constant-memory bulk benchmark importer + CLI for DANE/CBP/FOIA datasets.
7. Adds configurable complexity limits.
8. Deterministic batch-policy failures are permanent/non-retryable, preventing OOM retry loops.
9. Adds a dedicated worker ASGI entrypoint so heavy processing can be moved out of the customer web service once Render credentials are attached.

### Incident evidence
Render free service limit is ~512 MiB. The affected upload was accepted at 19:56:23Z; memory rose from ~180 MiB to ~376 MiB before a process restart, then the stale/retry path produced a second rise to ~439 MiB and another restart. This PR addresses both the allocation path and retry behavior.

### Safety
- No schema migration.
- No PPQ/ACE/LAWGS semantic change.
- No authoritative AI behavior change.
- Original evidence remains Vault-first for accepted shipment files.
- Bulk benchmark data is deliberately separated from customer shipment operations.

Do not merge unless general CI and the U.S. Lacey PostgreSQL gate are green on the exact final SHA.