### PR TITLE
fix(us-lacey): make bulk rejection customer-facing

### DIFF
--- a/src/litoral_trace/templates/us_lacey/operation_detail.html
+++ b/src/litoral_trace/templates/us_lacey/operation_detail.html
@@ -3,16 +3,37 @@
 {% from "components/ui.html" import button, alert, page_header %}
 {% block lacey_title %}Review shipment{% endblock %}
 {% block lacey_content %}
+{% set bulk_upload_rejection = error and error.startswith("This file contains multiple shipments.") %}
+{% set empty_bulk_rejection = bulk_upload_rejection and not detail.documents %}
 {{ page_header(detail.client_reference, "Lacey Act Declaration Preparation", "Human-reviewed preparation for ACE / LAWGS workflows. Litoral Trace does not submit this operation.", icon="fa-folder-open") }}
+
+{% if bulk_upload_rejection %}
+<section class="lt-alert lt-alert--warning" role="status" data-bulk-upload-rejection>
+    <i class="fa-solid fa-triangle-exclamation lt-alert__icon" aria-hidden="true"></i>
+    <div>
+        <p class="lt-alert__title">This file contains multiple shipments</p>
+        <p class="lt-alert__message">Litoral Trace processes one shipment per operation. Split this file so it contains only one shipment, then upload that file to this operation.</p>
+        <p class="mt-2 text-xs font-semibold text-slate-600">Nothing was added to this operation.</p>
+    </div>
+</section>
+{% elif error %}
+{{ alert("We could not complete that action", error, "danger") }}
+{% endif %}
+{% if notice %}{{ alert("Update complete", notice, "positive") }}{% endif %}
+
+{% if not empty_bulk_rejection %}
 <section id="engine2-dossier" class="lt-card mb-6 p-6" data-engine2-dossier data-engine2-availability="{{ engine2_dossier.availability }}"><h2 class="text-lg font-bold text-slate-950">Document evidence analysis</h2><p class="mt-2 text-sm text-slate-600">Read-only evidence preview. This is not a legal compliance determination. The human-reviewed preparation record remains authoritative; no ACE or LAWGS submission is made.</p>{% if engine2_dossier.availability != "CURRENT" %}<p class="mt-4 text-sm text-slate-700">{{ engine2_dossier.safe_status_message }}</p>{% else %}<div class="mt-4"><span data-engine2-readiness="{{ engine2_dossier.readiness }}">Preparation readiness: {{ engine2_dossier.readiness|replace("_", " ") }}</span></div><div class="mt-5 grid gap-3">{% for field in engine2_dossier.fields %}<article class="rounded-lg border border-slate-200 p-3" data-engine2-field="{{ field.field_key }}" data-engine2-state="{{ field.state }}"><strong>{{ field.label }}</strong> · {{ field.state|replace("_", " ") }}{% if field.values %}<p class="mt-1">{{ field.values|join(", ") }}</p>{% else %}<p class="mt-1">Missing</p>{% endif %}{% if field.evidence %}<details class="mt-2"><summary>Evidence ({{ field.evidence|length }})</summary>{% for evidence in field.evidence %}<p class="text-xs" data-engine2-evidence data-engine2-evidence-class="{{ evidence.evidence_class }}" data-engine2-source-page="{{ evidence.page }}"><strong>{{ evidence.source_filename }}</strong> · page {{ evidence.page }} · {{ evidence.evidence_class }}<br>Source: {{ evidence.source_text }}<br>Raw: {{ evidence.raw_text }} · Normalized: {{ evidence.normalized_value }} · score {{ evidence.candidate_score }} · authority {{ evidence.source_authority }} · {{ evidence.scope }}{% if evidence.line_key %} · line {{ evidence.line_key }}{% endif %}{% if evidence.component_key %} · component {{ evidence.component_key }}{% endif %}{% if evidence.bbox %} · bbox {{ evidence.bbox|join(", ") }}{% endif %}</p>{% endfor %}</details>{% endif %}</article>{% endfor %}</div>{% if engine2_dossier.issues %}<div class="mt-5 grid gap-3">{% for issue in engine2_dossier.issues %}<article class="rounded-lg border border-amber-200 p-3" data-engine2-issue><strong>{{ issue.label }}</strong> · {{ issue.severity }} · {{ issue.issue_type }}<p>{{ issue.message }}</p><p class="text-xs">Human review required: {{ issue.requires_human_review }} · {{ issue.source_filenames|join(", ") }}{% if issue.line_key %} · line {{ issue.line_key }}{% endif %}{% if issue.component_key %} · component {{ issue.component_key }}{% endif %}</p></article>{% endfor %}</div>{% endif %}{% endif %}</section>
-{% if error %}{{ alert(error, "error") }}{% endif %}
-{% if notice %}{{ alert(notice, "success") }}{% endif %}
+{% endif %}
+
+{% set processing_step_state = "pending" if empty_bulk_rejection else ("current" if not processing.terminal else "complete") %}
 <ol class="lt-progress-steps mb-6 border-b border-slate-200 pb-4 sm:grid sm:grid-cols-5" aria-label="Preparation workflow">
-{% for title,state in [("Documents", "complete" if detail.documents else "current"),("Processing", "current" if not processing.terminal else "complete"),("Review", "current" if processing.state == "READY_FOR_REVIEW" else "pending"),("Final confirmation", "current" if detail.status == "COMPLETED" else "pending"),("Preparation package", "complete" if detail.status == "COMPLETED" else "pending")] %}
+{% for title,state in [("Documents", "complete" if detail.documents else "current"),("Processing", processing_step_state),("Review", "current" if processing.state == "READY_FOR_REVIEW" else "pending"),("Final confirmation", "current" if detail.status == "COMPLETED" else "pending"),("Preparation package", "complete" if detail.status == "COMPLETED" else "pending")] %}
 <li class="lt-progress-step" data-state="{{ state }}"><span class="lt-progress-step__marker" aria-hidden="true">{% if state == "complete" %}✓{% else %}{{ loop.index }}{% endif %}</span><p class="lt-progress-step__title">{{ title }}</p></li>
 {% endfor %}</ol>
 <section class="lt-card p-6"><div class="flex flex-wrap items-start justify-between gap-4"><div><h2 class="text-lg font-bold text-slate-950">Documents</h2><p class="mt-1 text-sm text-slate-600">Upload source documents. We preserve the original files as evidence.</p></div><span class="text-sm font-semibold text-slate-600">{{ detail.document_count }} document{{ '' if detail.document_count == 1 else 's' }}</span></div>
 <form method="post" enctype="multipart/form-data" action="/operations/{{ detail.public_id }}/upload" class="lt-form mt-5 grid gap-4 md:grid-cols-[minmax(0,1fr)_minmax(0,1fr)_auto] md:items-end"><input type="hidden" name="csrf_token" value="{{ upload_csrf }}"><label class="lt-field"><span class="lt-field__label">Document type</span><select id="document_role" class="lt-control" name="document_role"><option value="UNKNOWN" selected>Auto-detect when possible</option>{% for value,label in [("COMMERCIAL_INVOICE","Commercial invoice"),("PACKING_LIST","Packing list"),("BILL_OF_LADING","Bill of lading"),("SUPPLIER_DECLARATION","Supplier declaration"),("CERTIFICATE","Certificate"),("OTHER","Other document")] %}<option value="{{ value }}">{{ label }}</option>{% endfor %}</select><span class="mt-1 block text-xs text-slate-500">Choose a type only when you know it; we never assume an unknown file is a supplier sheet.</span></label><label class="lt-field"><span class="lt-field__label">PDF, XLSX, XLS or CSV</span><input id="document" class="lt-control" name="document" type="file" accept=".pdf,.xlsx,.xls,.csv" required></label>{{ button("Upload and analyze", variant="primary", button_type="submit") }}</form>
 <div class="mt-5 grid gap-2">{% for doc in detail.documents %}<div class="flex flex-wrap items-center justify-between gap-2 rounded-lg border border-slate-200 px-3 py-2"><span class="font-semibold text-slate-900">{{ doc.filename }}</span><span class="text-xs font-semibold text-slate-600">{{ doc.document_role|replace('_', ' ')|title }}</span></div>{% else %}<p class="text-sm text-slate-600">No documents uploaded yet.</p>{% endfor %}</div></section>
+{% if not empty_bulk_rejection %}
 <div class="mt-6" id="processing-panel" {% if not processing.terminal %}hx-get="/operations/{{ detail.public_id }}/processing-fragment" hx-trigger="every 2s" hx-swap="outerHTML"{% endif %}>{% include "us_lacey/fragments/processing_fragment_body.html" %}</div>
+{% endif %}
 {% endblock %}

--- a/src/litoral_trace/us_lacey/batch_hardening.py
+++ b/src/litoral_trace/us_lacey/batch_hardening.py
@@ -60,8 +60,9 @@ def shipment_spreadsheet_limits() -> ShipmentSpreadsheetLimits:
 
 def _bulk_message() -> str:
     return (
-        "This spreadsheet appears to contain a bulk or multi-shipment dataset and is too large for one Lacey operation. "
-        "Use the Litoral bulk benchmark importer instead; the shipment workspace is reserved for documents belonging to one shipment."
+        "This file contains multiple shipments. "
+        "Litoral Trace processes one shipment per operation. "
+        "Split this file so it contains only one shipment, then upload that file to this operation."
     )
 
 

--- a/tests/test_us_lacey_bulk_rejection_ux_contract.py
+++ b/tests/test_us_lacey_bulk_rejection_ux_contract.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from jinja2 import Environment
+
+
+ROOT = Path(__file__).resolve().parents[1]
+TEMPLATE = ROOT / "src" / "litoral_trace" / "templates" / "us_lacey" / "operation_detail.html"
+
+
+def test_bulk_rejection_is_customer_guidance_not_internal_error_ui():
+    source = TEMPLATE.read_text(encoding="utf-8")
+    Environment().parse(source)
+
+    assert 'error.startswith("This file contains multiple shipments.")' in source
+    assert 'data-bulk-upload-rejection' in source
+    assert '>This file contains multiple shipments</p>' in source
+    assert (
+        "Litoral Trace processes one shipment per operation. Split this file so it contains only one shipment, "
+        "then upload that file to this operation."
+    ) in source
+    assert "Nothing was added to this operation." in source
+
+    lowered = source.lower()
+    assert "bulk benchmark" not in lowered
+    assert "benchmark importer" not in lowered
+    assert "try again" not in lowered
+    assert "contact support" not in lowered
+
+
+def test_empty_bulk_rejection_keeps_documents_current_and_processing_pending():
+    source = TEMPLATE.read_text(encoding="utf-8")
+
+    assert '{% set empty_bulk_rejection = bulk_upload_rejection and not detail.documents %}' in source
+    assert '("Documents", "complete" if detail.documents else "current")' in source
+    assert '{% set processing_step_state = "pending" if empty_bulk_rejection else' in source
+    assert '("Processing", processing_step_state)' in source
+
+    # A rejected first upload must not imply analysis started or poll a job that
+    # was never queued. Existing analysis remains visible when documents already
+    # belong to the operation.
+    assert source.count('{% if not empty_bulk_rejection %}') >= 2
+    assert 'id="engine2-dossier"' in source
+    assert 'id="processing-panel"' in source
+
+
+def test_generic_errors_remain_distinct_from_expected_bulk_guidance():
+    source = TEMPLATE.read_text(encoding="utf-8")
+
+    assert '{% elif error %}' in source
+    assert '{{ alert("We could not complete that action", error, "danger") }}' in source
+    assert '{{ alert("Update complete", notice, "positive") }}' in source

--- a/tests/test_us_lacey_memory_batch_hardening.py
+++ b/tests/test_us_lacey_memory_batch_hardening.py
@@ -18,6 +18,13 @@ from litoral_trace.us_lacey.batch_hardening import (
 from litoral_trace.us_lacey import workflow
 
 
+CUSTOMER_BULK_REJECTION = (
+    "This file contains multiple shipments. "
+    "Litoral Trace processes one shipment per operation. "
+    "Split this file so it contains only one shipment, then upload that file to this operation."
+)
+
+
 def _limits(*, rows: int = 5, columns: int = 8, cells: int = 32, size: int = 1024 * 1024):
     return ShipmentSpreadsheetLimits(max_bytes=size, max_rows=rows, max_columns=columns, max_cells=cells)
 
@@ -31,12 +38,15 @@ def test_small_shipment_csv_passes_bounded_profile():
     assert profile.columns == 3
 
 
-def test_bulk_csv_is_rejected_before_shipment_processing():
+def test_bulk_csv_is_rejected_before_shipment_processing_with_customer_safe_copy():
     content = b"BOL,Container\n" + b"ABC,MSCU1234567\n" * 8
     with pytest.raises(ShipmentBatchRejected) as captured:
         inspect_csv_chunks_for_shipment((content,), size_bytes=len(content), limits=_limits(rows=5, cells=40))
     assert captured.value.code == DATASET_TOO_COMPLEX
-    assert "bulk" in captured.value.safe_message.lower()
+    assert captured.value.safe_message == CUSTOMER_BULK_REJECTION
+    assert "benchmark" not in captured.value.safe_message.lower()
+    assert "pipeline" not in captured.value.safe_message.lower()
+    assert "importer" not in captured.value.safe_message.lower()
 
 
 def test_customer_workflow_rejects_bulk_before_ingestion_or_queue(monkeypatch):
@@ -59,7 +69,8 @@ def test_customer_workflow_rejects_bulk_before_ingestion_or_queue(monkeypatch):
             content=content,
             operations=ShouldNotRun(),
         )
-    assert "bulk" in str(captured.value).lower()
+    assert str(captured.value) == CUSTOMER_BULK_REJECTION
+    assert "benchmark" not in str(captured.value).lower()
 
 
 def test_bulk_importer_batches_without_shipment_semantics():


### PR DESCRIPTION
## Summary

Turn the expected multi-shipment/bulk upload rejection into customer guidance instead of an internal-looking processing error.

- replace benchmark/importer jargon with one-shipment guidance;
- render a dedicated warning state: **This file contains multiple shipments**;
- state clearly that nothing was added to the operation;
- keep Documents as the current step and Processing pending when the rejected first upload leaves the operation empty;
- suppress Engine 2 / processing placeholders for that empty rejected state;
- preserve existing analysis when an operation already has valid documents;
- keep unexpected errors on the generic danger path;
- add regression tests for safe copy and the template UX contract.

## Merge gate

Merge only after the final head SHA passes CI and the U.S. Lacey PostgreSQL gate with no unresolved review blockers.