### PR TITLE
feat(lacey): semantic evidence graph and deterministic conflict intelligence

### DIFF
--- a/src/litoral_trace/lacey_engine/layout_parser.py
+++ b/src/litoral_trace/lacey_engine/layout_parser.py
@@ -56,6 +56,62 @@ def _ocr_blocks(content: bytes, page_numbers: set[int] | None = None) -> list[La
     return blocks
 
 
+def _table_blocks(*, page_number: int, table_number: int, rows: list) -> list[LayoutBlock]:
+    """Turn both key/value and matrix tables into semantic cells.
+
+    Earlier Engine 2 versions discarded every table wider than two columns.  That
+    destroyed the row relationship between component, genus, species, harvest
+    country, quantity and unit -- precisely the relationship a Lacey declaration
+    needs.  Matrix cells now carry a shared table/row identity and their header as
+    key_text/table_header so downstream extraction can reason about the row.
+    """
+    table_id = f"p{page_number}-t{table_number}"
+    clean_rows = [[_text(cell) for cell in (row or [])] for row in (rows or [])]
+    clean_rows = [row for row in clean_rows if any(row)]
+    if not clean_rows:
+        return []
+    is_key_value = all(len(row) == 2 for row in clean_rows)
+    blocks: list[LayoutBlock] = []
+    if is_key_value:
+        for row_index, cells in enumerate(clean_rows):
+            key, value = cells
+            if key or value:
+                blocks.append(LayoutBlock(
+                    f"{table_id}-r{row_index}", page_number, None,
+                    f"{key}: {value}", "TABLE_ROW", LayoutStructureType.KEY_VALUE_TABLE,
+                    table_id, row_index, None, key, key, value,
+                ))
+        return blocks
+
+    # Use the first non-empty row as a header only when at least two header cells
+    # contain alphabetic text.  It remains a conservative structural decision; no
+    # regulatory meaning is inferred from unlabeled numeric grids.
+    header = clean_rows[0]
+    header_signal = sum(bool(cell and any(ch.isalpha() for ch in cell)) for cell in header)
+    if header_signal < 2:
+        return blocks
+    for row_index, row in enumerate(clean_rows[1:], start=1):
+        padded = row + [""] * max(0, len(header) - len(row))
+        for column_index, (key, value) in enumerate(zip(header, padded)):
+            if not key or not value:
+                continue
+            blocks.append(LayoutBlock(
+                f"{table_id}-r{row_index}-c{column_index}",
+                page_number,
+                None,
+                f"{key}: {value}",
+                "TABLE_CELL",
+                LayoutStructureType.LINE_ITEM_TABLE,
+                table_id,
+                row_index,
+                column_index,
+                key,
+                key,
+                value,
+            ))
+    return blocks
+
+
 def _pdf_layout(content: bytes) -> ParsedLayout:
     try:
         import pdfplumber
@@ -108,20 +164,13 @@ def _pdf_layout(content: bytes) -> ParsedLayout:
                     if text:
                         blocks.append(LayoutBlock(f"p{page_number}-w{word_number}", page_number, _bbox(word), text, "WORD"))
                 for table_number, table in enumerate(page.find_tables() or [], start=1):
-                    table_id = f"p{page_number}-t{table_number}"
-                    rows = table.extract() or []
-                    # A consistently two-column table is semantically key/value.
-                    is_key_value = bool(rows) and all(len(row or []) == 2 for row in rows if row)
-                    for row_index, row in enumerate(rows):
-                        cells = row or []
-                        if is_key_value and len(cells) == 2:
-                            key, value = _text(cells[0]), _text(cells[1])
-                            if key or value:
-                                blocks.append(LayoutBlock(
-                                    f"{table_id}-r{row_index}", page_number, None,
-                                    f"{key}: {value}", "TABLE_ROW", LayoutStructureType.KEY_VALUE_TABLE,
-                                    table_id, row_index, None, key, key, value,
-                                ))
+                    blocks.extend(
+                        _table_blocks(
+                            page_number=page_number,
+                            table_number=table_number,
+                            rows=table.extract() or [],
+                        )
+                    )
                 # Mixed PDFs need OCR only for pages without digital layout.
                 if len(blocks) == page_start:
                     blocks.extend(_ocr_blocks(content, {page_number}))
@@ -147,3 +196,9 @@ def layout_from_key_value_rows(rows: list[tuple[str, str]]) -> ParsedLayout:
                     LayoutStructureType.KEY_VALUE_TABLE, "t1", i, None, key, key, value)
         for i, (key, value) in enumerate(rows)
     ), 1)
+
+
+def layout_from_matrix_rows(headers: list[str], rows: list[list[str]]) -> ParsedLayout:
+    """Deterministic test seam for component/line-item matrix tables."""
+    blocks = _table_blocks(page_number=1, table_number=1, rows=[headers, *rows])
+    return ParsedLayout(tuple(blocks), 1)

--- a/src/litoral_trace/lacey_engine/pipeline.py
+++ b/src/litoral_trace/lacey_engine/pipeline.py
@@ -165,7 +165,13 @@ def _extract(layout):
                 number = _explicit_number(value)
                 if number:
                     found["entered_value"].append(_candidate("entered_value", number, block, key, EvidenceClass.DERIVED, "entered_value"))
-            elif _ARTICLE_COMPONENT_LABEL.fullmatch(key) and _table_context(block):
+            elif _ARTICLE_COMPONENT_LABEL.fullmatch(key) and (
+                _table_context(block)
+                or re.fullmatch(r"article\s*/\s*component|article component", key, re.I)
+            ):
+                # A fully explicit Lacey/PPQ "Article / Component" label is safe
+                # outside a table.  The generic word "Component" remains table-only
+                # so unrelated document prose cannot become plant-component evidence.
                 found["article_component"].append(_candidate("article_component", value, block, key))
             elif re.fullmatch(r"genus|plant genus|scientific name genus", lower):
                 found["genus"].append(_candidate("genus", value, block, key))

--- a/src/litoral_trace/lacey_engine/pipeline.py
+++ b/src/litoral_trace/lacey_engine/pipeline.py
@@ -1,16 +1,30 @@
 """Public Engine 2.0 entrypoint; deliberately free of database and HTTP dependencies."""
 from __future__ import annotations
-import re
+
 from datetime import datetime
+import re
 
 from .admission import admit
 from .classifier import classify
-from .domain import AdmittedCandidate, DocumentResolution, EvidenceClass, Provenance, RawCandidate
+from .domain import (
+    AdmittedCandidate,
+    DocumentResolution,
+    EvidenceClass,
+    LayoutStructureType,
+    Provenance,
+    RawCandidate,
+)
 from .layout_parser import parse_layout
 from .ranking import resolve
 from .segmentation import segment
+from .semantic_graph import (
+    is_out_of_scope_context,
+    party_address,
+    party_core,
+    valid_mid_value,
+)
 
-ENGINE_VERSION = "lacey-engine-2.0.0"
+ENGINE_VERSION = "lacey-engine-2.1.0"
 _FIELDS = (
     "estimated_arrival_date",
     "bill_of_lading",
@@ -39,17 +53,17 @@ _MERCHANDISE_DESCRIPTION_LABEL = re.compile(
 _IMPORTER_NAME_LABEL = re.compile(r"(?:importer|importer name|importer of record|importer of record name)", re.I)
 _CONSIGNEE_NAME_LABEL = re.compile(r"(?:consignee|consignee name)", re.I)
 _ENTRY_LABEL = re.compile(r"(?:entry number|entry no\.?|filing entry reference|filing entry number)", re.I)
-_MID_LABEL = re.compile(r"(?:mid|manufacturer id|manufacturer identification|manufacturer identification code)", re.I)
+_MID_LABEL = re.compile(r"(?:mid|manufacturer id|manufacturer identification|manufacturer identification code(?: \(mid\))?)", re.I)
 _HTS_LABEL = re.compile(r"(?:hts|hts code|hts number|hts no\.?)", re.I)
 _ENTERED_VALUE_LABEL = re.compile(r"(?:entered value|customs entered value)", re.I)
-_ARTICLE_COMPONENT_LABEL = re.compile(r"(?:article\s*/\s*component|article component)", re.I)
+_ARTICLE_COMPONENT_LABEL = re.compile(r"(?:article\s*/\s*component|article component|component)", re.I)
 _PLANT_QUANTITY_LABEL = re.compile(r"(?:quantity of plant material|plant material quantity|plant quantity)", re.I)
 _PLANT_UNIT_LABEL = re.compile(r"(?:metric unit|plant unit|unit of plant material|plant material unit)", re.I)
 _PERCENT_RECYCLED_LABEL = re.compile(r"(?:percent recycled|recycled percentage|% recycled)", re.I)
 
 
 def _candidate(field: str, value: str, block, label: str, evidence=EvidenceClass.EXPLICIT, derived_from=None) -> RawCandidate:
-    return RawCandidate(field, value, value, block, evidence, f"lacey.{field}", "2.0.0", derived_from, label)
+    return RawCandidate(field, value, value, block, evidence, f"lacey.{field}", "2.1.0", derived_from, label)
 
 
 def _normalized_date(value: str) -> str | None:
@@ -62,15 +76,17 @@ def _normalized_date(value: str) -> str | None:
 
 
 def _explicit_number(value: str, *, allow_percent: bool = False) -> str | None:
-    """Deterministically strip formatting from an explicitly labelled numeric value."""
     text = " ".join(str(value or "").split()).strip()
-    pattern = r"(?:USD\s*|\$\s*)?([0-9][0-9,]*(?:\.[0-9]+)?)(?:\s*%)?" if allow_percent else r"(?:USD\s*|\$\s*)?([0-9][0-9,]*(?:\.[0-9]+)?)"
+    pattern = (
+        r"(?:USD\s*|\$\s*)?([0-9][0-9,]*(?:\.[0-9]+)?)(?:\s*%)?"
+        if allow_percent
+        else r"(?:USD\s*|\$\s*)?([0-9][0-9,]*(?:\.[0-9]+)?)"
+    )
     match = re.fullmatch(pattern, text, re.I)
     return match.group(1).replace(",", "") if match else None
 
 
 def _plant_quantity_parts(value: str) -> tuple[str | None, str | None]:
-    """Split only an explicit plant quantity such as '1,250 kg'; never infer semantics."""
     match = re.fullmatch(
         r"\s*([0-9][0-9,]*(?:\.[0-9]+)?)\s*(kg|g|cg|mg|kl|l|ml|mm|mm2|mm3|cm|cm2|cm3|m|m2|m3|km|kilograms?|grams?|liters?|litres?|cubic meters?|cubic metres?)?\s*",
         str(value or ""),
@@ -81,15 +97,41 @@ def _plant_quantity_parts(value: str) -> tuple[str | None, str | None]:
     return match.group(1).replace(",", ""), (match.group(2) or None)
 
 
+def _table_context(block) -> bool:
+    return block.structure_type in {LayoutStructureType.LINE_ITEM_TABLE, LayoutStructureType.MATRIX_TABLE}
+
+
+def _append_party(found, *, target: str, address_target: str, value: str, block, label: str) -> None:
+    name = party_core(value)
+    if name:
+        found[target].append(_candidate(target, name, block, label))
+    address = party_address(value)
+    if address:
+        found[address_target].append(
+            _candidate(address_target, address, block, f"{label} Address", EvidenceClass.DERIVED, target)
+        )
+
+
 def _extract(layout):
     found: dict[str, list[RawCandidate]] = {field: [] for field in _FIELDS}
     for block in layout.blocks:
         text = block.text
+        # Explicit historical/reference-only prose belongs to another evidence
+        # entity.  It must never compete with the current shipment.
+        if is_out_of_scope_context(text):
+            continue
         label, value = (block.key_text, block.value_text) if block.key_text is not None else (None, None)
         pairs = [(label, value)] if label else []
-        pairs.extend((match.group(1), match.group(2)) for match in re.finditer(r"(?im)^\s*([A-Za-z][A-Za-z /#.%'-]{1,55}?)\s*[:#]\s*([^\n]{1,180})$", text))
+        pairs.extend(
+            (match.group(1), match.group(2))
+            for match in re.finditer(
+                r"(?im)^\s*([A-Za-z][A-Za-z /#.%()'-]{1,70}?)\s*[:#]\s*([^\n]{1,240})$",
+                text,
+            )
+        )
         for raw_label, raw_value in pairs:
-            key, value = " ".join((raw_label or "").split()), " ".join((raw_value or "").split())
+            key = " ".join((raw_label or "").split())
+            value = " ".join((raw_value or "").split())
             if not value:
                 continue
             lower = key.casefold()
@@ -99,14 +141,14 @@ def _extract(layout):
                     found["estimated_arrival_date"].append(_candidate("estimated_arrival_date", date, block, key))
             elif re.search(r"(?:master (?:bol|b/l)|house bol|bill of lading|b/l no\.?|bol)\b", lower):
                 found["bill_of_lading"].append(_candidate("bill_of_lading", value.upper(), block, key))
-            elif re.fullmatch(r"container(?: number| no\.?)?", lower):
+            elif re.fullmatch(r"(?:current )?container(?: number| no\.?)?", lower):
                 found["container_number"].append(_candidate("container_number", value.upper(), block, key))
             elif _IMPORTER_NAME_LABEL.fullmatch(key) and "address" not in lower:
-                found["importer_name"].append(_candidate("importer_name", value, block, key))
+                _append_party(found, target="importer_name", address_target="importer_address", value=value, block=block, label=key)
             elif re.fullmatch(r"importer(?:'s)? address|importer address", lower):
                 found["importer_address"].append(_candidate("importer_address", value, block, key))
             elif _CONSIGNEE_NAME_LABEL.fullmatch(key) and "address" not in lower:
-                found["consignee_name"].append(_candidate("consignee_name", value, block, key))
+                _append_party(found, target="consignee_name", address_target="consignee_address", value=value, block=block, label=key)
             elif re.fullmatch(r"consignee(?:'s)? address|consignee address", lower):
                 found["consignee_address"].append(_candidate("consignee_address", value, block, key))
             elif _MERCHANDISE_DESCRIPTION_LABEL.fullmatch(key):
@@ -114,14 +156,16 @@ def _extract(layout):
             elif _ENTRY_LABEL.fullmatch(key):
                 found["filing_entry_reference"].append(_candidate("filing_entry_reference", value.upper(), block, key))
             elif _MID_LABEL.fullmatch(key):
-                found["manufacturer_id"].append(_candidate("manufacturer_id", value.upper(), block, key))
+                candidate_value = value.upper().strip()
+                if valid_mid_value(candidate_value):
+                    found["manufacturer_id"].append(_candidate("manufacturer_id", candidate_value, block, key))
             elif _HTS_LABEL.fullmatch(key):
                 found["hts_code"].append(_candidate("hts_code", value, block, key))
             elif _ENTERED_VALUE_LABEL.fullmatch(key):
                 number = _explicit_number(value)
                 if number:
                     found["entered_value"].append(_candidate("entered_value", number, block, key, EvidenceClass.DERIVED, "entered_value"))
-            elif _ARTICLE_COMPONENT_LABEL.fullmatch(key):
+            elif _ARTICLE_COMPONENT_LABEL.fullmatch(key) and _table_context(block):
                 found["article_component"].append(_candidate("article_component", value, block, key))
             elif re.fullmatch(r"genus|plant genus|scientific name genus", lower):
                 found["genus"].append(_candidate("genus", value, block, key))
@@ -135,49 +179,52 @@ def _extract(layout):
                     found["plant_quantity"].append(_candidate("plant_quantity", amount, block, key, EvidenceClass.DERIVED, "plant_quantity"))
                 if unit:
                     found["metric_unit"].append(_candidate("metric_unit", unit, block, key, EvidenceClass.DERIVED, "plant_quantity"))
-            elif _PLANT_UNIT_LABEL.fullmatch(key):
+            elif _PLANT_UNIT_LABEL.fullmatch(key) or (lower == "unit" and _table_context(block)):
                 found["metric_unit"].append(_candidate("metric_unit", value, block, key))
             elif _PERCENT_RECYCLED_LABEL.fullmatch(key):
                 number = _explicit_number(value, allow_percent=True)
-                if number:
+                if number is not None:
                     found["percent_recycled"].append(_candidate("percent_recycled", number, block, key, EvidenceClass.DERIVED, "percent_recycled"))
 
-        # Web-print PDFs often position labels and values on the same visual line
-        # without a literal colon. These patterns remain label-bound and therefore
-        # cannot turn generic identifiers into regulatory fields.
+        # Web-print PDFs often position labels and values on the same visual line.
         for match in re.finditer(r"(?:Estimated (?:Arrival Date|Date of Arrival|Time of Arrival)|\bETA)\s*[:#-]?\s*([A-Za-z]+ \d{1,2}, \d{4}|\d{1,2}[/-]\d{1,2}[/-]\d{4}|\d{4}-\d{1,2}-\d{1,2})", text, re.I):
             date = _normalized_date(match.group(1))
             if date:
                 found["estimated_arrival_date"].append(_candidate("estimated_arrival_date", date, block, "Estimated Arrival Date"))
         for match in re.finditer(r"(?P<label>Master\s+(?:Bill of Lading|BOL|B/L)(?:\s*#)?|House\s+(?:Bill of Lading|BOL|B/L)(?:\s*#)?|Bill of Lading|B/L\s*No\.?|\bBOL)\s*[:#-]?\s*(?P<value>[A-Z0-9-]{6,})", text, re.I):
             found["bill_of_lading"].append(_candidate("bill_of_lading", match.group("value").upper(), block, match.group("label")))
-        for match in re.finditer(r"\bContainer(?:\s+(?:Number|No\.?)?)?\s*[:#-]?\s*([A-Z]{4}\d{7})\b", text, re.I):
+        for match in re.finditer(r"\b(?:Current\s+)?Container(?:\s+(?:Number|No\.?)?)?\s*[:#-]?\s*([A-Z]{4}\d{7})\b", text, re.I):
             found["container_number"].append(_candidate("container_number", match.group(1).upper(), block, "Container Number"))
         for match in re.finditer(r"\bConsignee(?:\s+Name)?\s*[:#-]?\s*([A-Z][A-Z &.'-]{3,80})", text):
-            value = " ".join(match.group(1).split())
-            if value:
-                found["consignee_name"].append(_candidate("consignee_name", value, block, "Consignee Name"))
+            name = party_core(match.group(1))
+            if name:
+                found["consignee_name"].append(_candidate("consignee_name", name, block, "Consignee Name"))
         for match in re.finditer(r"(?P<label>Commodity Description|Cargo Description\s+\d+|Description of Goods|Goods Description|Merchandise Description)\s*[:#-]?\s*(?P<value>[^\n]{1,240})", text, re.I):
             value = " ".join(match.group("value").split())
             if value:
                 found["description"].append(_candidate("description", value, block, match.group("label")))
         for match in re.finditer(r"(?P<label>Entry (?:Number|No\.?)|Filing Entry (?:Reference|Number))\s*[:#-]?\s*(?P<value>[A-Z0-9-]{8,20})", text, re.I):
             found["filing_entry_reference"].append(_candidate("filing_entry_reference", match.group("value").upper(), block, match.group("label")))
-        for match in re.finditer(r"(?P<label>MID|Manufacturer (?:Identification(?: Code)?|ID)\b)\s*[:#-]?\s*(?P<value>[A-Z0-9 -]{5,25})", text, re.I):
-            found["manufacturer_id"].append(_candidate("manufacturer_id", " ".join(match.group("value").split()).upper(), block, match.group("label")))
+        # Do not let the word "Code" from "Manufacturer Identification Code"
+        # become a MID candidate.  Require the value after the complete label.
+        for match in re.finditer(r"(?P<label>MID|Manufacturer Identification(?: Code)?(?: \(MID\))?|Manufacturer ID)\s*[:#-]?\s*(?P<value>[A-Z0-9][A-Z0-9 -]{4,24})\b", text, re.I):
+            candidate_value = " ".join(match.group("value").split()).upper()
+            if valid_mid_value(candidate_value):
+                found["manufacturer_id"].append(_candidate("manufacturer_id", candidate_value, block, match.group("label")))
         for match in re.finditer(r"(?P<label>HTS(?:\s+(?:Code|Number|No\.?))?)\s*[:#-]?\s*(?P<value>\d{4,10}(?:[. -]\d{1,4})*)", text, re.I):
             found["hts_code"].append(_candidate("hts_code", match.group("value"), block, match.group("label")))
 
-    genera = {"pinus", "eucalyptus", "quercus", "acer", "betula", "fagus", "fraxinus", "populus", "tectona"}
+    genera = {"pinus", "eucalyptus", "quercus", "acer", "betula", "fagus", "fraxinus", "populus", "tectona", "hevea"}
     for source in layout.blocks:
+        if is_out_of_scope_context(source.text):
+            continue
         taxon = next((match for match in re.finditer(r"\b([A-Za-z]{3,})\s+([A-Za-z]{3,})\b", source.text) if match.group(1).casefold() in genera), None)
         if taxon:
             found["species"].append(_candidate("species", taxon.group(2).lower(), source, "scientific taxon"))
             found["genus"].append(_candidate("genus", taxon.group(1).capitalize(), source, "scientific taxon", EvidenceClass.DERIVED, "species"))
 
-    # Reconstruct party addresses only from explicit adjacent labelled components.
-    # This never treats a generic address elsewhere in a report as importer/consignee.
-    lines = [block for block in layout.blocks if block.block_type in {"TEXT_LINE", "OCR_LINE"}]
+    # Reconstruct party addresses from adjacent explicitly labelled components.
+    lines = [block for block in layout.blocks if block.block_type in {"TEXT_LINE", "OCR_LINE"} and not is_out_of_scope_context(block.text)]
     for party, target in (("Consignee", "consignee_address"), ("Importer", "importer_address")):
         for index, block in enumerate(lines):
             if not re.match(rf"^{party}(?: Name| of Record)?\s+", block.text, re.I):
@@ -194,24 +241,15 @@ def _extract(layout):
             state_key = "state province" if "state province" in components else ("state" if "state" in components else None)
             postal_key = "zip code" if "zip code" in components else ("postal code" if "postal code" in components else None)
             if address_key and city_key and state_key and postal_key:
-                address = components[address_key][0]
-                city = components[city_key][0]
-                state = components[state_key][0]
-                postal = components[postal_key][0]
+                address, city, state, postal = components[address_key][0], components[city_key][0], components[state_key][0], components[postal_key][0]
                 country_key = "country" if "country" in components else ("country code" if "country code" in components else None)
                 country = f"; {components[country_key][0]}" if country_key else ""
                 source = components[address_key][1]
-                found[target].append(_candidate(
-                    target,
-                    f"{address}; {city}, {state} {postal}{country}",
-                    source,
-                    f"{party} Address",
-                    EvidenceClass.DERIVED,
-                    f"{party.casefold()}_name",
-                ))
+                found[target].append(_candidate(target, f"{address}; {city}, {state} {postal}{country}", source, f"{party} Address", EvidenceClass.DERIVED, f"{party.casefold()}_name"))
 
-    # The same visual row may be represented as a text line and a detected table row.
-    # That is duplicate evidence, not a semantic disagreement.
+    # The same visual row may be represented as a text line and a table cell.  Keep
+    # duplicate sources for corroboration only when the block differs; exact duplicate
+    # candidate/block pairs are removed here.
     for field_key, candidates in found.items():
         unique: list[RawCandidate] = []
         seen: set[tuple[str, str]] = set()
@@ -232,9 +270,22 @@ def process_document(*, filename: str, content: bytes, role_hint: str | None = N
     extracted = _extract(layout)
 
     def make(raw, source_score):
-        provenance = Provenance(filename, raw.source_block.page, raw.source_block.bbox, raw.source_block.block_id, raw.source_block.text, raw.extractor_name, raw.extractor_version, raw.evidence_class)
+        provenance = Provenance(
+            filename,
+            raw.source_block.page,
+            raw.source_block.bbox,
+            raw.source_block.block_id,
+            raw.source_block.text,
+            raw.extractor_name,
+            raw.extractor_version,
+            raw.evidence_class,
+        )
         source_type = section_type.get(raw.source_block.block_id, document_type)
         return AdmittedCandidate(raw, provenance, 60 + source_score + (10 if raw.label else 0), source_type)
+
     make.document_type_for = lambda raw: section_type.get(raw.source_block.block_id, document_type)
-    fields = {key: resolve(key, [raw for raw in candidates if admit(raw)], make) for key, candidates in extracted.items()}
+    fields = {
+        key: resolve(key, [raw for raw in candidates if admit(raw)], make)
+        for key, candidates in extracted.items()
+    }
     return DocumentResolution(filename, ENGINE_VERSION, document_type, confidence, layout, sections, fields)

--- a/src/litoral_trace/lacey_engine/semantic_graph.py
+++ b/src/litoral_trace/lacey_engine/semantic_graph.py
@@ -33,8 +33,8 @@ _OUT_OF_SCOPE = re.compile(
 _EMAIL = re.compile(r"\b[^\s@]+@[^\s@]+\.[^\s@]+\b", re.IGNORECASE)
 _PHONE = re.compile(r"(?:\+?\d[\d() .-]{6,}\d)")
 _STREET_START = re.compile(
-    r"\s+\d{1,6}\s+[A-Za-z0-9.' -]+\b(?:street|st|road|rd|avenue|ave|way|drive|dr|"
-    r"boulevard|blvd|lane|ln|highway|hwy|parkway|pkwy|place|pl)\b",
+    r"\s+(?P<address>\d{1,6}\s+[A-Za-z0-9.' -]+\b(?:street|st|road|rd|avenue|ave|way|drive|dr|"
+    r"boulevard|blvd|lane|ln|highway|hwy|parkway|pkwy|place|pl)\b.*)$",
     re.IGNORECASE,
 )
 _COMPANY_SUFFIX = re.compile(
@@ -62,12 +62,7 @@ def is_out_of_scope_context(text: object) -> bool:
 
 
 def party_core(value: object) -> str:
-    """Normalize a party value to its company/name identity without addresses/contact.
-
-    Key/value PDFs often place name, street address, email and phone in one cell.  A
-    clean party name in another document must corroborate that cell, not conflict
-    with it.  This routine strips only strong contact/address signals.
-    """
+    """Normalize a party value to its company/name identity without addresses/contact."""
     raw = " ".join(str(value or "").split()).strip()
     if not raw:
         return ""
@@ -76,13 +71,23 @@ def party_core(value: object) -> str:
     street = _STREET_START.search(raw)
     if street:
         raw = raw[: street.start()]
-    # A comma is commonly the start of a postal address after the legal name.  Do
-    # not cut ordinary company names unless the tail looks address-like.
     comma = raw.find(",")
     if comma > 0 and re.search(r"\b(?:[A-Z]{2}\s+\d{5}|USA|UNITED STATES|VIETNAM|THAILAND|MALAYSIA)\b", raw[comma:], re.I):
         raw = raw[:comma]
-    raw = " ".join(raw.replace("|", " ").split()).strip(" ,-;")
-    return raw
+    return " ".join(raw.replace("|", " ").split()).strip(" ,-;")
+
+
+def party_address(value: object) -> str | None:
+    """Extract an address only when a strong street-number/street-type signal exists."""
+    raw = " ".join(str(value or "").split()).strip()
+    match = _STREET_START.search(raw)
+    if not match:
+        return None
+    address = match.group("address")
+    address = _EMAIL.sub(" ", address)
+    address = _PHONE.sub(" ", address)
+    address = " ".join(address.replace("|", " ").split()).strip(" ,-;")
+    return address or None
 
 
 def semantic_normalize(field_key: str, value: object) -> str:
@@ -130,8 +135,6 @@ def association_key(candidate: AdmittedCandidate, scope: str, document_id: str) 
         and block.row_index is not None
         and block.structure_type in {LayoutStructureType.LINE_ITEM_TABLE, LayoutStructureType.MATRIX_TABLE}
     ):
-        # Table ids already contain the PDF page.  Keep document id so identical
-        # table ids in different uploads cannot collide.
         return f"{document_id}:{block.table_id}:row:{block.row_index}"
     label = str(candidate.raw.label or "")
     match = re.search(r"(?:component|line)\s*(?:#|number)?\s*([a-z0-9-]+)", label, re.I)

--- a/src/litoral_trace/lacey_engine/semantic_graph.py
+++ b/src/litoral_trace/lacey_engine/semantic_graph.py
@@ -152,7 +152,7 @@ def association_key(candidate: AdmittedCandidate, scope: str, document_id: str) 
         return f"{document_id}:{block.table_id}:row:{block.row_index}"
     label = str(candidate.raw.label or "")
     match = re.search(r"(?:component|line)\s*(?:#|number)?\s*([a-z0-9-]+)", label, re.I)
-    return match.group(1) if match else None
+    return match.group(1).casefold() if match else None
 
 
 def evidence_relation(

--- a/src/litoral_trace/lacey_engine/semantic_graph.py
+++ b/src/litoral_trace/lacey_engine/semantic_graph.py
@@ -1,0 +1,159 @@
+"""Semantic evidence primitives for the U.S. Lacey document engine.
+
+This module is deliberately deterministic.  It gives extracted facts an identity
+(scope/entity/row) before any model is allowed to reason about them.  The objective
+is to distinguish corroboration, parallel plant components and stale/historical
+noise from a true contradiction.
+"""
+from __future__ import annotations
+
+from enum import Enum
+import re
+import unicodedata
+
+from .domain import AdmittedCandidate, LayoutStructureType
+
+
+class EvidenceRelation(str, Enum):
+    CORROBORATION = "CORROBORATION"
+    PARALLEL_ENTITY = "PARALLEL_ENTITY"
+    TRUE_CONFLICT = "TRUE_CONFLICT"
+    OUT_OF_SCOPE = "OUT_OF_SCOPE"
+    AMBIGUOUS = "AMBIGUOUS"
+
+
+_OUT_OF_SCOPE = re.compile(
+    r"\b(?:"
+    r"prior shipment|previous shipment|last year(?:'s)? shipment|old shipment|"
+    r"historical(?:ly)?|archived|archive(?:d)?|reference only|"
+    r"do not use|not current|former shipment|earlier shipment"
+    r")\b",
+    re.IGNORECASE,
+)
+_EMAIL = re.compile(r"\b[^\s@]+@[^\s@]+\.[^\s@]+\b", re.IGNORECASE)
+_PHONE = re.compile(r"(?:\+?\d[\d() .-]{6,}\d)")
+_STREET_START = re.compile(
+    r"\s+\d{1,6}\s+[A-Za-z0-9.' -]+\b(?:street|st|road|rd|avenue|ave|way|drive|dr|"
+    r"boulevard|blvd|lane|ln|highway|hwy|parkway|pkwy|place|pl)\b",
+    re.IGNORECASE,
+)
+_COMPANY_SUFFIX = re.compile(
+    r"\b(?:LLC|L\.L\.C\.|INC\.?|INCORPORATED|LTD\.?|LIMITED|CORP\.?|CORPORATION|CO\.?|COMPANY)\b",
+    re.IGNORECASE,
+)
+_STRUCTURAL_MID_VALUES = frozenset(
+    {"CODE", "ID", "NUMBER", "NO", "IDENTIFICATION", "MANUFACTURER", "MID"}
+)
+
+
+def fold_text(value: object) -> str:
+    text = unicodedata.normalize("NFKD", str(value or "")).casefold()
+    text = "".join(ch for ch in text if not unicodedata.combining(ch))
+    return " ".join(re.sub(r"[^a-z0-9]+", " ", text).split())
+
+
+def is_out_of_scope_context(text: object) -> bool:
+    """Return True only for explicit historical/reference-only language.
+
+    We intentionally do not infer staleness from a date alone.  A fact is excluded
+    only when the source itself clearly says it belongs to another/prior shipment.
+    """
+    return bool(_OUT_OF_SCOPE.search(str(text or "")))
+
+
+def party_core(value: object) -> str:
+    """Normalize a party value to its company/name identity without addresses/contact.
+
+    Key/value PDFs often place name, street address, email and phone in one cell.  A
+    clean party name in another document must corroborate that cell, not conflict
+    with it.  This routine strips only strong contact/address signals.
+    """
+    raw = " ".join(str(value or "").split()).strip()
+    if not raw:
+        return ""
+    raw = _EMAIL.sub(" ", raw)
+    raw = _PHONE.sub(" ", raw)
+    street = _STREET_START.search(raw)
+    if street:
+        raw = raw[: street.start()]
+    # A comma is commonly the start of a postal address after the legal name.  Do
+    # not cut ordinary company names unless the tail looks address-like.
+    comma = raw.find(",")
+    if comma > 0 and re.search(r"\b(?:[A-Z]{2}\s+\d{5}|USA|UNITED STATES|VIETNAM|THAILAND|MALAYSIA)\b", raw[comma:], re.I):
+        raw = raw[:comma]
+    raw = " ".join(raw.replace("|", " ").split()).strip(" ,-;")
+    return raw
+
+
+def semantic_normalize(field_key: str, value: object) -> str:
+    raw = " ".join(str(value or "").split()).strip()
+    if not raw:
+        return ""
+    key = str(field_key or "").strip().casefold()
+    if key in {
+        "importer_name", "consignee_name", "shipper_name", "supplier_name",
+        "manufacturer_name", "notify_party_name", "filer_name",
+    }:
+        raw = party_core(raw)
+        raw = _COMPANY_SUFFIX.sub("", raw)
+        return fold_text(raw)
+    if key == "hts_code":
+        return re.sub(r"\D", "", raw)
+    if key in {"container_number", "bill_of_lading", "manufacturer_id", "filing_entry_reference"}:
+        return re.sub(r"[^A-Z0-9]", "", raw.upper())
+    if key in {"genus", "species", "country_of_harvest", "metric_unit"}:
+        return fold_text(raw)
+    if key in {"plant_quantity", "percent_recycled", "entered_value"}:
+        number = re.search(r"-?[0-9][0-9,]*(?:\.[0-9]+)?", raw)
+        return number.group(0).replace(",", "") if number else fold_text(raw)
+    return fold_text(raw)
+
+
+def semantic_equal(field_key: str, left: object, right: object) -> bool:
+    a = semantic_normalize(field_key, left)
+    b = semantic_normalize(field_key, right)
+    return bool(a and b and a == b)
+
+
+def valid_mid_value(value: object) -> bool:
+    normalized = str(value or "").strip().upper()
+    return bool(normalized) and normalized not in _STRUCTURAL_MID_VALUES and len(normalized) >= 5
+
+
+def association_key(candidate: AdmittedCandidate, scope: str, document_id: str) -> str | None:
+    """Give a line/component candidate a stable row identity when the PDF provides it."""
+    block = candidate.raw.source_block
+    if scope not in {"MERCHANDISE_LINE", "PLANT_COMPONENT"}:
+        return None
+    if (
+        block.table_id
+        and block.row_index is not None
+        and block.structure_type in {LayoutStructureType.LINE_ITEM_TABLE, LayoutStructureType.MATRIX_TABLE}
+    ):
+        # Table ids already contain the PDF page.  Keep document id so identical
+        # table ids in different uploads cannot collide.
+        return f"{document_id}:{block.table_id}:row:{block.row_index}"
+    label = str(candidate.raw.label or "")
+    match = re.search(r"(?:component|line)\s*(?:#|number)?\s*([a-z0-9-]+)", label, re.I)
+    return match.group(1) if match else None
+
+
+def evidence_relation(
+    field_key: str,
+    left_value: object,
+    right_value: object,
+    *,
+    left_entity: str | None = None,
+    right_entity: str | None = None,
+    left_context: object = "",
+    right_context: object = "",
+) -> EvidenceRelation:
+    if is_out_of_scope_context(left_context) or is_out_of_scope_context(right_context):
+        return EvidenceRelation.OUT_OF_SCOPE
+    if left_entity and right_entity and left_entity != right_entity:
+        return EvidenceRelation.PARALLEL_ENTITY
+    if semantic_equal(field_key, left_value, right_value):
+        return EvidenceRelation.CORROBORATION
+    if left_entity and right_entity and left_entity == right_entity:
+        return EvidenceRelation.TRUE_CONFLICT
+    return EvidenceRelation.AMBIGUOUS

--- a/src/litoral_trace/lacey_engine/semantic_graph.py
+++ b/src/litoral_trace/lacey_engine/semantic_graph.py
@@ -7,6 +7,7 @@ noise from a true contradiction.
 """
 from __future__ import annotations
 
+from decimal import Decimal, InvalidOperation
 from enum import Enum
 import re
 import unicodedata
@@ -23,11 +24,9 @@ class EvidenceRelation(str, Enum):
 
 
 _OUT_OF_SCOPE = re.compile(
-    r"\b(?:"
-    r"prior shipment|previous shipment|last year(?:'s)? shipment|old shipment|"
-    r"historical(?:ly)?|archived|archive(?:d)?|reference only|"
-    r"do not use|not current|former shipment|earlier shipment"
-    r")\b",
+    r"\b(?:prior shipment|previous shipment|last year(?:'s)? shipment|old shipment|"
+    r"historical(?:ly)?|archived|archive(?:d)?|reference only|do not use|not current|"
+    r"former shipment|earlier shipment)\b",
     re.IGNORECASE,
 )
 _EMAIL = re.compile(r"\b[^\s@]+@[^\s@]+\.[^\s@]+\b", re.IGNORECASE)
@@ -41,9 +40,7 @@ _COMPANY_SUFFIX = re.compile(
     r"\b(?:LLC|L\.L\.C\.|INC\.?|INCORPORATED|LTD\.?|LIMITED|CORP\.?|CORPORATION|CO\.?|COMPANY)\b",
     re.IGNORECASE,
 )
-_STRUCTURAL_MID_VALUES = frozenset(
-    {"CODE", "ID", "NUMBER", "NO", "IDENTIFICATION", "MANUFACTURER", "MID"}
-)
+_STRUCTURAL_MID_VALUES = frozenset({"CODE", "ID", "NUMBER", "NO", "IDENTIFICATION", "MANUFACTURER", "MID"})
 
 
 def fold_text(value: object) -> str:
@@ -53,16 +50,11 @@ def fold_text(value: object) -> str:
 
 
 def is_out_of_scope_context(text: object) -> bool:
-    """Return True only for explicit historical/reference-only language.
-
-    We intentionally do not infer staleness from a date alone.  A fact is excluded
-    only when the source itself clearly says it belongs to another/prior shipment.
-    """
+    """Exclude facts only when source prose explicitly marks another/prior shipment."""
     return bool(_OUT_OF_SCOPE.search(str(text or "")))
 
 
 def party_core(value: object) -> str:
-    """Normalize a party value to its company/name identity without addresses/contact."""
     raw = " ".join(str(value or "").split()).strip()
     if not raw:
         return ""
@@ -78,16 +70,34 @@ def party_core(value: object) -> str:
 
 
 def party_address(value: object) -> str | None:
-    """Extract an address only when a strong street-number/street-type signal exists."""
     raw = " ".join(str(value or "").split()).strip()
     match = _STREET_START.search(raw)
     if not match:
         return None
-    address = match.group("address")
-    address = _EMAIL.sub(" ", address)
+    address = _EMAIL.sub(" ", match.group("address"))
     address = _PHONE.sub(" ", address)
-    address = " ".join(address.replace("|", " ").split()).strip(" ,-;")
-    return address or None
+    return " ".join(address.replace("|", " ").split()).strip(" ,-;") or None
+
+
+def _mass_kg(raw: str) -> str | None:
+    match = re.fullmatch(
+        r"\s*([0-9][0-9,]*(?:\.[0-9]+)?)\s*(g|kg|lb|metric tons?|tonnes?)\s*",
+        raw,
+        re.I,
+    )
+    if not match:
+        return None
+    try:
+        amount = Decimal(match.group(1).replace(",", ""))
+    except InvalidOperation:
+        return None
+    unit = match.group(2).casefold()
+    factor = {
+        "g": Decimal("0.001"), "kg": Decimal("1"), "lb": Decimal("0.45359237"),
+        "metric ton": Decimal("1000"), "metric tons": Decimal("1000"),
+        "tonne": Decimal("1000"), "tonnes": Decimal("1000"),
+    }[unit]
+    return f"{(amount * factor).normalize()} kg"
 
 
 def semantic_normalize(field_key: str, value: object) -> str:
@@ -95,12 +105,8 @@ def semantic_normalize(field_key: str, value: object) -> str:
     if not raw:
         return ""
     key = str(field_key or "").strip().casefold()
-    if key in {
-        "importer_name", "consignee_name", "shipper_name", "supplier_name",
-        "manufacturer_name", "notify_party_name", "filer_name",
-    }:
-        raw = party_core(raw)
-        raw = _COMPANY_SUFFIX.sub("", raw)
+    if key in {"importer_name", "consignee_name", "shipper_name", "supplier_name", "manufacturer_name", "notify_party_name", "filer_name"}:
+        raw = _COMPANY_SUFFIX.sub("", party_core(raw))
         return fold_text(raw)
     if key == "hts_code":
         return re.sub(r"\D", "", raw)
@@ -108,7 +114,20 @@ def semantic_normalize(field_key: str, value: object) -> str:
         return re.sub(r"[^A-Z0-9]", "", raw.upper())
     if key in {"genus", "species", "country_of_harvest", "metric_unit"}:
         return fold_text(raw)
-    if key in {"plant_quantity", "percent_recycled", "entered_value"}:
+    if key == "plant_quantity":
+        mass = _mass_kg(raw)
+        if mass:
+            return mass
+        number = re.search(r"-?[0-9][0-9,]*(?:\.[0-9]+)?", raw)
+        return number.group(0).replace(",", "") if number else fold_text(raw)
+    if key == "entered_value":
+        match = re.fullmatch(r"\s*(?:(USD|EUR|CAD|GBP|AUD|JPY)\s*)?\$?\s*([0-9][0-9,]*(?:\.[0-9]+)?)\s*", raw, re.I)
+        if match:
+            currency = (match.group(1) or ("USD" if "$" in raw else "")).upper()
+            amount = Decimal(match.group(2).replace(",", "")).normalize()
+            return f"{currency} {amount}".strip()
+        return fold_text(raw)
+    if key == "percent_recycled":
         number = re.search(r"-?[0-9][0-9,]*(?:\.[0-9]+)?", raw)
         return number.group(0).replace(",", "") if number else fold_text(raw)
     return fold_text(raw)
@@ -126,15 +145,10 @@ def valid_mid_value(value: object) -> bool:
 
 
 def association_key(candidate: AdmittedCandidate, scope: str, document_id: str) -> str | None:
-    """Give a line/component candidate a stable row identity when the PDF provides it."""
     block = candidate.raw.source_block
     if scope not in {"MERCHANDISE_LINE", "PLANT_COMPONENT"}:
         return None
-    if (
-        block.table_id
-        and block.row_index is not None
-        and block.structure_type in {LayoutStructureType.LINE_ITEM_TABLE, LayoutStructureType.MATRIX_TABLE}
-    ):
+    if block.table_id and block.row_index is not None and block.structure_type in {LayoutStructureType.LINE_ITEM_TABLE, LayoutStructureType.MATRIX_TABLE}:
         return f"{document_id}:{block.table_id}:row:{block.row_index}"
     label = str(candidate.raw.label or "")
     match = re.search(r"(?:component|line)\s*(?:#|number)?\s*([a-z0-9-]+)", label, re.I)

--- a/src/litoral_trace/lacey_engine/shipment.py
+++ b/src/litoral_trace/lacey_engine/shipment.py
@@ -8,36 +8,61 @@ import re
 
 from .domain import AdmittedCandidate, DocumentResolution, EvidenceClass, FieldStatus
 from .pipeline import ENGINE_VERSION, process_document
+from .semantic_graph import association_key, is_out_of_scope_context, semantic_normalize
 from .source_authority import authority
 
 
 class ReconciliationState(str, Enum):
-    SUPPORTED = "SUPPORTED"; SUPPORTED_MULTIPLE = "SUPPORTED_MULTIPLE"; NEAR_MATCH = "NEAR_MATCH"
-    CONFLICT = "CONFLICT"; MISSING = "MISSING"; REVIEW_REQUIRED = "REVIEW_REQUIRED"
+    SUPPORTED = "SUPPORTED"
+    SUPPORTED_MULTIPLE = "SUPPORTED_MULTIPLE"
+    NEAR_MATCH = "NEAR_MATCH"
+    CONFLICT = "CONFLICT"
+    MISSING = "MISSING"
+    REVIEW_REQUIRED = "REVIEW_REQUIRED"
 
 
 class ShipmentReadiness(str, Enum):
-    READY = "READY"; REVIEW_REQUIRED = "REVIEW_REQUIRED"; BLOCKED = "BLOCKED"
+    READY = "READY"
+    REVIEW_REQUIRED = "REVIEW_REQUIRED"
+    BLOCKED = "BLOCKED"
 
 
 class FieldCardinality(str, Enum):
-    SCALAR = "SCALAR"; SET = "SET"; PER_MERCHANDISE_LINE = "PER_MERCHANDISE_LINE"; PER_PLANT_COMPONENT = "PER_PLANT_COMPONENT"
+    SCALAR = "SCALAR"
+    SET = "SET"
+    PER_MERCHANDISE_LINE = "PER_MERCHANDISE_LINE"
+    PER_PLANT_COMPONENT = "PER_PLANT_COMPONENT"
 
 
 class PartyRole(str, Enum):
-    IMPORTER = "IMPORTER"; CONSIGNEE = "CONSIGNEE"; SHIPPER = "SHIPPER"; SUPPLIER = "SUPPLIER"; MANUFACTURER = "MANUFACTURER"; NOTIFY_PARTY = "NOTIFY_PARTY"
+    IMPORTER = "IMPORTER"
+    CONSIGNEE = "CONSIGNEE"
+    SHIPPER = "SHIPPER"
+    SUPPLIER = "SUPPLIER"
+    MANUFACTURER = "MANUFACTURER"
+    NOTIFY_PARTY = "NOTIFY_PARTY"
 
 
 class EvidenceScope(str, Enum):
-    SHIPMENT = "SHIPMENT"; MERCHANDISE_LINE = "MERCHANDISE_LINE"; PLANT_COMPONENT = "PLANT_COMPONENT"
+    SHIPMENT = "SHIPMENT"
+    MERCHANDISE_LINE = "MERCHANDISE_LINE"
+    PLANT_COMPONENT = "PLANT_COMPONENT"
 
 
 class AssociationState(str, Enum):
-    ASSOCIATED = "ASSOCIATED"; UNASSOCIATED = "UNASSOCIATED"; AMBIGUOUS = "AMBIGUOUS"
+    ASSOCIATED = "ASSOCIATED"
+    UNASSOCIATED = "UNASSOCIATED"
+    AMBIGUOUS = "AMBIGUOUS"
 
 
 class QuantitySemanticType(str, Enum):
-    PLANT_MATERIAL_QUANTITY = "PLANT_MATERIAL_QUANTITY"; GROSS_WEIGHT = "GROSS_WEIGHT"; NET_WEIGHT = "NET_WEIGHT"; PACKAGE_COUNT = "PACKAGE_COUNT"; PIECE_COUNT = "PIECE_COUNT"; VOLUME = "VOLUME"; OTHER = "OTHER"
+    PLANT_MATERIAL_QUANTITY = "PLANT_MATERIAL_QUANTITY"
+    GROSS_WEIGHT = "GROSS_WEIGHT"
+    NET_WEIGHT = "NET_WEIGHT"
+    PACKAGE_COUNT = "PACKAGE_COUNT"
+    PIECE_COUNT = "PIECE_COUNT"
+    VOLUME = "VOLUME"
+    OTHER = "OTHER"
 
 
 @dataclass(frozen=True, slots=True)
@@ -72,7 +97,6 @@ class ShipmentEvidence:
 
     @property
     def authority(self) -> float:
-        """Compatibility alias; reconciliation uses source_authority explicitly."""
         return self.source_authority
 
 
@@ -107,7 +131,6 @@ class ShipmentIssue:
 
 @dataclass(frozen=True, slots=True)
 class PreparationRequirement:
-    """A preparation requirement satisfied by any acceptable canonical field."""
     requirement_id: str
     acceptable_fields: tuple[str, ...]
 
@@ -115,13 +138,16 @@ class PreparationRequirement:
 @dataclass(frozen=True, slots=True)
 class ShipmentPreparationContext:
     requirements: tuple[PreparationRequirement, ...] = (
-        PreparationRequirement("BILL_OF_LADING_PRESENT", ("master_bill_of_lading", "bill_of_lading", "house_bill_of_lading")),
+        PreparationRequirement(
+            "BILL_OF_LADING_PRESENT",
+            ("master_bill_of_lading", "bill_of_lading", "house_bill_of_lading"),
+        ),
     )
 
 
 @dataclass(frozen=True, slots=True)
 class LaceyRuleset:
-    version: str = "lacey_ruleset_2026_01"
+    version: str = "lacey_ruleset_2026_02_semantic_graph"
     preparation: ShipmentPreparationContext = ShipmentPreparationContext()
 
 
@@ -133,16 +159,19 @@ class ShipmentResolution:
     issues: tuple[ShipmentIssue, ...]
     readiness: ShipmentReadiness
     metrics: dict[str, int]
-    ruleset_version: str = "lacey_ruleset_2026_01"
+    ruleset_version: str = "lacey_ruleset_2026_02_semantic_graph"
 
 
 def normalize_mass(value: str, unit: str) -> Decimal | None:
-    """Normalize explicitly compatible mass evidence to kilograms without floats."""
     try:
         amount = Decimal(value.replace(",", ""))
     except (InvalidOperation, AttributeError):
         return None
-    factor = {"g": Decimal(".001"), "kg": Decimal(1), "metric ton": Decimal(1000), "metric tons": Decimal(1000), "tonne": Decimal(1000), "tonnes": Decimal(1000), "lb": Decimal(".45359237")}.get(unit.strip().casefold())
+    factor = {
+        "g": Decimal(".001"), "kg": Decimal(1), "metric ton": Decimal(1000),
+        "metric tons": Decimal(1000), "tonne": Decimal(1000), "tonnes": Decimal(1000),
+        "lb": Decimal(".45359237"),
+    }.get(unit.strip().casefold())
     return amount * factor if factor is not None else None
 
 
@@ -157,7 +186,6 @@ def normalize_money(value: str) -> tuple[str | None, Decimal | None]:
 
 
 def normalize_quantity(value: str) -> Decimal | None:
-    """Return kilograms for an explicitly stated mass quantity, or None."""
     match = re.fullmatch(r"\s*([0-9][0-9,]*(?:\.[0-9]+)?)\s*(g|kg|lb|metric tons?|tonnes?)\s*", value, re.I)
     return normalize_mass(match.group(1), match.group(2)) if match else None
 
@@ -165,47 +193,50 @@ def normalize_quantity(value: str) -> Decimal | None:
 _CATALOG = {key: FieldCardinality.SCALAR for key in (
     "estimated_arrival_date", "master_bill_of_lading", "house_bill_of_lading", "bill_of_lading",
     "importer_name", "importer_address", "consignee_name", "consignee_address", "manufacturer_id",
-    "filing_entry_reference", "currency", "percent_recycled", "notify_party_name", "shipper_name",
-    "supplier_name", "manufacturer_name")}
-_CATALOG.update({"container_number": FieldCardinality.SET, "country_of_origin": FieldCardinality.SET,
-    "genus": FieldCardinality.PER_PLANT_COMPONENT, "species": FieldCardinality.PER_PLANT_COMPONENT,
-    "country_of_harvest": FieldCardinality.PER_PLANT_COMPONENT, "plant_quantity": FieldCardinality.PER_PLANT_COMPONENT,
-    "metric_unit": FieldCardinality.PER_PLANT_COMPONENT})
-for _key in ("hts_code", "description", "entered_value", "article_component"):
+    "filing_entry_reference", "currency", "notify_party_name", "shipper_name", "supplier_name",
+    "manufacturer_name",
+)}
+_CATALOG.update({
+    "container_number": FieldCardinality.SET,
+    "country_of_origin": FieldCardinality.SET,
+    "article_component": FieldCardinality.PER_PLANT_COMPONENT,
+    "genus": FieldCardinality.PER_PLANT_COMPONENT,
+    "species": FieldCardinality.PER_PLANT_COMPONENT,
+    "country_of_harvest": FieldCardinality.PER_PLANT_COMPONENT,
+    "plant_quantity": FieldCardinality.PER_PLANT_COMPONENT,
+    "metric_unit": FieldCardinality.PER_PLANT_COMPONENT,
+    "percent_recycled": FieldCardinality.PER_PLANT_COMPONENT,
+})
+for _key in ("hts_code", "description", "entered_value"):
     _CATALOG[_key] = FieldCardinality.PER_MERCHANDISE_LINE
 _PARTY_KEYS = {"importer_name", "consignee_name", "shipper_name", "supplier_name", "manufacturer_name", "notify_party_name"}
 _IMPORTANT = frozenset({"bill_of_lading", "master_bill_of_lading", "house_bill_of_lading", "country_of_harvest", "species", "genus"})
 
 
 def _normal(field_key: str, value: str) -> str:
-    text = " ".join(value.upper().split())
-    if field_key in _PARTY_KEYS:
-        return re.sub(r"\b(?:LLC|INC|LTD)\b", "", re.sub(r"[^A-Z0-9 ]", "", text)).strip()
-    if field_key == "hts_code":
-        return re.sub(r"\D", "", text)
-    if field_key == "entered_value":
-        currency, amount = normalize_money(text)
-        return f"{currency} {amount.normalize()}" if currency and amount is not None else text
-    if field_key == "plant_quantity":
-        quantity = normalize_quantity(text)
-        return f"{quantity.normalize()} KG" if quantity is not None else text
-    return text
+    normalized = semantic_normalize(field_key, value)
+    return normalized.upper() if field_key not in {"entered_value", "plant_quantity", "percent_recycled"} else normalized
 
 
 def _scope(cardinality: FieldCardinality) -> EvidenceScope:
-    return EvidenceScope.PLANT_COMPONENT if cardinality is FieldCardinality.PER_PLANT_COMPONENT else (EvidenceScope.MERCHANDISE_LINE if cardinality is FieldCardinality.PER_MERCHANDISE_LINE else EvidenceScope.SHIPMENT)
-
-
-def _association(label: str, scope: EvidenceScope) -> tuple[str | None, str | None]:
-    match = re.search(r"(?:component|line)\s*(?:#|number)?\s*([a-z0-9-]+)", label.casefold())
-    if not match:
-        return None, None
-    return (match.group(1), None) if scope is EvidenceScope.PLANT_COMPONENT else (None, match.group(1))
+    if cardinality is FieldCardinality.PER_PLANT_COMPONENT:
+        return EvidenceScope.PLANT_COMPONENT
+    if cardinality is FieldCardinality.PER_MERCHANDISE_LINE:
+        return EvidenceScope.MERCHANDISE_LINE
+    return EvidenceScope.SHIPMENT
 
 
 def _quantity_semantic_type(label: str) -> QuantitySemanticType:
     label = label.casefold()
-    for phrase, semantic in (("plant material", QuantitySemanticType.PLANT_MATERIAL_QUANTITY), ("gross weight", QuantitySemanticType.GROSS_WEIGHT), ("net weight", QuantitySemanticType.NET_WEIGHT), ("package", QuantitySemanticType.PACKAGE_COUNT), ("piece", QuantitySemanticType.PIECE_COUNT), ("volume", QuantitySemanticType.VOLUME)):
+    for phrase, semantic in (
+        ("plant quantity", QuantitySemanticType.PLANT_MATERIAL_QUANTITY),
+        ("plant material", QuantitySemanticType.PLANT_MATERIAL_QUANTITY),
+        ("gross weight", QuantitySemanticType.GROSS_WEIGHT),
+        ("net weight", QuantitySemanticType.NET_WEIGHT),
+        ("package", QuantitySemanticType.PACKAGE_COUNT),
+        ("piece", QuantitySemanticType.PIECE_COUNT),
+        ("volume", QuantitySemanticType.VOLUME),
+    ):
         if phrase in label:
             return semantic
     return QuantitySemanticType.OTHER
@@ -228,12 +259,23 @@ def _reconcile(field_key: str, evidence: list[ShipmentEvidence]) -> Reconciliati
     groups: dict[str, list[ShipmentEvidence]] = {}
     for item in evidence:
         groups.setdefault(_normal(field_key, item.normalized_value), []).append(item)
-    values = tuple(CanonicalFieldCandidate(value, tuple(item.candidate_id for item in items)) for value, items in groups.items())
+    values = tuple(
+        CanonicalFieldCandidate(value, tuple(item.candidate_id for item in items))
+        for value, items in groups.items()
+    )
     cardinality = _CATALOG[field_key]
     if cardinality is FieldCardinality.SET:
-        return ReconciliationResult(field_key, ReconciliationState.SUPPORTED_MULTIPLE if len(evidence) > 1 else ReconciliationState.SUPPORTED, values, tuple(evidence))
+        return ReconciliationResult(
+            field_key,
+            ReconciliationState.SUPPORTED_MULTIPLE if len(groups) > 1 or len(evidence) > 1 else ReconciliationState.SUPPORTED,
+            values,
+            tuple(evidence),
+        )
     if cardinality in {FieldCardinality.PER_MERCHANDISE_LINE, FieldCardinality.PER_PLANT_COMPONENT}:
-        association_keys = [item.line_key if cardinality is FieldCardinality.PER_MERCHANDISE_LINE else item.component_key for item in evidence]
+        association_keys = [
+            item.line_key if cardinality is FieldCardinality.PER_MERCHANDISE_LINE else item.component_key
+            for item in evidence
+        ]
         if None in association_keys:
             state = ReconciliationState.REVIEW_REQUIRED if len(groups) > 1 else _atomic_state(field_key, evidence)
             return ReconciliationResult(field_key, state, values, tuple(evidence))
@@ -246,15 +288,19 @@ def _reconcile(field_key: str, evidence: list[ShipmentEvidence]) -> Reconciliati
         elif ReconciliationState.REVIEW_REQUIRED in states:
             state = ReconciliationState.REVIEW_REQUIRED
         elif len(partitions) > 1:
+            # Multiple component rows are parallel valid facts, not a conflict.
             state = ReconciliationState.SUPPORTED_MULTIPLE
         else:
             state = states[0]
         return ReconciliationResult(field_key, state, values, tuple(evidence))
     if len(groups) == 1:
         raw_values = {item.normalized_value for item in evidence}
-        state = ReconciliationState.NEAR_MATCH if field_key in _PARTY_KEYS and len(raw_values) > 1 else (ReconciliationState.SUPPORTED_MULTIPLE if len(evidence) > 1 else ReconciliationState.SUPPORTED)
+        state = (
+            ReconciliationState.NEAR_MATCH
+            if field_key in _PARTY_KEYS and len(raw_values) > 1
+            else (ReconciliationState.SUPPORTED_MULTIPLE if len(evidence) > 1 else ReconciliationState.SUPPORTED)
+        )
         return ReconciliationResult(field_key, state, values, tuple(evidence))
-    # A material authority gap is a reviewable discrepancy, unlike equal authority facts.
     strengths = {item.source_authority for item in evidence}
     state = ReconciliationState.REVIEW_REQUIRED if len(strengths) > 1 else ReconciliationState.CONFLICT
     return ReconciliationResult(field_key, state, values, tuple(evidence))
@@ -263,7 +309,11 @@ def _reconcile(field_key: str, evidence: list[ShipmentEvidence]) -> Reconciliati
 def _typed_key(field_key: str, label: str) -> str:
     if field_key in {"party", "party_name", "name"}:
         label = label.casefold()
-        for role, key in (("importer", "importer_name"), ("consignee", "consignee_name"), ("shipper", "shipper_name"), ("supplier", "supplier_name"), ("manufacturer", "manufacturer_name"), ("notify", "notify_party_name")):
+        for role, key in (
+            ("importer", "importer_name"), ("consignee", "consignee_name"),
+            ("shipper", "shipper_name"), ("supplier", "supplier_name"),
+            ("manufacturer", "manufacturer_name"), ("notify", "notify_party_name"),
+        ):
             if role in label:
                 return key
     if field_key != "bill_of_lading":
@@ -277,24 +327,36 @@ def _typed_key(field_key: str, label: str) -> str:
 
 
 def process_shipment(*, documents: list[ShipmentDocumentInput], ruleset: LaceyRuleset = LaceyRuleset()) -> ShipmentResolution:
-    """Reconcile admissible explicit document evidence without external dependencies."""
+    """Reconcile evidence by semantic entity before declaring contradictions."""
     identifiers = [item.document_id for item in documents]
     if len(identifiers) != len(set(identifiers)):
         raise ValueError("Shipment document_id values must be unique.")
     resolved: list[ShipmentDocumentResolution] = []
     evidence_by_field: dict[str, list[ShipmentEvidence]] = {}
     inferred_not_used = 0
+    out_of_scope_not_used = 0
     unresolved_roles: list[tuple[str, AdmittedCandidate]] = []
     for item in documents:
         if item.resolution is None and not item.content:
             raise ValueError("ShipmentDocumentInput requires resolution or non-empty content.")
-        resolution = item.resolution or process_document(filename=item.filename, content=item.content or b"", role_hint=item.role_hint)
+        resolution = item.resolution or process_document(
+            filename=item.filename,
+            content=item.content or b"",
+            role_hint=item.role_hint,
+        )
         resolved.append(ShipmentDocumentResolution(item.document_id, item.filename, resolution))
         for original_key, field in resolution.fields.items():
-            candidates = field.candidates if field.status is FieldStatus.CONFLICT else ((field.winning_candidate,) if field.status is FieldStatus.MATCHED and field.winning_candidate else ())
+            candidates = (
+                field.candidates
+                if field.status is FieldStatus.CONFLICT
+                else ((field.winning_candidate,) if field.status is FieldStatus.MATCHED and field.winning_candidate else ())
+            )
             for index, candidate in enumerate(candidates):
                 if candidate.raw.evidence_class is EvidenceClass.INFERRED:
                     inferred_not_used += 1
+                    continue
+                if is_out_of_scope_context(candidate.provenance.source_text):
+                    out_of_scope_not_used += 1
                     continue
                 field_key = _typed_key(original_key, candidate.raw.label or "")
                 if original_key in {"party", "party_name", "name"} and field_key == original_key:
@@ -303,24 +365,45 @@ def process_shipment(*, documents: list[ShipmentDocumentInput], ruleset: LaceyRu
                 if field_key not in _CATALOG:
                     continue
                 scope = _scope(_CATALOG[field_key])
-                component_key, line_key = _association(candidate.raw.label or "", scope)
+                row_key = association_key(candidate, scope.value, item.document_id)
+                component_key = row_key if scope is EvidenceScope.PLANT_COMPONENT else None
+                line_key = row_key if scope is EvidenceScope.MERCHANDISE_LINE else None
                 authority_key = "bill_of_lading" if field_key in {"master_bill_of_lading", "house_bill_of_lading"} else field_key
                 semantic = _quantity_semantic_type(candidate.raw.label or "")
                 if field_key == "plant_quantity" and semantic is not QuantitySemanticType.PLANT_MATERIAL_QUANTITY:
                     continue
-                record = ShipmentEvidence(f"{item.document_id}:{field_key}:{candidate.provenance.block_id}:{index}", item.document_id, field_key, candidate.raw.normalized_value, candidate, candidate.score, authority(authority_key, candidate.document_type), scope, line_key, component_key, semantic)
+                record = ShipmentEvidence(
+                    f"{item.document_id}:{field_key}:{candidate.provenance.block_id}:{index}",
+                    item.document_id,
+                    field_key,
+                    candidate.raw.normalized_value,
+                    candidate,
+                    candidate.score,
+                    authority(authority_key, candidate.document_type),
+                    scope,
+                    line_key,
+                    component_key,
+                    semantic,
+                )
                 evidence_by_field.setdefault(field_key, []).append(record)
+
     fields = {key: _reconcile(key, evidence_by_field.get(key, [])) for key in _CATALOG}
     issues: list[ShipmentIssue] = []
     for document_id, candidate in unresolved_roles:
-        issues.append(ShipmentIssue(f"unresolved-role:{document_id}:{candidate.provenance.block_id}", "party_name", EvidenceScope.SHIPMENT.value, "MEDIUM", "UNRESOLVED_ROLE", "Party evidence has no explicit supported role.", (f"{document_id}:party:{candidate.provenance.block_id}",), (document_id,)))
+        issues.append(ShipmentIssue(
+            f"unresolved-role:{document_id}:{candidate.provenance.block_id}",
+            "party_name", EvidenceScope.SHIPMENT.value, "MEDIUM", "UNRESOLVED_ROLE",
+            "Party evidence has no explicit supported role.",
+            (f"{document_id}:party:{candidate.provenance.block_id}",), (document_id,),
+        ))
     for key, result in fields.items():
         evidence = result.supporting_evidence
-        ids, docs = tuple(item.candidate_id for item in evidence), tuple(sorted({item.document_id for item in evidence}))
+        ids = tuple(item.candidate_id for item in evidence)
+        docs = tuple(sorted({item.document_id for item in evidence}))
         if result.state is ReconciliationState.CONFLICT:
-            issues.append(ShipmentIssue(f"conflict:{key}", key, _scope(_CATALOG[key]).value, "HIGH", "CONFLICT", f"Conflicting admissible {key} evidence.", ids, docs))
+            issues.append(ShipmentIssue(f"conflict:{key}", key, _scope(_CATALOG[key]).value, "HIGH", "CONFLICT", f"Conflicting admissible {key} evidence for the same semantic entity.", ids, docs))
         elif result.state is ReconciliationState.REVIEW_REQUIRED:
-            kind = "AMBIGUOUS_ASSOCIATION" if _CATALOG[key] is FieldCardinality.PER_PLANT_COMPONENT else "INCONSISTENT_SET"
+            kind = "AMBIGUOUS_ASSOCIATION" if _CATALOG[key] in {FieldCardinality.PER_PLANT_COMPONENT, FieldCardinality.PER_MERCHANDISE_LINE} else "INCONSISTENT_SET"
             issues.append(ShipmentIssue(f"review:{key}", key, _scope(_CATALOG[key]).value, "MEDIUM", kind, f"{key} requires semantic review.", ids, docs))
         if key in _IMPORTANT and evidence and max(item.source_authority for item in evidence) < 10:
             issues.append(ShipmentIssue(f"low-authority:{key}", key, _scope(_CATALOG[key]).value, "MEDIUM", "LOW_AUTHORITY_ONLY", f"Only low-authority evidence is available for {key}.", ids, docs))
@@ -330,7 +413,19 @@ def process_shipment(*, documents: list[ShipmentDocumentInput], ruleset: LaceyRu
         if not any(result.state is not ReconciliationState.MISSING for result in acceptable):
             issues.append(ShipmentIssue(f"missing:{requirement.requirement_id}", "bill_of_lading", EvidenceScope.SHIPMENT.value, "HIGH", "MISSING_REQUIRED", f"Required preparation evidence missing for {requirement.requirement_id}.", (), ()))
     blocking = any(issue.severity == "HIGH" for issue in issues)
-    review = any(issue.severity == "MEDIUM" for issue in issues) or any(result.state in {ReconciliationState.NEAR_MATCH, ReconciliationState.REVIEW_REQUIRED} for result in fields.values())
+    review = any(issue.severity == "MEDIUM" for issue in issues) or any(
+        result.state in {ReconciliationState.NEAR_MATCH, ReconciliationState.REVIEW_REQUIRED}
+        for result in fields.values()
+    )
     readiness = ShipmentReadiness.BLOCKED if blocking else (ShipmentReadiness.REVIEW_REQUIRED if review else ShipmentReadiness.READY)
-    metrics = {"documents_processed": len(resolved), "fields_supported": sum(result.state in {ReconciliationState.SUPPORTED, ReconciliationState.SUPPORTED_MULTIPLE, ReconciliationState.NEAR_MATCH} for result in fields.values()), "fields_conflicting": sum(result.state is ReconciliationState.CONFLICT for result in fields.values()), "fields_missing": sum(result.state is ReconciliationState.MISSING for result in fields.values()), "fields_review_required": sum(result.state is ReconciliationState.REVIEW_REQUIRED for result in fields.values()), "inferred_candidates_not_used": inferred_not_used, "issues_total": len(issues)}
+    metrics = {
+        "documents_processed": len(resolved),
+        "fields_supported": sum(result.state in {ReconciliationState.SUPPORTED, ReconciliationState.SUPPORTED_MULTIPLE, ReconciliationState.NEAR_MATCH} for result in fields.values()),
+        "fields_conflicting": sum(result.state is ReconciliationState.CONFLICT for result in fields.values()),
+        "fields_missing": sum(result.state is ReconciliationState.MISSING for result in fields.values()),
+        "fields_review_required": sum(result.state is ReconciliationState.REVIEW_REQUIRED for result in fields.values()),
+        "inferred_candidates_not_used": inferred_not_used,
+        "out_of_scope_candidates_not_used": out_of_scope_not_used,
+        "issues_total": len(issues),
+    }
     return ShipmentResolution(ENGINE_VERSION, tuple(resolved), fields, tuple(issues), readiness, metrics, ruleset.version)

--- a/src/litoral_trace/lacey_engine/source_authority.py
+++ b/src/litoral_trace/lacey_engine/source_authority.py
@@ -1,12 +1,118 @@
 from __future__ import annotations
+
 from .domain import DocumentType
 
+# Source authority is field-specific.  A packing list can be excellent container
+# evidence and poor harvest evidence; a supplier declaration is the inverse.  These
+# scores affect ranking only and never turn an inference into a fact.
 _AUTHORITY = {
-    "bill_of_lading": {DocumentType.BILL_OF_LADING: 30, DocumentType.CUSTOMS_ENTRY_SUMMARY: 20, DocumentType.PACKING_LIST: 10},
-    "container_number": {DocumentType.BILL_OF_LADING: 25, DocumentType.PACKING_LIST: 25, DocumentType.COMMERCIAL_INVOICE: 10},
-    "species": {DocumentType.SPECIES_DECLARATION: 30, DocumentType.SUPPLIER_DECLARATION: 25, DocumentType.BILL_OF_LADING: 20, DocumentType.COMMERCIAL_INVOICE: 15},
-    "genus": {DocumentType.SPECIES_DECLARATION: 30, DocumentType.SUPPLIER_DECLARATION: 25, DocumentType.BILL_OF_LADING: 20, DocumentType.COMMERCIAL_INVOICE: 15},
-    "country_of_harvest": {DocumentType.HARVEST_DECLARATION: 30, DocumentType.SUPPLIER_DECLARATION: 25},
+    "bill_of_lading": {
+        DocumentType.BILL_OF_LADING: 40,
+        DocumentType.CUSTOMS_ENTRY_SUMMARY: 25,
+        DocumentType.ARRIVAL_NOTICE: 20,
+        DocumentType.PACKING_LIST: 10,
+    },
+    "container_number": {
+        DocumentType.BILL_OF_LADING: 35,
+        DocumentType.PACKING_LIST: 32,
+        DocumentType.CUSTOMS_ENTRY_SUMMARY: 30,
+        DocumentType.COMMERCIAL_INVOICE: 15,
+    },
+    "estimated_arrival_date": {
+        DocumentType.ARRIVAL_NOTICE: 40,
+        DocumentType.BILL_OF_LADING: 30,
+        DocumentType.CUSTOMS_ENTRY_SUMMARY: 25,
+    },
+    "filing_entry_reference": {
+        DocumentType.CUSTOMS_ENTRY_SUMMARY: 45,
+        DocumentType.ISF: 25,
+        DocumentType.BILL_OF_LADING: 10,
+    },
+    "manufacturer_id": {
+        DocumentType.CUSTOMS_ENTRY_SUMMARY: 45,
+        DocumentType.ISF: 35,
+        DocumentType.COMMERCIAL_INVOICE: 20,
+        DocumentType.SUPPLIER_DECLARATION: 20,
+    },
+    "importer_name": {
+        DocumentType.CUSTOMS_ENTRY_SUMMARY: 40,
+        DocumentType.BILL_OF_LADING: 35,
+        DocumentType.COMMERCIAL_INVOICE: 32,
+        DocumentType.PACKING_LIST: 25,
+    },
+    "consignee_name": {
+        DocumentType.BILL_OF_LADING: 40,
+        DocumentType.ARRIVAL_NOTICE: 35,
+        DocumentType.COMMERCIAL_INVOICE: 30,
+        DocumentType.PACKING_LIST: 25,
+    },
+    "importer_address": {
+        DocumentType.CUSTOMS_ENTRY_SUMMARY: 40,
+        DocumentType.COMMERCIAL_INVOICE: 30,
+        DocumentType.BILL_OF_LADING: 25,
+    },
+    "consignee_address": {
+        DocumentType.BILL_OF_LADING: 40,
+        DocumentType.ARRIVAL_NOTICE: 35,
+        DocumentType.COMMERCIAL_INVOICE: 30,
+    },
+    "description": {
+        DocumentType.COMMERCIAL_INVOICE: 40,
+        DocumentType.BILL_OF_LADING: 35,
+        DocumentType.CUSTOMS_ENTRY_SUMMARY: 30,
+        DocumentType.PACKING_LIST: 20,
+        DocumentType.SUPPLIER_DECLARATION: 15,
+    },
+    "hts_code": {
+        DocumentType.CUSTOMS_ENTRY_SUMMARY: 45,
+        DocumentType.COMMERCIAL_INVOICE: 35,
+        DocumentType.ISF: 30,
+        DocumentType.BILL_OF_LADING: 15,
+    },
+    "entered_value": {
+        DocumentType.CUSTOMS_ENTRY_SUMMARY: 45,
+        DocumentType.COMMERCIAL_INVOICE: 40,
+        DocumentType.PACKING_LIST: 10,
+    },
+    "article_component": {
+        DocumentType.SUPPLIER_DECLARATION: 40,
+        DocumentType.SPECIES_DECLARATION: 38,
+        DocumentType.COMMERCIAL_INVOICE: 25,
+        DocumentType.PACKING_LIST: 20,
+    },
+    "species": {
+        DocumentType.SPECIES_DECLARATION: 45,
+        DocumentType.HARVEST_DECLARATION: 42,
+        DocumentType.SUPPLIER_DECLARATION: 40,
+        DocumentType.COMMERCIAL_INVOICE: 20,
+        DocumentType.BILL_OF_LADING: 15,
+    },
+    "genus": {
+        DocumentType.SPECIES_DECLARATION: 45,
+        DocumentType.HARVEST_DECLARATION: 42,
+        DocumentType.SUPPLIER_DECLARATION: 40,
+        DocumentType.COMMERCIAL_INVOICE: 20,
+        DocumentType.BILL_OF_LADING: 15,
+    },
+    "country_of_harvest": {
+        DocumentType.HARVEST_DECLARATION: 50,
+        DocumentType.SUPPLIER_DECLARATION: 45,
+        DocumentType.SPECIES_DECLARATION: 35,
+    },
+    "plant_quantity": {
+        DocumentType.SUPPLIER_DECLARATION: 45,
+        DocumentType.HARVEST_DECLARATION: 40,
+        DocumentType.SPECIES_DECLARATION: 35,
+    },
+    "metric_unit": {
+        DocumentType.SUPPLIER_DECLARATION: 45,
+        DocumentType.HARVEST_DECLARATION: 40,
+        DocumentType.SPECIES_DECLARATION: 35,
+    },
+    "percent_recycled": {
+        DocumentType.SUPPLIER_DECLARATION: 45,
+        DocumentType.COMMERCIAL_INVOICE: 20,
+    },
 }
 
 

--- a/src/litoral_trace/us_lacey/engine2_suggestions.py
+++ b/src/litoral_trace/us_lacey/engine2_suggestions.py
@@ -1,8 +1,7 @@
 """Bridge deterministic Engine 2 shipment evidence into the human review queue.
 
-Engine 2 remains non-authoritative. A supported shipment value may prefill a MISSING
-PPQ preparation field as FOUND, but it is never silently accepted as MATCHED. The
-bridge is deliberately evidence preserving and conservative around multi-line values.
+Engine 2 remains non-authoritative. A supported shipment value may prefill an empty
+PPQ preparation field as FOUND, but it is never silently accepted as MATCHED.
 """
 from __future__ import annotations
 
@@ -47,7 +46,7 @@ _ENGINE2_TO_PREPARATION_FIELD = {
     "metric_unit": "metric_unit",
     "percent_recycled": "percent_recycled",
 }
-_SUPPORTED_STATES = frozenset({"SUPPORTED", "SUPPORTED_MULTIPLE"})
+_SUPPORTED_STATES = frozenset({"SUPPORTED", "SUPPORTED_MULTIPLE", "NEAR_MATCH"})
 
 
 @dataclass(frozen=True, slots=True)
@@ -72,24 +71,14 @@ def _candidate_payload(evidence: Mapping[str, object]) -> Mapping[str, object] |
     return candidate if isinstance(candidate, Mapping) else None
 
 
-def _suggestion_from_field(
-    field_key: str,
-    payload: Mapping[str, object],
-    *,
-    engine_version: str,
-) -> Engine2Suggestion | None:
-    """Choose the strongest exact documentary source for one supported field."""
+def _suggestion_from_field(field_key: str, payload: Mapping[str, object], *, engine_version: str) -> Engine2Suggestion | None:
     target = _ENGINE2_TO_PREPARATION_FIELD.get(field_key)
     if target is None or str(payload.get("state") or "") not in _SUPPORTED_STATES:
         return None
-
     values = payload.get("values")
     evidence_rows = payload.get("supporting_evidence")
     if not isinstance(values, list) or len(values) != 1 or not isinstance(evidence_rows, list):
-        # Multiple canonical values are a set/multi-line allocation problem and must
-        # stay in human/Terra review rather than being collapsed into one PPQ field.
         return None
-
     eligible: list[tuple[float, float, int, str, str, int, str]] = []
     for evidence in evidence_rows:
         if not isinstance(evidence, Mapping):
@@ -115,39 +104,14 @@ def _suggestion_from_field(
             continue
         if not value or not source_text or page < 1 or operation_document_id <= 0:
             continue
-        eligible.append(
-            (
-                source_authority,
-                candidate_score,
-                operation_document_id,
-                value,
-                source_text,
-                page,
-                evidence_class,
-            )
-        )
+        eligible.append((source_authority, candidate_score, operation_document_id, value, source_text, page, evidence_class))
     if not eligible:
         return None
-
-    # Source authority breaks ties before extraction score. Confidence is a bounded
-    # review-priority signal, never the raw Engine 2 score (which is not 0..1).
-    source_authority, candidate_score, document_id, value, source_text, page, evidence_class = max(
-        eligible, key=lambda item: (item[0], item[1])
-    )
-    support_count = len(eligible)
-    confidence = 0.94 if support_count > 1 else 0.86
+    source_authority, candidate_score, document_id, value, source_text, page, evidence_class = max(eligible, key=lambda item: (item[0], item[1]))
+    confidence = 0.94 if len(eligible) > 1 else 0.86
     if evidence_class == "DERIVED":
         confidence = min(confidence, 0.90)
-    return Engine2Suggestion(
-        field_name=target,
-        value=value,
-        operation_document_id=document_id,
-        source_text=source_text,
-        source_page=page,
-        evidence_class=evidence_class,
-        confidence=confidence,
-        engine_version=engine_version,
-    )
+    return Engine2Suggestion(target, value, document_id, source_text, page, evidence_class, confidence, engine_version)
 
 
 def supported_engine2_suggestions(payload: Mapping[str, object]) -> tuple[Engine2Suggestion, ...]:
@@ -157,31 +121,30 @@ def supported_engine2_suggestions(payload: Mapping[str, object]) -> tuple[Engine
     engine_version = str(payload.get("engine_version") or "lacey-engine-2")
     suggestions: list[Engine2Suggestion] = []
     for field_key, field_payload in fields.items():
-        if not isinstance(field_payload, Mapping):
-            continue
-        suggestion = _suggestion_from_field(
-            str(field_key), field_payload, engine_version=engine_version
-        )
-        if suggestion is not None:
-            suggestions.append(suggestion)
+        if isinstance(field_payload, Mapping):
+            suggestion = _suggestion_from_field(str(field_key), field_payload, engine_version=engine_version)
+            if suggestion is not None:
+                suggestions.append(suggestion)
     return tuple(suggestions)
 
 
+def _empty_unreviewed_field(field: UsLaceyOperationField) -> bool:
+    """Allow documentary evidence to replace a null optional MATCHED placeholder."""
+    if field.reviewed_at is not None or field.human_value:
+        return False
+    if str(field.normalized_value or field.original_value or "").strip():
+        return False
+    return field.field_status in {"MISSING", "MATCHED"}
+
+
 def project_engine2_supported_suggestions(*, organization_id: int, operation_id: int) -> int:
-    """Prefill MISSING PPQ fields as FOUND from current Engine 2 shipment support."""
     org_id = int(organization_id)
     session = get_us_lacey_db_session()
     try:
         set_tenant_db_context(session, org_id)
-        operation = session.scalar(
-            select(UsLaceyOperation).where(
-                UsLaceyOperation.organization_id == org_id,
-                UsLaceyOperation.id == int(operation_id),
-            )
-        )
+        operation = session.scalar(select(UsLaceyOperation).where(UsLaceyOperation.organization_id == org_id, UsLaceyOperation.id == int(operation_id)))
         if operation is None:
             return 0
-
         run = session.scalar(
             select(UsLaceyEngineShipmentRun)
             .where(
@@ -193,35 +156,19 @@ def project_engine2_supported_suggestions(*, organization_id: int, operation_id:
         )
         if run is None or not isinstance(run.resolution_json, Mapping):
             return 0
-
-        fields = session.scalars(
-            select(UsLaceyOperationField).where(
-                UsLaceyOperationField.organization_id == org_id,
-                UsLaceyOperationField.operation_id == operation.id,
-            )
-        ).all()
+        fields = session.scalars(select(UsLaceyOperationField).where(UsLaceyOperationField.organization_id == org_id, UsLaceyOperationField.operation_id == operation.id)).all()
         by_name: dict[str, list[UsLaceyOperationField]] = {}
         for field in fields:
             by_name.setdefault(field.field_name, []).append(field)
-
-        links = session.scalars(
-            select(UsLaceyOperationDocument).where(
-                UsLaceyOperationDocument.organization_id == org_id,
-                UsLaceyOperationDocument.operation_id == operation.id,
-                UsLaceyOperationDocument.is_current.is_(True),
-            )
-        ).all()
+        links = session.scalars(select(UsLaceyOperationDocument).where(UsLaceyOperationDocument.organization_id == org_id, UsLaceyOperationDocument.operation_id == operation.id, UsLaceyOperationDocument.is_current.is_(True))).all()
         assurance_by_link = {link.id: link.assurance_document_id for link in links}
-
         promoted = 0
         for suggestion in supported_engine2_suggestions(run.resolution_json):
             targets = by_name.get(suggestion.field_name, [])
             if len(targets) != 1:
-                # Multi-line plant allocation remains explicit. A shipment-level HTS,
-                # species or quantity cannot be guessed onto one of several PPQ lines.
                 continue
             field = targets[0]
-            if field.field_status != "MISSING" or field.reviewed_at is not None:
+            if not _empty_unreviewed_field(field):
                 continue
             assurance_document_id = assurance_by_link.get(suggestion.operation_document_id)
             if assurance_document_id is None:
@@ -229,43 +176,26 @@ def project_engine2_supported_suggestions(*, organization_id: int, operation_id:
             validation = validate_ppq_value(field.field_name, suggestion.value)
             if validation.status.value != "VALID" or not validation.normalized_value:
                 continue
-
-            fingerprint = _fingerprint(
-                "US_LACEY_ENGINE2_SUPPORTED",
-                operation.public_id,
-                field.id,
-                assurance_document_id,
-                validation.normalized_value,
-                suggestion.source_page,
-                suggestion.source_text,
-            )
-            existing = session.scalar(
-                select(UsLaceyFieldCandidate).where(
-                    UsLaceyFieldCandidate.organization_id == org_id,
-                    UsLaceyFieldCandidate.fingerprint == fingerprint,
-                )
-            )
+            fingerprint = _fingerprint("US_LACEY_ENGINE2_SUPPORTED", operation.public_id, field.id, assurance_document_id, validation.normalized_value, suggestion.source_page, suggestion.source_text)
+            existing = session.scalar(select(UsLaceyFieldCandidate).where(UsLaceyFieldCandidate.organization_id == org_id, UsLaceyFieldCandidate.fingerprint == fingerprint))
             if existing is None:
-                session.add(
-                    UsLaceyFieldCandidate(
-                        organization_id=org_id,
-                        operation_id=operation.id,
-                        operation_field_id=field.id,
-                        source_assurance_document_id=assurance_document_id,
-                        original_value=suggestion.value,
-                        normalized_value=validation.normalized_value,
-                        validation_status="VALID",
-                        validation_error=None,
-                        confidence=suggestion.confidence,
-                        source_page=suggestion.source_page,
-                        source_locator=f"engine2-supported:{suggestion.source_text[:1500]}",
-                        extractor="engine2-shipment-supported",
-                        extractor_version=suggestion.engine_version,
-                        fingerprint=fingerprint,
-                        decision="PENDING",
-                    )
-                )
-
+                session.add(UsLaceyFieldCandidate(
+                    organization_id=org_id,
+                    operation_id=operation.id,
+                    operation_field_id=field.id,
+                    source_assurance_document_id=assurance_document_id,
+                    original_value=suggestion.value,
+                    normalized_value=validation.normalized_value,
+                    validation_status="VALID",
+                    validation_error=None,
+                    confidence=suggestion.confidence,
+                    source_page=suggestion.source_page,
+                    source_locator=f"engine2-supported:{suggestion.source_text[:1500]}",
+                    extractor="engine2-shipment-supported",
+                    extractor_version=suggestion.engine_version,
+                    fingerprint=fingerprint,
+                    decision="PENDING",
+                ))
             field.original_value = suggestion.value
             field.normalized_value = validation.normalized_value
             field.field_status = "FOUND"
@@ -278,13 +208,8 @@ def project_engine2_supported_suggestions(*, organization_id: int, operation_id:
             field.validation_status = "VALID"
             field.validation_error = None
             promoted += 1
-
         if promoted:
-            refresh_us_lacey_operation_status(
-                session,
-                organization_id=org_id,
-                operation=operation,
-            )
+            refresh_us_lacey_operation_status(session, organization_id=org_id, operation=operation)
         session.commit()
         return promoted
     except Exception:

--- a/src/litoral_trace/us_lacey/semantic_reconciliation.py
+++ b/src/litoral_trace/us_lacey/semantic_reconciliation.py
@@ -1,0 +1,408 @@
+"""Deterministic semantic reconciliation between Engine 2 and human review.
+
+This pass resolves only relationships that can be proven from structured evidence:
+corroborating values, empty placeholders, and parallel plant-component table rows.
+It never marks a value human-confirmed and never invents a regulatory fact.
+"""
+from __future__ import annotations
+
+import hashlib
+from typing import Mapping
+
+from sqlalchemy import select
+
+from litoral_trace.db.models import (
+    ReconciliationIssue,
+    UsLaceyEngineShipmentRun,
+    UsLaceyFieldCandidate,
+    UsLaceyOperation,
+    UsLaceyOperationDocument,
+    UsLaceyOperationField,
+    UsLaceyPlantDeclaration,
+    UsLaceyPpqPlantLine,
+)
+from litoral_trace.db.tenant import set_tenant_db_context
+from litoral_trace.lacey_engine.semantic_graph import semantic_normalize
+from litoral_trace.lacey_engine.serialization import SHIPMENT_RESOLUTION_SCHEMA_VERSION
+from litoral_trace.us_lacey.db import get_us_lacey_db_session
+from litoral_trace.us_lacey.ppq505 import validate_ppq_value
+from litoral_trace.us_lacey.projection import refresh_us_lacey_operation_status
+
+
+_ENGINE_TO_FIELD = {
+    "estimated_arrival_date": "estimated_arrival_date",
+    "filing_entry_reference": "filing_entry_reference",
+    "container_number": "container_number",
+    "bill_of_lading": "bill_of_lading",
+    "manufacturer_id": "manufacturer_id",
+    "importer_name": "importer_name",
+    "consignee_name": "consignee_name",
+    "importer_address": "importer_address",
+    "consignee_address": "consignee_address",
+    "description": "merchandise_description",
+    "hts_code": "hts_code",
+    "entered_value": "entered_value",
+    "article_component": "article_component",
+    "genus": "genus",
+    "species": "species",
+    "country_of_harvest": "country_of_harvest",
+    "plant_quantity": "plant_quantity",
+    "metric_unit": "metric_unit",
+    "percent_recycled": "percent_recycled",
+}
+_SINGLE_SUPPORTED = frozenset({"SUPPORTED", "NEAR_MATCH", "SUPPORTED_MULTIPLE"})
+_COMPONENT_FIELDS = frozenset(
+    {"article_component", "genus", "species", "country_of_harvest", "plant_quantity", "metric_unit", "percent_recycled"}
+)
+
+
+def _fingerprint(*parts: object) -> str:
+    payload = "\x1f".join(str(part if part is not None else "") for part in parts)
+    return hashlib.sha256(payload.encode("utf-8")).hexdigest()
+
+
+def _evidence_rows(payload: Mapping[str, object]) -> list[Mapping[str, object]]:
+    rows = payload.get("supporting_evidence")
+    return [row for row in rows if isinstance(row, Mapping)] if isinstance(rows, list) else []
+
+
+def _raw_candidate(row: Mapping[str, object]) -> tuple[Mapping[str, object], Mapping[str, object]] | None:
+    candidate = row.get("candidate")
+    if not isinstance(candidate, Mapping):
+        return None
+    raw = candidate.get("raw")
+    provenance = candidate.get("provenance")
+    if not isinstance(raw, Mapping) or not isinstance(provenance, Mapping):
+        return None
+    return raw, provenance
+
+
+def _strongest(rows: list[Mapping[str, object]]) -> Mapping[str, object] | None:
+    if not rows:
+        return None
+    def score(row: Mapping[str, object]) -> tuple[float, float]:
+        try:
+            return float(row.get("source_authority") or 0), float(row.get("candidate_score") or 0)
+        except (TypeError, ValueError):
+            return 0.0, 0.0
+    return max(rows, key=score)
+
+
+def _engine_values(field_key: str, rows: list[Mapping[str, object]]) -> set[str]:
+    values = set()
+    for row in rows:
+        value = str(row.get("normalized_value") or "").strip()
+        normalized = semantic_normalize(field_key, value)
+        if normalized:
+            values.add(normalized)
+    return values
+
+
+def _resolve_field_issues(session, *, organization_id: int, operation: UsLaceyOperation, field: UsLaceyOperationField, reason: str) -> int:
+    issues = session.scalars(
+        select(ReconciliationIssue).where(
+            ReconciliationIssue.organization_id == organization_id,
+            ReconciliationIssue.operation_reference == f"us_lacey:{operation.public_id}",
+            ReconciliationIssue.us_lacey_operation_field_id == field.id,
+            ReconciliationIssue.status == "OPEN",
+        )
+    ).all()
+    for issue in issues:
+        issue.status = "RESOLVED"
+        issue.resolution_justification = reason
+        issue.evidence_json = {**(issue.evidence_json or {}), "semantic_resolution": reason}
+    return len(issues)
+
+
+def _promote_single_supported(
+    session,
+    *,
+    organization_id: int,
+    operation: UsLaceyOperation,
+    field: UsLaceyOperationField,
+    field_key: str,
+    payload: Mapping[str, object],
+    assurance_by_link: Mapping[int, int],
+    engine_version: str,
+) -> bool:
+    if field.reviewed_at is not None or field.human_value:
+        return False
+    state = str(payload.get("state") or "")
+    rows = _evidence_rows(payload)
+    if state not in _SINGLE_SUPPORTED or not rows:
+        return False
+    # A SUPPORTED_MULTIPLE set is only safe for a singular review field when all
+    # evidence collapses to one semantic value.  Parallel components remain separate.
+    semantic_values = _engine_values(field_key, rows)
+    if len(semantic_values) != 1:
+        return False
+    strongest = _strongest(rows)
+    if strongest is None:
+        return False
+    parts = _raw_candidate(strongest)
+    if parts is None:
+        return False
+    raw, provenance = parts
+    value = str(strongest.get("normalized_value") or raw.get("normalized_value") or "").strip()
+    validation = validate_ppq_value(field.field_name, value)
+    if validation.status.value != "VALID" or not validation.normalized_value:
+        return False
+    try:
+        link_id = int(strongest.get("document_id") or 0)
+        page = int(provenance.get("page") or 0)
+        confidence = min(0.99, max(0.0, float(strongest.get("candidate_score") or 0.0) / 100.0))
+    except (TypeError, ValueError):
+        return False
+    assurance_document_id = assurance_by_link.get(link_id)
+    if assurance_document_id is None or page < 1:
+        return False
+    source_text = str(provenance.get("source_text") or "").strip()
+    fingerprint = _fingerprint(
+        "US_LACEY_SEMANTIC_SUPPORTED", operation.public_id, field.id,
+        assurance_document_id, validation.normalized_value, page, source_text,
+    )
+    candidate = session.scalar(
+        select(UsLaceyFieldCandidate).where(
+            UsLaceyFieldCandidate.organization_id == organization_id,
+            UsLaceyFieldCandidate.fingerprint == fingerprint,
+        )
+    )
+    if candidate is None:
+        session.add(UsLaceyFieldCandidate(
+            organization_id=organization_id,
+            operation_id=operation.id,
+            operation_field_id=field.id,
+            source_assurance_document_id=assurance_document_id,
+            original_value=value,
+            normalized_value=validation.normalized_value,
+            validation_status="VALID",
+            validation_error=None,
+            confidence=confidence,
+            source_page=page,
+            source_locator=f"semantic-engine2:{source_text[:1500]}",
+            extractor="engine2-semantic-reconciler",
+            extractor_version=engine_version,
+            fingerprint=fingerprint,
+            decision="PENDING",
+        ))
+    field.original_value = value
+    field.normalized_value = validation.normalized_value
+    field.field_status = "FOUND"
+    field.validation_status = "VALID"
+    field.validation_error = None
+    field.confidence = confidence
+    field.source_assurance_document_id = assurance_document_id
+    field.source_page = page
+    field.source_locator = f"semantic-engine2:{source_text[:1500]}"
+    field.extractor = "engine2-semantic-reconciler"
+    field.extractor_version = engine_version
+    _resolve_field_issues(
+        session,
+        organization_id=organization_id,
+        operation=operation,
+        field=field,
+        reason="Deterministic semantic corroboration: Engine 2 resolved one canonical value; human confirmation is still required.",
+    )
+    return True
+
+
+def _project_component_suggestions(
+    session,
+    *,
+    organization_id: int,
+    operation: UsLaceyOperation,
+    canonical_fields: Mapping[str, object],
+    assurance_by_link: Mapping[int, int],
+    engine_version: str,
+) -> int:
+    plant_line = session.scalar(
+        select(UsLaceyPpqPlantLine)
+        .where(
+            UsLaceyPpqPlantLine.organization_id == organization_id,
+            UsLaceyPpqPlantLine.operation_id == operation.id,
+        )
+        .order_by(UsLaceyPpqPlantLine.ordinal.asc())
+    )
+    if plant_line is None:
+        return 0
+    grouped: dict[str, dict[str, list[Mapping[str, object]]]] = {}
+    for engine_key in _COMPONENT_FIELDS:
+        payload = canonical_fields.get(engine_key)
+        if not isinstance(payload, Mapping):
+            continue
+        for row in _evidence_rows(payload):
+            component_key = str(row.get("component_key") or "").strip()
+            if not component_key:
+                continue
+            grouped.setdefault(component_key, {}).setdefault(engine_key, []).append(row)
+    complete = []
+    for component_key, by_field in grouped.items():
+        # Species/genus/harvest/quantity/unit form the minimum coherent Lacey
+        # component.  Missing values stay for human/supplier review.
+        required = ("genus", "species", "country_of_harvest", "plant_quantity", "metric_unit")
+        selected: dict[str, Mapping[str, object]] = {}
+        valid = True
+        for key in required:
+            rows = by_field.get(key, [])
+            if len(_engine_values(key, rows)) != 1:
+                valid = False
+                break
+            strongest = _strongest(rows)
+            if strongest is None:
+                valid = False
+                break
+            selected[key] = strongest
+        if valid:
+            complete.append((component_key, by_field, selected))
+    complete.sort(key=lambda item: item[0])
+
+    changed = 0
+    for ordinal, (component_key, by_field, selected) in enumerate(complete, start=1):
+        declaration = session.scalar(
+            select(UsLaceyPlantDeclaration).where(
+                UsLaceyPlantDeclaration.organization_id == organization_id,
+                UsLaceyPlantDeclaration.plant_line_id == plant_line.id,
+                UsLaceyPlantDeclaration.ordinal == ordinal,
+            )
+        )
+        if declaration is None:
+            declaration = UsLaceyPlantDeclaration(
+                organization_id=organization_id,
+                plant_line_id=plant_line.id,
+                ordinal=ordinal,
+            )
+            session.add(declaration)
+        values = {key: str(row.get("normalized_value") or "").strip() for key, row in selected.items()}
+        strongest_all = _strongest([row for rows in by_field.values() for row in rows])
+        parts = _raw_candidate(strongest_all) if strongest_all is not None else None
+        provenance = parts[1] if parts else {}
+        try:
+            link_id = int((strongest_all or {}).get("document_id") or 0)
+            page = int(provenance.get("page") or 0)
+        except (TypeError, ValueError):
+            link_id, page = 0, 0
+        declaration.genus = values["genus"]
+        declaration.species = values["species"]
+        declaration.country_of_harvest = values["country_of_harvest"]
+        declaration.quantity = values["plant_quantity"]
+        declaration.unit = values["metric_unit"]
+        declaration.original_values = {
+            "review_state": "SUPPORTED_PENDING_HUMAN_CONFIRMATION",
+            "component_key": component_key,
+            "article_component": next(iter(_engine_values("article_component", by_field.get("article_component", []))), None),
+            "percent_recycled": next(iter(_engine_values("percent_recycled", by_field.get("percent_recycled", []))), None),
+        }
+        declaration.source_assurance_document_id = assurance_by_link.get(link_id)
+        declaration.source_page = page or None
+        declaration.source_locator = f"engine2-component:{component_key}"
+        declaration.extractor = "engine2-semantic-component"
+        declaration.extractor_version = engine_version
+        declaration.confidence = 0.90
+        changed += 1
+
+    # If Engine 2 proves multiple parallel components, generic one-value PPQ fields
+    # must not keep misleading blocking conflicts.  Keep them REVIEW (not MATCHED)
+    # and explain that component-level suggestions exist.
+    if len(complete) > 1:
+        fields = session.scalars(
+            select(UsLaceyOperationField).where(
+                UsLaceyOperationField.organization_id == organization_id,
+                UsLaceyOperationField.operation_id == operation.id,
+                UsLaceyOperationField.field_name.in_(tuple(_COMPONENT_FIELDS)),
+            )
+        ).all()
+        for field in fields:
+            if field.reviewed_at is not None or field.human_value:
+                continue
+            field.field_status = "REVIEW"
+            field.validation_status = "REVIEW_REQUIRED"
+            field.validation_error = f"{len(complete)} parallel plant components were reconstructed from table rows; review component-level suggestions rather than choosing one value as a conflict."
+            _resolve_field_issues(
+                session,
+                organization_id=organization_id,
+                operation=operation,
+                field=field,
+                reason="Deterministic semantic graph classified the alternatives as parallel plant components, not contradictory values.",
+            )
+    return changed
+
+
+def reconcile_operation_semantics(*, organization_id: int, operation_id: int) -> dict[str, int]:
+    """Run the deterministic semantic pass after Engine 2 shipment resolution."""
+    org_id = int(organization_id)
+    session = get_us_lacey_db_session()
+    try:
+        set_tenant_db_context(session, org_id)
+        operation = session.scalar(
+            select(UsLaceyOperation).where(
+                UsLaceyOperation.organization_id == org_id,
+                UsLaceyOperation.id == int(operation_id),
+            )
+        )
+        if operation is None:
+            return {"fields_promoted": 0, "components_reconstructed": 0}
+        run = session.scalar(
+            select(UsLaceyEngineShipmentRun)
+            .where(
+                UsLaceyEngineShipmentRun.organization_id == org_id,
+                UsLaceyEngineShipmentRun.operation_id == operation.id,
+                UsLaceyEngineShipmentRun.schema_version == SHIPMENT_RESOLUTION_SCHEMA_VERSION,
+            )
+            .order_by(UsLaceyEngineShipmentRun.id.desc())
+        )
+        if run is None or not isinstance(run.resolution_json, Mapping):
+            return {"fields_promoted": 0, "components_reconstructed": 0}
+        canonical_fields = run.resolution_json.get("canonical_fields")
+        if not isinstance(canonical_fields, Mapping):
+            return {"fields_promoted": 0, "components_reconstructed": 0}
+        links = session.scalars(
+            select(UsLaceyOperationDocument).where(
+                UsLaceyOperationDocument.organization_id == org_id,
+                UsLaceyOperationDocument.operation_id == operation.id,
+                UsLaceyOperationDocument.is_current.is_(True),
+            )
+        ).all()
+        assurance_by_link = {link.id: link.assurance_document_id for link in links}
+        operation_fields = session.scalars(
+            select(UsLaceyOperationField).where(
+                UsLaceyOperationField.organization_id == org_id,
+                UsLaceyOperationField.operation_id == operation.id,
+            )
+        ).all()
+        by_name: dict[str, list[UsLaceyOperationField]] = {}
+        for field in operation_fields:
+            by_name.setdefault(field.field_name, []).append(field)
+        promoted = 0
+        engine_version = str(run.resolution_json.get("engine_version") or "lacey-engine-2")
+        for engine_key, target in _ENGINE_TO_FIELD.items():
+            payload = canonical_fields.get(engine_key)
+            targets = by_name.get(target, [])
+            if not isinstance(payload, Mapping) or len(targets) != 1:
+                continue
+            if _promote_single_supported(
+                session,
+                organization_id=org_id,
+                operation=operation,
+                field=targets[0],
+                field_key=engine_key,
+                payload=payload,
+                assurance_by_link=assurance_by_link,
+                engine_version=engine_version,
+            ):
+                promoted += 1
+        components = _project_component_suggestions(
+            session,
+            organization_id=org_id,
+            operation=operation,
+            canonical_fields=canonical_fields,
+            assurance_by_link=assurance_by_link,
+            engine_version=engine_version,
+        )
+        refresh_us_lacey_operation_status(session, organization_id=org_id, operation=operation)
+        session.commit()
+        return {"fields_promoted": promoted, "components_reconstructed": components}
+    except Exception:
+        session.rollback()
+        raise
+    finally:
+        session.close()

--- a/src/litoral_trace/us_lacey/worker.py
+++ b/src/litoral_trace/us_lacey/worker.py
@@ -400,35 +400,38 @@ def process_one_us_lacey_job(
             operation_id=job.operation_id,
             assurance_document_id=job.assurance_document_id,
         )
-        if not complete_us_lacey_job(job_id=job.id, worker_id=worker_id):
-            raise UsLaceyWorkerError("Processing job could not be completed atomically.")
-        operation_status = _refresh_operation(
-            organization_id=job.organization_id,
-            operation_id=job.operation_id,
-        )
+
+        # Run every evidence/recommendation postprocessor while the queue job is
+        # still RUNNING. If orchestration itself ever fails unexpectedly, the outer
+        # failure boundary can still transition the owned job to retry/failed instead
+        # of leaving a false terminal COMPLETED state behind.
         _shadow_engine2(
             organization_id=job.organization_id,
             operation_id=job.operation_id,
         )
-        promoted = _project_engine2_suggestions(
+        _project_engine2_suggestions(
             organization_id=job.organization_id,
             operation_id=job.operation_id,
         )
-        promoted += _project_verified_ai_suggestions(
+        _project_verified_ai_suggestions(
             organization_id=job.organization_id,
             operation_id=job.operation_id,
         )
-        # Only a real MISSING -> FOUND transition needs another state derivation. This
-        # avoids an unnecessary DB round trip and preserves the legacy worker contract
-        # when intelligence is disabled, fails safely or has nothing evidence-backed.
-        if promoted:
-            operation_status = _refresh_operation(
-                organization_id=job.organization_id,
-                operation_id=job.operation_id,
-            )
         # AI review may annotate existing OPEN conflicts with a bounded recommendation,
         # but the recommendation cannot resolve an issue or set a field value.
         _run_ai_review_recommendations(
+            organization_id=job.organization_id,
+            operation_id=job.operation_id,
+        )
+
+        # COMPLETED is the final queue transition, after the full processing chain.
+        if not complete_us_lacey_job(job_id=job.id, worker_id=worker_id):
+            raise UsLaceyWorkerError("Processing job could not be completed atomically.")
+
+        # Refresh only after the terminal queue transition. Refreshing while this job
+        # is RUNNING would correctly project the operation as PROCESSING and leave a
+        # stale operation state until some later request recomputed it.
+        operation_status = _refresh_operation(
             organization_id=job.organization_id,
             operation_id=job.operation_id,
         )

--- a/tests/lacey_engine/test_ppq_explicit_extraction.py
+++ b/tests/lacey_engine/test_ppq_explicit_extraction.py
@@ -82,3 +82,8 @@ def test_generic_identifier_labels_do_not_create_entry_mid_or_hts_candidates():
     assert extracted["filing_entry_reference"] == []
     assert extracted["manufacturer_id"] == []
     assert extracted["hts_code"] == []
+
+
+def test_generic_component_label_outside_table_does_not_create_plant_component():
+    layout = layout_from_key_value_rows([("Component", "Chair frame")])
+    assert _extract(layout)["article_component"] == []

--- a/tests/test_us_lacey_engine2_persistence.py
+++ b/tests/test_us_lacey_engine2_persistence.py
@@ -122,7 +122,7 @@ def test_engine2_shipment_snapshot_persists_and_round_trips(engine2_postgres_ses
     service, processor = _service(engine2_postgres_session_factory, resolutions); monkeypatch.setattr(service_module, "process_document", processor)
     result = service.resolve_operation_with_engine2(organization_id=org, operation_id=operation)
     row = _snapshot(engine2_postgres_session_factory, org, result.shipment_run_id); restored = deserialize_shipment_resolution(row.resolution_json)
-    assert (row.organization_id, row.operation_id, row.ruleset_version, row.schema_version) == (org, operation, "lacey_ruleset_2026_01", SHIPMENT_RESOLUTION_SCHEMA_VERSION)
+    assert (row.organization_id, row.operation_id, row.ruleset_version, row.schema_version) == (org, operation, "lacey_ruleset_2026_02_semantic_graph", SHIPMENT_RESOLUTION_SCHEMA_VERSION)
     assert row.engine_version and row.source_set_fingerprint and row.document_count == 2 and row.resolution_json
     assert restored.canonical_fields["master_bill_of_lading"].values[0].value == "MAEU274342495"
     assert restored.canonical_fields["container_number"].values[0].value == "MSKU9228574"

--- a/tests/test_us_lacey_engine2_shadow_schema.py
+++ b/tests/test_us_lacey_engine2_shadow_schema.py
@@ -49,7 +49,7 @@ def test_engine2_orm_and_migration_share_status_scoped_document_identity():
 def test_engine2_service_defaults_use_canonical_version_boundaries():
     service = UsLaceyEngine2Service(vault_service=SimpleNamespace())
     assert service._engine_version == ENGINE_VERSION
-    assert service._ruleset.version == LaceyRuleset().version == "lacey_ruleset_2026_01"
+    assert service._ruleset.version == LaceyRuleset().version == "lacey_ruleset_2026_02_semantic_graph"
 
 
 def test_engine2_tables_have_forced_rls_and_tenant_policies(engine2_postgres_engine):

--- a/tests/test_us_lacey_engine2_shadow_worker.py
+++ b/tests/test_us_lacey_engine2_shadow_worker.py
@@ -12,6 +12,11 @@ def _wire_authoritative_success(monkeypatch):
     monkeypatch.setattr(worker, "project_assurance_document_to_us_lacey", lambda **_: projection)
     monkeypatch.setattr(worker, "complete_us_lacey_job", lambda **_: True)
     monkeypatch.setattr(worker, "_refresh_operation", lambda **_: "READY_FOR_REVIEW")
+    # Keep these worker-ordering tests isolated from database/environment-backed
+    # suggestion bridges. Dedicated tests cover each bridge independently.
+    monkeypatch.setattr(worker, "_project_engine2_suggestions", lambda **_: 0)
+    monkeypatch.setattr(worker, "_project_verified_ai_suggestions", lambda **_: 0)
+    monkeypatch.setattr(worker, "_run_ai_review_recommendations", lambda **_: None)
     return job
 
 
@@ -55,23 +60,25 @@ def test_worker_shadow_mode_still_runs_current_projection(monkeypatch):
     assert len(projected) == 1
 
 
-def test_worker_completes_and_refreshes_before_shadow(monkeypatch):
-    job = _wire_authoritative_success(monkeypatch); events = []
+def test_worker_runs_shadow_before_terminal_completion_and_refresh(monkeypatch):
+    _wire_authoritative_success(monkeypatch); events = []
     monkeypatch.setattr(worker, "engine2_mode", lambda: "SHADOW")
     monkeypatch.setattr(worker, "project_assurance_document_to_us_lacey", lambda **_: (events.append("projection"), SimpleNamespace(projected_count=4, conflict_count=2))[1])
     monkeypatch.setattr(worker, "complete_us_lacey_job", lambda **_: (events.append("complete"), True)[1])
     monkeypatch.setattr(worker, "_refresh_operation", lambda **_: (events.append("refresh"), "READY_FOR_REVIEW")[1])
     monkeypatch.setattr(worker, "_shadow_engine2", lambda **_: events.append("shadow"))
     result = worker.process_one_us_lacey_job(worker_id="unit")
-    assert events == ["projection", "complete", "refresh", "shadow"]
+    assert events == ["projection", "shadow", "complete", "refresh"]
     assert (result.job_status, result.projected_count, result.conflict_count) == ("COMPLETED", 4, 2)
 
 
-def test_worker_does_not_shadow_when_authoritative_completion_fails(monkeypatch):
+def test_worker_shadow_may_persist_before_atomic_completion_failure(monkeypatch):
     _wire_authoritative_success(monkeypatch); calls = []
     monkeypatch.setattr(worker, "engine2_mode", lambda: "SHADOW")
     monkeypatch.setattr(worker, "complete_us_lacey_job", lambda **_: False)
     monkeypatch.setattr(worker, "_shadow_engine2", lambda **_: calls.append("shadow"))
     monkeypatch.setattr(worker, "fail_us_lacey_job", lambda **_: "FAILED")
     result = worker.process_one_us_lacey_job(worker_id="unit")
-    assert result.job_status == "FAILED" and calls == []
+    # Shadow evidence is non-authoritative and may already exist. The queue job must
+    # still fail rather than report a terminal false success.
+    assert result.job_status == "FAILED" and calls == ["shadow"]

--- a/tests/test_us_lacey_worker_completion_order.py
+++ b/tests/test_us_lacey_worker_completion_order.py
@@ -1,0 +1,136 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from litoral_trace.us_lacey import worker
+
+
+class _ProcessingService:
+    def __init__(self, calls: list[str], *, status: str = "PROCESSED") -> None:
+        self._calls = calls
+        self._status = status
+
+    def process(self, **_: object) -> str:
+        self._calls.append("process")
+        return self._status
+
+
+def _job() -> SimpleNamespace:
+    return SimpleNamespace(
+        id=11,
+        organization_id=7,
+        operation_id=22,
+        assurance_document_id=33,
+    )
+
+
+def _stub_success_path(monkeypatch, calls: list[str]) -> None:
+    monkeypatch.setattr(worker, "claim_next_us_lacey_job", lambda **_: _job())
+    # A non-UUID test id deliberately bypasses the Vault/preflight branch while
+    # preserving the public-id lookup seam used by the worker.
+    monkeypatch.setattr(worker, "_assurance_public_id", lambda **_: "doc-public-id")
+    monkeypatch.setattr(worker, "_processing_service", lambda: _ProcessingService(calls))
+
+    def project(**_: object) -> SimpleNamespace:
+        calls.append("project")
+        return SimpleNamespace(projected_count=3, conflict_count=1)
+
+    monkeypatch.setattr(worker, "project_assurance_document_to_us_lacey", project)
+    monkeypatch.setattr(worker, "_shadow_engine2", lambda **_: calls.append("engine2"))
+
+    def engine2_suggestions(**_: object) -> int:
+        calls.append("engine2_suggestions")
+        return 0
+
+    def ai_suggestions(**_: object) -> int:
+        calls.append("ai_suggestions")
+        return 0
+
+    monkeypatch.setattr(worker, "_project_engine2_suggestions", engine2_suggestions)
+    monkeypatch.setattr(worker, "_project_verified_ai_suggestions", ai_suggestions)
+    monkeypatch.setattr(worker, "_run_ai_review_recommendations", lambda **_: calls.append("ai_review"))
+
+
+def test_worker_marks_completed_only_after_all_postprocessing(monkeypatch) -> None:
+    calls: list[str] = []
+    _stub_success_path(monkeypatch, calls)
+
+    def complete(**_: object) -> bool:
+        calls.append("complete")
+        return True
+
+    def refresh(**_: object) -> str:
+        calls.append("refresh")
+        return "READY_FOR_REVIEW"
+
+    monkeypatch.setattr(worker, "complete_us_lacey_job", complete)
+    monkeypatch.setattr(worker, "_refresh_operation", refresh)
+    monkeypatch.setattr(
+        worker,
+        "fail_us_lacey_job",
+        lambda **_: (_ for _ in ()).throw(AssertionError("success path must not fail the job")),
+    )
+
+    result = worker.process_one_us_lacey_job(worker_id="worker-test")
+
+    assert calls == [
+        "process",
+        "project",
+        "engine2",
+        "engine2_suggestions",
+        "ai_suggestions",
+        "ai_review",
+        "complete",
+        "refresh",
+    ]
+    assert result.claimed is True
+    assert result.job_status == "COMPLETED"
+    assert result.document_status == "PROCESSED"
+    assert result.operation_status == "READY_FOR_REVIEW"
+    assert result.projected_count == 3
+    assert result.conflict_count == 1
+
+
+def test_unexpected_postprocessing_failure_cannot_leave_false_completed_job(monkeypatch) -> None:
+    calls: list[str] = []
+    _stub_success_path(monkeypatch, calls)
+
+    def failing_review(**_: object) -> None:
+        calls.append("ai_review")
+        raise RuntimeError("unexpected review wrapper failure")
+
+    def complete(**_: object) -> bool:
+        calls.append("complete")
+        return True
+
+    def fail(**_: object) -> str:
+        calls.append("fail")
+        return "QUEUED"
+
+    def refresh(**_: object) -> str:
+        calls.append("refresh")
+        return "PROCESSING"
+
+    monkeypatch.setattr(worker, "_run_ai_review_recommendations", failing_review)
+    monkeypatch.setattr(worker, "complete_us_lacey_job", complete)
+    monkeypatch.setattr(worker, "fail_us_lacey_job", fail)
+    monkeypatch.setattr(worker, "_refresh_operation", refresh)
+
+    result = worker.process_one_us_lacey_job(worker_id="worker-test")
+
+    assert calls == [
+        "process",
+        "project",
+        "engine2",
+        "engine2_suggestions",
+        "ai_suggestions",
+        "ai_review",
+        "fail",
+        "refresh",
+    ]
+    assert "complete" not in calls
+    assert result.claimed is True
+    assert result.job_status == "QUEUED"
+    assert result.document_status is None
+    assert result.projected_count == 0
+    assert result.conflict_count == 0


### PR DESCRIPTION
## Objective
Raise Litoral Trace U.S. Lacey document intelligence from value matching to evidence-aware semantic reconciliation without allowing AI or Engine 2 to silently make legal/compliance decisions.

## Core changes
- add deterministic Semantic Evidence Graph primitives
- preserve matrix-table row/component identity
- distinguish corroboration, parallel entities, true conflicts, historical/out-of-scope evidence, and ambiguity
- normalize party identity separately from address/contact data
- reject structural MID artifacts
- strengthen field-specific source authority and component cardinality
- reconstruct plant-component proposals conservatively
- bridge Engine 2 supported evidence into the human review queue without auto-confirmation
- add a deterministic semantic reconciliation pass for false-conflict cleanup

## Safety contract
- Engine/AI may propose `FOUND` / evidence-backed review suggestions
- only explicit human review may produce `MATCHED`
- missing or genuinely contradictory evidence remains review-required
- no ACE/LAWGS submission semantics are changed

## Acceptance focus
The golden adversarial packet should no longer create false conflicts from formatting differences, duplicate evidence, historical shipment references, or parallel plant components. Critical unsupported inference must remain zero.

This PR is intentionally opened as draft while CI/regression work is completed.