### PR TITLE
fix(lacey): preserve explicit multi-component plant rows

### DIFF
--- a/src/litoral_trace/us_lacey/projection.py
+++ b/src/litoral_trace/us_lacey/projection.py
@@ -22,12 +22,15 @@ from litoral_trace.db.models import (
     UsLaceyFieldCandidate,
     UsLaceyOperation,
     UsLaceyOperationField,
+    UsLaceyPlantDeclaration,
+    UsLaceyPpqPlantLine,
     UsLaceyProcessingJob,
 )
 from litoral_trace.db.tenant import set_tenant_db_context
 from litoral_trace.us_lacey.db import get_us_lacey_db_session
 from litoral_trace.us_lacey.ppq505 import (
     PPQ505_FIELDS_BY_KEY,
+    PPQ505_PLANT_FIELDS,
     PPQ505_SHIPMENT_REFERENCE,
     PpqScope,
     validate_ppq_value,
@@ -179,6 +182,19 @@ _PARTY_NON_NAMES = frozenset(
     }
 )
 
+_PLANT_ROW_IDENTITY_TARGETS = frozenset(
+    {
+        "article_component",
+        "genus",
+        "species",
+        "country_of_harvest",
+        "plant_quantity",
+        "metric_unit",
+        "percent_recycled",
+    }
+)
+_MAX_AUTO_PLANT_LINES = 500
+
 
 def _fold(value: object) -> str:
     text = unicodedata.normalize("NFKD", str(value or "").lower())
@@ -276,6 +292,113 @@ def _line_reference(
         if 1 <= row_number <= len(line_references):
             return line_references[row_number - 1]
     return line_references[0] if len(line_references) == 1 else ""
+
+
+def _explicit_plant_data_rows(
+    extracted: tuple[ExtractedDocumentField, ...] | list[ExtractedDocumentField],
+    *,
+    table_headers: frozenset[str],
+) -> tuple[int, ...]:
+    """Return explicit table rows that carry plant-line identity evidence.
+
+    Row numbers are evidence locators, not inferred declaration facts. Restricting
+    materialization to plant identity fields prevents shipment totals or generic
+    invoice rows from manufacturing declaration lines.
+    """
+    rows: set[int] = set()
+    for source in extracted:
+        target, _priority = _target_field(source, table_headers=table_headers)
+        if target not in _PLANT_ROW_IDENTITY_TARGETS:
+            continue
+        match = _DATA_ROW.search(str(source.source_locator or ""))
+        if match is None:
+            continue
+        row_number = int(match.group("row"))
+        if 1 <= row_number <= _MAX_AUTO_PLANT_LINES:
+            rows.add(row_number)
+    return tuple(sorted(rows))
+
+
+def _new_line_reference(*, ordinal: int, used: set[str]) -> str:
+    preferred = str(ordinal)
+    if preferred not in used:
+        return preferred
+    base = f"auto-{ordinal}"
+    candidate = base
+    suffix = 2
+    while candidate in used:
+        candidate = f"{base}-{suffix}"
+        suffix += 1
+    return candidate
+
+
+def _materialize_explicit_plant_lines(
+    session,
+    *,
+    organization_id: int,
+    operation: UsLaceyOperation,
+    extracted: tuple[ExtractedDocumentField, ...] | list[ExtractedDocumentField],
+    table_headers: frozenset[str],
+) -> tuple[str, ...]:
+    """Create only consecutively evidenced plant rows missing from an operation.
+
+    Upload-first intentionally starts with a minimal operation. When extraction
+    explicitly identifies data_row:2, data_row:3, ... for plant identity fields,
+    those rows must become independent PPQ plant lines before projection. This keeps
+    parallel components from being collapsed into line 1 while refusing large row
+    jumps or shipment-only evidence as a basis for creating regulatory rows.
+    """
+    plant_lines = list(
+        session.scalars(
+            select(UsLaceyPpqPlantLine)
+            .where(
+                UsLaceyPpqPlantLine.organization_id == organization_id,
+                UsLaceyPpqPlantLine.operation_id == operation.id,
+            )
+            .order_by(UsLaceyPpqPlantLine.ordinal.asc(), UsLaceyPpqPlantLine.id.asc())
+        ).all()
+    )
+    explicit_rows = set(_explicit_plant_data_rows(extracted, table_headers=table_headers))
+    used = {str(row.line_reference) for row in plant_lines}
+    next_ordinal = len(plant_lines) + 1
+    while next_ordinal <= _MAX_AUTO_PLANT_LINES and next_ordinal in explicit_rows:
+        line_reference = _new_line_reference(ordinal=next_ordinal, used=used)
+        plant_line = UsLaceyPpqPlantLine(
+            organization_id=organization_id,
+            operation_id=operation.id,
+            line_reference=line_reference,
+            ordinal=next_ordinal,
+        )
+        session.add(plant_line)
+        session.flush()
+        session.add(
+            UsLaceyPlantDeclaration(
+                organization_id=organization_id,
+                plant_line_id=plant_line.id,
+                ordinal=1,
+            )
+        )
+        for field_contract in PPQ505_PLANT_FIELDS:
+            session.add(
+                UsLaceyOperationField(
+                    organization_id=organization_id,
+                    operation_id=operation.id,
+                    merchandise_line_reference=line_reference,
+                    field_name=field_contract.key,
+                    field_scope="PLANT_LINE",
+                    plant_line_id=plant_line.id,
+                    field_status="MISSING",
+                    validation_status="MISSING",
+                    confidence=0.0,
+                )
+            )
+        plant_lines.append(plant_line)
+        used.add(line_reference)
+        next_ordinal += 1
+
+    operation.merchandise_line_count = len(plant_lines)
+    session.flush()
+    return tuple(str(row.line_reference) for row in plant_lines)
 
 
 def _fingerprint(*parts: object) -> str:
@@ -444,21 +567,6 @@ def project_assurance_document_to_us_lacey(
         if latest_run is None:
             raise UsLaceyProjectionError("Processed document has no extraction run.")
 
-        operation_fields = session.scalars(
-            select(UsLaceyOperationField).where(
-                UsLaceyOperationField.organization_id == org_id,
-                UsLaceyOperationField.operation_id == operation.id,
-            )
-        ).all()
-        line_references = tuple(dict.fromkeys(
-            row.merchandise_line_reference
-            for row in operation_fields
-            if row.field_scope == "PLANT_LINE"
-        ))
-        indexed = {
-            (row.merchandise_line_reference, row.field_name): row
-            for row in operation_fields
-        }
         extracted = session.scalars(
             select(ExtractedDocumentField)
             .where(
@@ -473,6 +581,23 @@ def project_assurance_document_to_us_lacey(
             for row in extracted
             if (match := _RAW_TABLE_FIELD.match(str(row.field_name or "")))
         )
+        line_references = _materialize_explicit_plant_lines(
+            session,
+            organization_id=org_id,
+            operation=operation,
+            extracted=extracted,
+            table_headers=table_headers,
+        )
+        operation_fields = session.scalars(
+            select(UsLaceyOperationField).where(
+                UsLaceyOperationField.organization_id == org_id,
+                UsLaceyOperationField.operation_id == operation.id,
+            )
+        ).all()
+        indexed = {
+            (row.merchandise_line_reference, row.field_name): row
+            for row in operation_fields
+        }
 
         candidates: dict[tuple[str, str], list[tuple[int, ExtractedDocumentField]]] = {}
         for row in extracted:
@@ -560,6 +685,11 @@ def project_assurance_document_to_us_lacey(
             validation = validate_ppq_value(target, raw_value)
             new_value = validation.normalized_value or raw_value
             existing_value = field.human_value or field.normalized_value or field.original_value
+            human_confirmed = bool(
+                field.field_status == "MATCHED"
+                and field.human_value is not None
+                and str(field.human_value).strip()
+            )
             if existing_value and str(existing_value).strip() != new_value:
                 _upsert_conflict(
                     session,
@@ -589,7 +719,7 @@ def project_assurance_document_to_us_lacey(
             if validation.status.value in {"INVALID", "REVIEW_REQUIRED"}:
                 field.field_status = "REVIEW"
                 review += 1
-            elif existing_value:
+            elif human_confirmed:
                 field.field_status = "MATCHED"
                 matched += 1
             elif float(source.confidence) >= 0.90 and not bool(source.needs_review):

--- a/tests/test_us_lacey_projection_line_materialization.py
+++ b/tests/test_us_lacey_projection_line_materialization.py
@@ -1,0 +1,142 @@
+from types import SimpleNamespace
+
+from litoral_trace.db.models import (
+    UsLaceyOperationField,
+    UsLaceyPlantDeclaration,
+    UsLaceyPpqPlantLine,
+)
+from litoral_trace.us_lacey.ppq505 import PPQ505_PLANT_FIELDS
+from litoral_trace.us_lacey.projection import (
+    _explicit_plant_data_rows,
+    _line_reference,
+    _materialize_explicit_plant_lines,
+)
+
+
+class _ScalarRows:
+    def __init__(self, rows):
+        self._rows = rows
+
+    def all(self):
+        return list(self._rows)
+
+
+class _FakeSession:
+    def __init__(self, existing_lines):
+        self.existing_lines = list(existing_lines)
+        self.added = []
+        self._next_id = 100
+
+    def scalars(self, _statement):
+        return _ScalarRows(self.existing_lines)
+
+    def add(self, row):
+        if isinstance(row, UsLaceyPpqPlantLine) and row.id is None:
+            row.id = self._next_id
+            self._next_id += 1
+        self.added.append(row)
+
+    def flush(self):
+        return None
+
+
+def _source(*, header: str, value: str, row: int | None):
+    locator = "table:1"
+    if row is not None:
+        locator += f";data_row:{row};column:1"
+    return SimpleNamespace(
+        field_name=f"raw.table.1.{header}",
+        original_value=value,
+        normalized_value=None,
+        source_locator=locator,
+    )
+
+
+def test_explicit_plant_rows_ignore_entered_value_without_plant_identity():
+    sources = [
+        _source(header="Entered Value", value="18600", row=2),
+        _source(header="Article Component", value="Solid rubberwood coasters", row=1),
+    ]
+
+    assert _explicit_plant_data_rows(sources, table_headers=frozenset()) == (1,)
+
+
+def test_projection_materializes_second_explicit_plant_component_before_mapping():
+    existing = SimpleNamespace(id=1, line_reference="1", ordinal=1)
+    session = _FakeSession([existing])
+    operation = SimpleNamespace(id=77, merchandise_line_count=1)
+    sources = [
+        _source(header="Article Component", value="Solid rubberwood coasters", row=1),
+        _source(header="Genus", value="Hevea", row=1),
+        _source(header="Species", value="brasiliensis", row=1),
+        _source(header="Country of Harvest", value="Thailand", row=1),
+        _source(header="Plant Quantity", value="1440", row=1),
+        _source(header="Metric Unit", value="KG", row=1),
+        _source(header="Article Component", value="MDF holder", row=2),
+        _source(header="Genus", value="SPECIAL", row=2),
+        _source(header="Species", value="COMPOSITE", row=2),
+        _source(header="Country of Harvest", value="Malaysia", row=2),
+        _source(header="Plant Quantity", value="360", row=2),
+        _source(header="Metric Unit", value="KG", row=2),
+    ]
+
+    line_references = _materialize_explicit_plant_lines(
+        session,
+        organization_id=5,
+        operation=operation,
+        extracted=sources,
+        table_headers=frozenset(),
+    )
+
+    assert line_references == ("1", "2")
+    assert operation.merchandise_line_count == 2
+
+    new_lines = [row for row in session.added if isinstance(row, UsLaceyPpqPlantLine)]
+    declarations = [row for row in session.added if isinstance(row, UsLaceyPlantDeclaration)]
+    fields = [row for row in session.added if isinstance(row, UsLaceyOperationField)]
+    assert len(new_lines) == 1
+    assert new_lines[0].line_reference == "2"
+    assert new_lines[0].ordinal == 2
+    assert len(declarations) == 1
+    assert len(fields) == len(PPQ505_PLANT_FIELDS)
+    assert {field.merchandise_line_reference for field in fields} == {"2"}
+    assert {field.field_name for field in fields} == {
+        contract.key for contract in PPQ505_PLANT_FIELDS
+    }
+
+    assert _line_reference(
+        target="country_of_harvest",
+        source_locator="table:1;data_row:1;column:4",
+        line_references=line_references,
+    ) == "1"
+    assert _line_reference(
+        target="country_of_harvest",
+        source_locator="table:1;data_row:2;column:4",
+        line_references=line_references,
+    ) == "2"
+    assert _line_reference(
+        target="entered_value",
+        source_locator="page:2;label:Total Entered Value",
+        line_references=line_references,
+    ) == ""
+
+
+def test_materialization_refuses_nonconsecutive_row_jump():
+    existing = SimpleNamespace(id=1, line_reference="1", ordinal=1)
+    session = _FakeSession([existing])
+    operation = SimpleNamespace(id=77, merchandise_line_count=1)
+    sources = [
+        _source(header="Article Component", value="Unexpected distant row", row=20),
+    ]
+
+    line_references = _materialize_explicit_plant_lines(
+        session,
+        organization_id=5,
+        operation=operation,
+        extracted=sources,
+        table_headers=frozenset(),
+    )
+
+    assert line_references == ("1",)
+    assert operation.merchandise_line_count == 1
+    assert not session.added


### PR DESCRIPTION
## Problem
Upload-first operations begin with one plant line. When extraction contains explicit `data_row:2`, `data_row:3`, etc. plant evidence, projection previously fell back to line 1 and could manufacture false conflicts between parallel components.

## Change
- Materialize only consecutively evidenced plant rows before field projection.
- Require plant-identity evidence; shipment totals / entered-value-only rows cannot create declaration lines.
- Keep unscoped plant values unmapped once multiple lines exist.
- Preserve `MATCHED` only for already human-confirmed values; machine evidence cannot auto-promote an existing value to `MATCHED`.
- Add regression coverage for the two-component pattern behind the Golden Packet failure and for non-consecutive row-jump rejection.

## Safety contract
- Engine/AI may propose `FOUND` / review candidates.
- `MATCHED` requires prior explicit human confirmation.
- Country of Origin remains distinct from Country of Harvest.
- No weight semantics are changed; gross/net shipment weight is not promoted to plant quantity.
- No ACE/LAWGS submission behavior changes.