### PR TITLE
fix(lacey): keep shipment file picker fully English

### DIFF
--- a/src/litoral_trace/templates/us_lacey/operations.html
+++ b/src/litoral_trace/templates/us_lacey/operations.html
@@ -19,13 +19,13 @@
 
   {% if entitlement.remaining_operations > 0 %}
   <form id="document-intake-form" class="mt-6" action="/operations/intake" method="post" enctype="multipart/form-data" data-upload-first-intake>
-    <label class="relative block cursor-pointer overflow-hidden rounded-2xl border-2 border-dashed border-emerald-200 bg-emerald-50/40 p-8 text-center transition hover:border-emerald-300 hover:bg-emerald-50">
+    <label for="intake-documents" class="block cursor-pointer rounded-2xl border-2 border-dashed border-emerald-200 bg-emerald-50/40 p-8 text-center transition hover:border-emerald-300 hover:bg-emerald-50">
       <span class="mx-auto flex h-12 w-12 items-center justify-center rounded-xl bg-emerald-600 text-white" aria-hidden="true"><i class="fa-solid fa-cloud-arrow-up"></i></span>
       <span class="mt-4 block text-lg font-bold text-slate-950">Choose your shipment files</span>
       <span class="mt-2 block text-sm text-slate-600">PDF, XLSX, XLS or CSV · select several files at once</span>
       <span class="mt-1 block text-xs text-slate-500">Commercial invoice, packing list, bill of lading, supplier/species declarations and supporting certificates can all be uploaded together.</span>
-      <input id="intake-documents" class="absolute inset-0 z-10 h-full w-full cursor-pointer opacity-0" name="documents" type="file" accept=".pdf,.xlsx,.xls,.csv" multiple required aria-describedby="intake-file-summary">
     </label>
+    <input id="intake-documents" hidden name="documents" type="file" accept=".pdf,.xlsx,.xls,.csv" multiple required aria-describedby="intake-file-summary">
     <div id="intake-file-summary" class="mt-3 text-sm text-slate-600" aria-live="polite">No files selected.</div>
     <div class="mt-5 flex flex-wrap items-center gap-3">
       {{ button("Upload and analyze", variant="primary", button_type="submit", icon="fa-wand-magic-sparkles") }}

--- a/src/litoral_trace/templates/us_lacey/operations.html
+++ b/src/litoral_trace/templates/us_lacey/operations.html
@@ -19,12 +19,12 @@
 
   {% if entitlement.remaining_operations > 0 %}
   <form id="document-intake-form" class="mt-6" action="/operations/intake" method="post" enctype="multipart/form-data" data-upload-first-intake>
-    <label class="block cursor-pointer rounded-2xl border-2 border-dashed border-emerald-200 bg-emerald-50/40 p-8 text-center transition hover:border-emerald-300 hover:bg-emerald-50">
+    <label class="relative block cursor-pointer overflow-hidden rounded-2xl border-2 border-dashed border-emerald-200 bg-emerald-50/40 p-8 text-center transition hover:border-emerald-300 hover:bg-emerald-50">
       <span class="mx-auto flex h-12 w-12 items-center justify-center rounded-xl bg-emerald-600 text-white" aria-hidden="true"><i class="fa-solid fa-cloud-arrow-up"></i></span>
       <span class="mt-4 block text-lg font-bold text-slate-950">Choose your shipment files</span>
       <span class="mt-2 block text-sm text-slate-600">PDF, XLSX, XLS or CSV · select several files at once</span>
       <span class="mt-1 block text-xs text-slate-500">Commercial invoice, packing list, bill of lading, supplier/species declarations and supporting certificates can all be uploaded together.</span>
-      <input id="intake-documents" class="sr-only" style="position:absolute;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;clip:rect(0,0,0,0);white-space:nowrap;border:0;" name="documents" type="file" accept=".pdf,.xlsx,.xls,.csv" multiple required aria-describedby="intake-file-summary">
+      <input id="intake-documents" class="absolute inset-0 z-10 h-full w-full cursor-pointer opacity-0" name="documents" type="file" accept=".pdf,.xlsx,.xls,.csv" multiple required aria-describedby="intake-file-summary">
     </label>
     <div id="intake-file-summary" class="mt-3 text-sm text-slate-600" aria-live="polite">No files selected.</div>
     <div class="mt-5 flex flex-wrap items-center gap-3">

--- a/src/litoral_trace/templates/us_lacey/operations.html
+++ b/src/litoral_trace/templates/us_lacey/operations.html
@@ -24,7 +24,7 @@
       <span class="mt-4 block text-lg font-bold text-slate-950">Choose your shipment files</span>
       <span class="mt-2 block text-sm text-slate-600">PDF, XLSX, XLS or CSV · select several files at once</span>
       <span class="mt-1 block text-xs text-slate-500">Commercial invoice, packing list, bill of lading, supplier/species declarations and supporting certificates can all be uploaded together.</span>
-      <input id="intake-documents" class="sr-only" name="documents" type="file" accept=".pdf,.xlsx,.xls,.csv" multiple required>
+      <input id="intake-documents" class="sr-only" style="position:absolute;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;clip:rect(0,0,0,0);white-space:nowrap;border:0;" name="documents" type="file" accept=".pdf,.xlsx,.xls,.csv" multiple required aria-describedby="intake-file-summary">
     </label>
     <div id="intake-file-summary" class="mt-3 text-sm text-slate-600" aria-live="polite">No files selected.</div>
     <div class="mt-5 flex flex-wrap items-center gap-3">

--- a/tests/test_us_lacey_english_shell.py
+++ b/tests/test_us_lacey_english_shell.py
@@ -34,3 +34,30 @@ def test_us_lacey_templates_do_not_contain_regional_spanish_navigation_copy():
         text = template.read_text(encoding="utf-8")
         for phrase in banned:
             assert phrase not in text, f"{template} contains regional Spanish copy: {phrase!r}"
+
+
+def test_us_lacey_customer_templates_do_not_expose_common_spanish_ui_copy():
+    banned = {
+        "Seleccionar archivo",
+        "Seleccionar archivos",
+        "Ningún archivo seleccionado",
+        "Ningún archivo",
+        "Iniciar sesión",
+        "Cerrar sesión",
+        "Correo electrónico",
+        "Contraseña",
+        "Facturación",
+        "Guardar cambios",
+        "Cancelar",
+        "Continuar",
+        "Volver",
+        "Subir archivos",
+        "Descargar",
+        "Procesando",
+        "Confirmar",
+    }
+
+    for template in sorted(US_LACEY_TEMPLATE_DIR.rglob("*.html")):
+        text = template.read_text(encoding="utf-8")
+        for phrase in banned:
+            assert phrase not in text, f"{template} contains Spanish customer UI copy: {phrase!r}"

--- a/tests/test_us_lacey_upload_first_ai_workflow.py
+++ b/tests/test_us_lacey_upload_first_ai_workflow.py
@@ -34,6 +34,15 @@ def test_operations_starts_with_multi_file_upload_and_no_manual_metadata_fields(
         assert old_manual_name not in source
 
 
+def test_operations_hides_locale_dependent_native_file_picker_chrome():
+    source = OPERATIONS_TEMPLATE.read_text(encoding="utf-8")
+    assert 'id="intake-documents"' in source
+    assert 'style="position:absolute;width:1px;height:1px;' in source
+    assert 'clip:rect(0,0,0,0)' in source
+    assert 'aria-describedby="intake-file-summary"' in source
+    assert ">No files selected.</div>" in source
+
+
 def test_found_values_are_suggestions_not_confirmed_data():
     detail = SimpleNamespace(
         fields=(

--- a/tests/test_us_lacey_upload_first_ai_workflow.py
+++ b/tests/test_us_lacey_upload_first_ai_workflow.py
@@ -36,8 +36,8 @@ def test_operations_starts_with_multi_file_upload_and_no_manual_metadata_fields(
 
 def test_operations_hides_locale_dependent_native_file_picker_chrome():
     source = OPERATIONS_TEMPLATE.read_text(encoding="utf-8")
-    assert 'id="intake-documents"' in source
-    assert 'class="absolute inset-0 z-10 h-full w-full cursor-pointer opacity-0"' in source
+    assert '<label for="intake-documents"' in source
+    assert 'id="intake-documents" hidden name="documents" type="file"' in source
     assert 'aria-describedby="intake-file-summary"' in source
     assert ">No files selected.</div>" in source
     assert 'style=' not in source

--- a/tests/test_us_lacey_upload_first_ai_workflow.py
+++ b/tests/test_us_lacey_upload_first_ai_workflow.py
@@ -37,10 +37,10 @@ def test_operations_starts_with_multi_file_upload_and_no_manual_metadata_fields(
 def test_operations_hides_locale_dependent_native_file_picker_chrome():
     source = OPERATIONS_TEMPLATE.read_text(encoding="utf-8")
     assert 'id="intake-documents"' in source
-    assert 'style="position:absolute;width:1px;height:1px;' in source
-    assert 'clip:rect(0,0,0,0)' in source
+    assert 'class="absolute inset-0 z-10 h-full w-full cursor-pointer opacity-0"' in source
     assert 'aria-describedby="intake-file-summary"' in source
     assert ">No files selected.</div>" in source
+    assert 'style=' not in source
 
 
 def test_found_values_are_suggestions_not_confirmed_data():


### PR DESCRIPTION
## Goal
Keep the U.S. Lacey customer surface fully English regardless of the browser/OS locale.

## Root cause
The shipment upload control is a native `<input type="file">`. Its browser-rendered chrome (for example `Seleccionar archivos` / `Ningún archivo seleccionado`) follows the user's browser/OS language. The existing `sr-only` utility was not reliably suppressing that native chrome on the deployed stylesheet.

## Fix
- retain the native file input for functionality/accessibility;
- add a CSS-independent visually-hidden fallback directly on the input so localized browser chrome cannot leak into the customer UI;
- keep the existing English custom summary (`No files selected.` / selected filenames);
- add `aria-describedby` to bind the input to that custom summary;
- add a regression test so future stylesheet drift cannot re-expose native localized labels.

## Expected UX
The upload area remains entirely in English. Users click the custom `Choose your shipment files` surface; after selection, Litoral Trace displays the custom English file summary instead of browser-localized native labels.