### PR TITLE
fix(us-lacey): remove Wise from current commercial runtime

### DIFF
--- a/src/litoral_trace/us_lacey/commercial.py
+++ b/src/litoral_trace/us_lacey/commercial.py
@@ -50,18 +50,15 @@ def load_us_lacey_commercial_config(
 ) -> UsLaceyCommercialConfig:
     env = os.environ if environ is None else environ
     provider = _required(env, "US_LACEY_PAYMENT_PROVIDER").upper()
-    # WISE remains accepted only as a backward-compatible deployment value so
-    # an existing environment cannot become unready during the Lemon cutover.
-    # New commercial configuration is intended to use LEMON_SQUEEZY.
-    if provider not in {"MANUAL_BANK_TRANSFER", "WISE", "LEMON_SQUEEZY"}:
+    if provider not in {"MANUAL_BANK_TRANSFER", "LEMON_SQUEEZY"}:
         raise UsLaceyCommercialConfigurationError(
-            "US_LACEY_PAYMENT_PROVIDER must be MANUAL_BANK_TRANSFER, WISE, or LEMON_SQUEEZY."
+            "US_LACEY_PAYMENT_PROVIDER must be MANUAL_BANK_TRANSFER or LEMON_SQUEEZY."
         )
 
     bank_instructions = str(env.get("US_LACEY_BANK_TRANSFER_INSTRUCTIONS", "")).strip()
-    if provider in {"MANUAL_BANK_TRANSFER", "WISE"} and not bank_instructions:
+    if provider == "MANUAL_BANK_TRANSFER" and not bank_instructions:
         raise UsLaceyCommercialConfigurationError(
-            "US_LACEY_BANK_TRANSFER_INSTRUCTIONS is required for transfer-based payment."
+            "US_LACEY_BANK_TRANSFER_INSTRUCTIONS is required for manual bank transfer."
         )
 
     support_email = str(env.get("US_LACEY_SUPPORT_EMAIL", "support@litoraltrace.com")).strip().lower()

--- a/tests/test_us_lacey_no_wise_runtime_contract.py
+++ b/tests/test_us_lacey_no_wise_runtime_contract.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+import pytest
+
+from litoral_trace.us_lacey.commercial import (
+    UsLaceyCommercialConfigurationError,
+    load_us_lacey_commercial_config,
+)
+
+
+def _env(**overrides: str) -> dict[str, str]:
+    values = {
+        "US_LACEY_PRIVATE_BETA_PRICE_CENTS": "12500",
+        "US_LACEY_MONTHLY_OPERATION_LIMIT": "25",
+        "US_LACEY_PAYMENT_PROVIDER": "LEMON_SQUEEZY",
+        "US_LACEY_TERMS_VERSION": "terms-v1",
+        "US_LACEY_PRIVACY_VERSION": "privacy-v1",
+        "US_LACEY_BETA_TERMS_VERSION": "beta-v1",
+        "US_LACEY_SUPPORT_EMAIL": "support@litoraltrace.com",
+    }
+    values.update(overrides)
+    return values
+
+
+def test_lemon_squeezy_remains_valid_without_transfer_instructions() -> None:
+    config = load_us_lacey_commercial_config(_env())
+    assert config.payment_provider == "LEMON_SQUEEZY"
+    assert config.bank_transfer_instructions == ""
+
+
+def test_wise_is_rejected_fail_closed() -> None:
+    with pytest.raises(
+        UsLaceyCommercialConfigurationError,
+        match="MANUAL_BANK_TRANSFER or LEMON_SQUEEZY",
+    ):
+        load_us_lacey_commercial_config(
+            _env(
+                US_LACEY_PAYMENT_PROVIDER="WISE",
+                US_LACEY_BANK_TRANSFER_INSTRUCTIONS="must never be used",
+            )
+        )
+
+
+def test_manual_bank_transfer_requires_explicit_instructions() -> None:
+    with pytest.raises(
+        UsLaceyCommercialConfigurationError,
+        match="US_LACEY_BANK_TRANSFER_INSTRUCTIONS",
+    ):
+        load_us_lacey_commercial_config(
+            _env(US_LACEY_PAYMENT_PROVIDER="MANUAL_BANK_TRANSFER")
+        )

--- a/tests/test_us_lacey_pilot_core.py
+++ b/tests/test_us_lacey_pilot_core.py
@@ -29,7 +29,7 @@ def _safe_env() -> dict[str, str]:
         "US_LACEY_APP_HOSTNAME": "lacey.litoraltrace.com",
         "US_LACEY_PRIVATE_BETA_PRICE_CENTS": "12500",
         "US_LACEY_MONTHLY_OPERATION_LIMIT": "25",
-        "US_LACEY_PAYMENT_PROVIDER": "WISE",
+        "US_LACEY_PAYMENT_PROVIDER": "MANUAL_BANK_TRANSFER",
         "US_LACEY_BANK_TRANSFER_INSTRUCTIONS": "Use the payment reference shown in Billing.",
         "US_LACEY_TERMS_VERSION": "terms-2026-08",
         "US_LACEY_PRIVACY_VERSION": "privacy-2026-08",

--- a/tests/test_us_lacey_portal_flow.py
+++ b/tests/test_us_lacey_portal_flow.py
@@ -22,7 +22,7 @@ def _portal_env(monkeypatch) -> None:
         "US_LACEY_APP_HOSTNAME": "app.lacey.litoraltrace.com",
         "US_LACEY_PRIVATE_BETA_PRICE_CENTS": "12500",
         "US_LACEY_MONTHLY_OPERATION_LIMIT": "25",
-        "US_LACEY_PAYMENT_PROVIDER": "WISE",
+        "US_LACEY_PAYMENT_PROVIDER": "MANUAL_BANK_TRANSFER",
         "US_LACEY_BANK_TRANSFER_INSTRUCTIONS": "Send USD and include the exact reference.",
         "US_LACEY_TERMS_VERSION": "terms-v1",
         "US_LACEY_PRIVACY_VERSION": "privacy-v1",
@@ -206,7 +206,7 @@ def test_payment_pending_account_can_view_billing_but_not_self_activate(monkeypa
         subscription_status="PENDING",
         payment_status="PENDING",
         payment_reference="LT-US-ABC123",
-        payment_provider="WISE",
+        payment_provider="MANUAL_BANK_TRANSFER",
     )
     monkeypatch.setattr(
         "litoral_trace.web.us_lacey_pilot_app.resolve_us_lacey_session",
@@ -281,7 +281,7 @@ def test_pilot_billing_and_operations_render_canonical_action_contracts(monkeypa
         subscription_status="PILOT",
         payment_status="WAIVED",
         payment_reference="LT-US-PILOT",
-        payment_provider="WISE",
+        payment_provider="MANUAL_BANK_TRANSFER",
     )
     detail = SimpleNamespace(
         public_id="OP-DEMO",

--- a/tests/test_us_lacey_portal_http_postgres_e2e.py
+++ b/tests/test_us_lacey_portal_http_postgres_e2e.py
@@ -26,8 +26,8 @@ def _configure_customer_portal(monkeypatch: pytest.MonkeyPatch) -> None:
         "US_LACEY_SESSION_TTL_HOURS": "1",
         "US_LACEY_PRIVATE_BETA_PRICE_CENTS": "12500",
         "US_LACEY_MONTHLY_OPERATION_LIMIT": "25",
-        "US_LACEY_PAYMENT_PROVIDER": "WISE",
-        "US_LACEY_BANK_TRANSFER_INSTRUCTIONS": "CI-only Wise USD transfer instructions",
+        "US_LACEY_PAYMENT_PROVIDER": "MANUAL_BANK_TRANSFER",
+        "US_LACEY_BANK_TRANSFER_INSTRUCTIONS": "CI-only manual USD transfer instructions",
         "US_LACEY_TERMS_VERSION": "terms-http-e2e-v1",
         "US_LACEY_PRIVACY_VERSION": "privacy-http-e2e-v1",
         "US_LACEY_BETA_TERMS_VERSION": "beta-http-e2e-v1",
@@ -131,7 +131,7 @@ def test_signup_verify_login_billing_logout_real_http_and_postgres(
         assert "How to complete the payment" in billing.text
         assert "Payment matching code" in billing.text
         assert "bank account, payment link or destination address" in billing.text
-        assert "CI-only Wise USD transfer instructions" in billing.text
+        assert "CI-only manual USD transfer instructions" in billing.text
         assert "Document processing unlocks only after Litoral Trace verifies the payment server-side" in billing.text
         assert "verify-payment" not in billing.text.lower()
 

--- a/tests/test_us_lacey_portal_postgres_integration.py
+++ b/tests/test_us_lacey_portal_postgres_integration.py
@@ -34,7 +34,7 @@ def _commercial_config() -> UsLaceyCommercialConfig:
     return UsLaceyCommercialConfig(
         price_cents=12500,
         monthly_operation_limit=25,
-        payment_provider="WISE",
+        payment_provider="MANUAL_BANK_TRANSFER",
         bank_transfer_instructions="CI-only payment instructions",
         terms_version="terms-ci-v1",
         privacy_version="privacy-ci-v1",

--- a/tests/test_us_lacey_self_service_scale.py
+++ b/tests/test_us_lacey_self_service_scale.py
@@ -63,7 +63,7 @@ def _commercial_config() -> UsLaceyCommercialConfig:
     return UsLaceyCommercialConfig(
         price_cents=12500,
         monthly_operation_limit=25,
-        payment_provider="WISE",
+        payment_provider="MANUAL_BANK_TRANSFER",
         bank_transfer_instructions="Configured outside source control",
         terms_version="terms-2026-08",
         privacy_version="privacy-2026-08",
@@ -74,13 +74,15 @@ def _commercial_config() -> UsLaceyCommercialConfig:
 
 def test_commercial_config_fails_closed_without_price_or_legal_versions():
     with pytest.raises(UsLaceyCommercialConfigurationError):
-        load_us_lacey_commercial_config({"US_LACEY_PAYMENT_PROVIDER": "WISE"})
+        load_us_lacey_commercial_config(
+            {"US_LACEY_PAYMENT_PROVIDER": "LEMON_SQUEEZY"}
+        )
 
 
 def test_commercial_config_accepts_explicit_launch_values():
     config = load_us_lacey_commercial_config(
         {
-            "US_LACEY_PAYMENT_PROVIDER": "WISE",
+            "US_LACEY_PAYMENT_PROVIDER": "MANUAL_BANK_TRANSFER",
             "US_LACEY_PRIVATE_BETA_PRICE_CENTS": "12500",
             "US_LACEY_MONTHLY_OPERATION_LIMIT": "25",
             "US_LACEY_BANK_TRANSFER_INSTRUCTIONS": "Configured at deploy time",
@@ -91,7 +93,7 @@ def test_commercial_config_accepts_explicit_launch_values():
     )
     assert config.price_cents == 12500
     assert config.monthly_operation_limit == 25
-    assert config.payment_provider == "WISE"
+    assert config.payment_provider == "MANUAL_BANK_TRANSFER"
 
 
 def test_registration_never_persists_raw_verification_token(monkeypatch):


### PR DESCRIPTION
## Summary

Replaces the stale #166 approach on the current U.S. Lacey head without introducing a competing Alembic 043 revision.

- `WISE` is no longer an accepted `US_LACEY_PAYMENT_PROVIDER` value;
- supported runtime providers are `LEMON_SQUEEZY` and explicit `MANUAL_BANK_TRANSFER` only;
- manual transfer still requires explicit instructions;
- Lemon remains valid without transfer instructions;
- active portal/runtime test fixtures now use supported providers;
- a fail-closed contract proves that `WISE` is rejected.

Historical database values remain readable for audit/backward readability. This patch changes active commercial configuration and new self-service behavior; it does not rewrite historical records.

## PR hygiene

The obsolete migration-based #166 is closed without merge. Its competing 043 revision must not be revived because the integration branch already has the canonical Engine 2 043 migration.

## Merge gate

Merge only after CI and the U.S. Lacey PostgreSQL gate pass on the exact final SHA.