### PR TITLE
Fix U.S. Lacey review routing and serialize operation projection

### DIFF
--- a/src/litoral_trace/templates/us_lacey/fragments/operation_workspace.html
+++ b/src/litoral_trace/templates/us_lacey/fragments/operation_workspace.html
@@ -47,13 +47,8 @@
 } %}{{ guidance.get(field_name, "Add a supporting document or enter this value only if you can verify it.") }}{% endmacro %}
 
 {% macro review_field(field) %}
-{% if field.status == "FOUND" %}
-  {% set action_url = "/operations/" ~ detail.public_id ~ "/review-supported/" ~ field.id %}
-  {% set field_csrf = complete_csrf %}
-{% else %}
-  {% set action_url = "/operations/" ~ detail.public_id ~ "/review/" ~ field.id %}
-  {% set field_csrf = review_csrf.get(field.id, "") %}
-{% endif %}
+{% set action_url = "/operations/" ~ detail.public_id ~ "/review/fields/" ~ field.id %}
+{% set field_csrf = review_csrf.get(field.id, "") %}
 <article class="rounded-xl border {% if field.status == 'FOUND' %}border-emerald-200 bg-emerald-50/40{% else %}border-amber-200 bg-amber-50/40{% endif %} p-4" data-review-field data-review-status="{{ field.status }}">
   <div class="flex flex-wrap items-center justify-between gap-2">
     <h3 class="font-bold text-slate-950">{{ field.label }}</h3>
@@ -72,7 +67,7 @@
     <div class="mt-3 rounded-lg border border-rose-200 bg-rose-50 p-3 text-sm text-rose-900">
       <strong>Conflicting values found.</strong> The prefilled value may be wrong. Choose the supported value below or edit it manually.
     </div>
-    <div class="mt-3 grid gap-2">{% for candidate in field.candidates %}<form method="post" action="/operations/{{ detail.public_id }}/review/{{ field.id }}" class="rounded-lg border border-amber-200 bg-white p-3"><input type="hidden" name="csrf_token" value="{{ review_csrf.get(field.id, '') }}"><input type="hidden" name="action" value="accept"><input type="hidden" name="candidate_id" value="{{ candidate.id }}"><p class="font-semibold">{{ candidate.normalized_value or candidate.original_value }}</p><p class="mt-1 text-xs text-slate-500">Source document{% if candidate.source_page %} · page {{ candidate.source_page }}{% endif %} · confidence {{ (candidate.confidence * 100)|round(0) }}%</p>{{ button("Use this value", variant="secondary", button_type="submit") }}</form>{% endfor %}</div>
+    <div class="mt-3 grid gap-2">{% for candidate in field.candidates %}<form method="post" action="/operations/{{ detail.public_id }}/review/fields/{{ field.id }}" class="rounded-lg border border-amber-200 bg-white p-3"><input type="hidden" name="csrf_token" value="{{ review_csrf.get(field.id, '') }}"><input type="hidden" name="action" value="accept"><input type="hidden" name="candidate_id" value="{{ candidate.id }}"><p class="font-semibold">{{ candidate.normalized_value or candidate.original_value }}</p><p class="mt-1 text-xs text-slate-500">Source document{% if candidate.source_page %} · page {{ candidate.source_page }}{% endif %} · confidence {{ (candidate.confidence * 100)|round(0) }}%</p>{{ button("Use this value", variant="secondary", button_type="submit") }}</form>{% endfor %}</div>
   {% endif %}
 
   <div class="mt-4 grid gap-3 md:grid-cols-2">
@@ -82,7 +77,7 @@
     <form method="post" action="{{ action_url }}" class="flex gap-2"><input type="hidden" name="csrf_token" value="{{ field_csrf }}"><input type="hidden" name="action" value="edit"><label class="sr-only" for="field-{{ field.id }}">Correct {{ field.label }}</label><input id="field-{{ field.id }}" class="lt-control" name="value" maxlength="4000" required placeholder="Add or correct information" value="{{ field.effective_value or '' }}">{{ button("Save", variant="secondary", button_type="submit") }}</form>
   </div>
 
-  {% if field.field_name == "percent_recycled" and field.status != "FOUND" %}<form class="mt-3" method="post" action="/operations/{{ detail.public_id }}/review/{{ field.id }}"><input type="hidden" name="csrf_token" value="{{ review_csrf.get(field.id, '') }}"><input type="hidden" name="action" value="not_required"><input type="hidden" name="reason_code" value="NOT_PAPER_OR_PAPERBOARD">{{ button("Not applicable — not paper or paperboard", variant="secondary", button_type="submit") }}</form>{% endif %}
+  {% if field.field_name == "percent_recycled" and field.status != "FOUND" %}<form class="mt-3" method="post" action="/operations/{{ detail.public_id }}/review/fields/{{ field.id }}"><input type="hidden" name="csrf_token" value="{{ review_csrf.get(field.id, '') }}"><input type="hidden" name="action" value="not_required"><input type="hidden" name="reason_code" value="NOT_PAPER_OR_PAPERBOARD">{{ button("Not applicable — not paper or paperboard", variant="secondary", button_type="submit") }}</form>{% endif %}
 
   {% if field.proposed_value %}<details class="mt-4 text-sm"><summary class="cursor-pointer font-semibold text-emerald-800">View evidence</summary><dl class="mt-3 grid gap-2 rounded-lg border border-slate-200 bg-white p-3 text-sm"><div><dt class="text-xs font-semibold text-slate-500">Source</dt><dd>{% if field.extractor == "operator-entered-metadata" %}Operation details{% else %}Document evidence{% if field.source_page %} · page {{ field.source_page }}{% endif %}{% endif %}</dd></div><div><dt class="text-xs font-semibold text-slate-500">Confidence</dt><dd>{% if field.extractor == "operator-entered-metadata" %}Entered by user{% else %}{{ (field.confidence * 100)|round(0) }}%{% endif %}</dd></div></dl><details class="mt-2 text-xs text-slate-500"><summary class="cursor-pointer font-semibold">Technical details</summary><p class="mt-2">Field reference: {{ field.field_name }}{% if field.source_locator %} · {{ field.source_locator }}{% endif %}</p></details></details>{% endif %}
 </article>
@@ -104,7 +99,7 @@
   <section class="lt-card p-6">
     <div class="flex flex-wrap items-center justify-between gap-3">
       <div><h2 class="text-lg font-bold text-slate-950">Review extracted data</h2><p class="mt-1 text-sm text-slate-600">Safe suggestions are prefilled. Missing facts and conflicts remain visibly blocked until you resolve them.</p></div>
-      {% if bulk.items %}<form method="post" action="/operations/{{ detail.public_id }}/review/accept-supported"><input type="hidden" name="csrf_token" value="{{ complete_csrf }}">{{ button("Accept all safe suggestions (" ~ bulk.items|length ~ ")", variant="primary", button_type="submit", icon="fa-check-double") }}</form>{% endif %}
+      {% if bulk.items %}<form method="post" action="/operations/{{ detail.public_id }}/review/actions/accept-supported"><input type="hidden" name="csrf_token" value="{{ complete_csrf }}">{{ button("Accept all safe suggestions (" ~ bulk.items|length ~ ")", variant="primary", button_type="submit", icon="fa-check-double") }}</form>{% endif %}
     </div>
     <div class="mt-5 grid gap-4">{% for field in exception_fields %}{{ review_field(field) }}{% else %}{{ empty_state("No open review items", icon="fa-circle-check") }}{% endfor %}</div>
   </section>

--- a/src/litoral_trace/us_lacey/bulk_review.py
+++ b/src/litoral_trace/us_lacey/bulk_review.py
@@ -1,0 +1,207 @@
+"""Atomic customer confirmation for safe U.S. Lacey suggestions.
+
+Bulk confirmation is an explicit human review action.  It may promote only current
+``FOUND`` proposals that are unambiguous and have no open reconciliation issue.
+The whole click is committed as one transaction so a validation failure cannot
+leave a partially-confirmed operation.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from uuid import UUID
+
+from sqlalchemy import func, select
+
+from litoral_trace.db.models import (
+    ReconciliationIssue,
+    UsLaceyFieldCandidate,
+    UsLaceyOperation,
+    UsLaceyOperationField,
+)
+from litoral_trace.db.tenant import set_tenant_db_context
+from litoral_trace.services.audit import (
+    AuditAction,
+    AuditActor,
+    AuditOutcome,
+    record_audit_event,
+)
+from litoral_trace.us_lacey.db import get_us_lacey_db_session
+from litoral_trace.us_lacey.operations import UsLaceyOperationNotFound
+from litoral_trace.us_lacey.ppq505 import validate_ppq_value
+from litoral_trace.us_lacey.projection import refresh_us_lacey_operation_status
+from litoral_trace.us_lacey.review import UsLaceyReviewError
+
+
+@dataclass(frozen=True, slots=True)
+class UsLaceyBulkAcceptResult:
+    accepted_count: int
+    operation_status: str
+
+
+def _utc_now():
+    return datetime.now(timezone.utc)
+
+
+def accept_supported_us_lacey_fields(
+    *,
+    organization_id: int,
+    operation_public_id: UUID | str,
+    user_id: int,
+    user_email: str,
+) -> UsLaceyBulkAcceptResult:
+    """Confirm every currently safe ``FOUND`` field in one locked transaction.
+
+    Idempotency follows from the state transition itself: after a successful click
+    each eligible field is ``MATCHED``.  A repeated request therefore sees no
+    eligible ``FOUND`` rows and writes no duplicate field-review audit events.
+    ``REVIEW``/``MISSING`` fields and fields with open conflicts are never touched.
+    """
+    org_id = int(organization_id)
+    try:
+        public_id = (
+            operation_public_id
+            if isinstance(operation_public_id, UUID)
+            else UUID(str(operation_public_id))
+        )
+    except (ValueError, TypeError, AttributeError) as exc:
+        raise UsLaceyOperationNotFound("Operation not found.") from exc
+
+    session = get_us_lacey_db_session()
+    try:
+        set_tenant_db_context(session, org_id)
+        operation = session.scalar(
+            select(UsLaceyOperation)
+            .where(
+                UsLaceyOperation.organization_id == org_id,
+                UsLaceyOperation.public_id == public_id,
+            )
+            .with_for_update()
+        )
+        if operation is None:
+            raise UsLaceyOperationNotFound("Operation not found.")
+
+        found_fields = session.scalars(
+            select(UsLaceyOperationField)
+            .where(
+                UsLaceyOperationField.organization_id == org_id,
+                UsLaceyOperationField.operation_id == operation.id,
+                UsLaceyOperationField.field_status == "FOUND",
+            )
+            .order_by(UsLaceyOperationField.id.asc())
+            .with_for_update()
+        ).all()
+
+        if found_fields:
+            field_ids = [field.id for field in found_fields]
+            candidate_counts = dict(
+                session.execute(
+                    select(
+                        UsLaceyFieldCandidate.operation_field_id,
+                        func.count(UsLaceyFieldCandidate.id),
+                    )
+                    .where(
+                        UsLaceyFieldCandidate.organization_id == org_id,
+                        UsLaceyFieldCandidate.operation_id == operation.id,
+                        UsLaceyFieldCandidate.operation_field_id.in_(field_ids),
+                    )
+                    .group_by(UsLaceyFieldCandidate.operation_field_id)
+                ).all()
+            )
+            conflicted_field_ids = set(
+                session.scalars(
+                    select(ReconciliationIssue.us_lacey_operation_field_id).where(
+                        ReconciliationIssue.organization_id == org_id,
+                        ReconciliationIssue.operation_reference
+                        == f"us_lacey:{operation.public_id}",
+                        ReconciliationIssue.status == "OPEN",
+                        ReconciliationIssue.us_lacey_operation_field_id.in_(field_ids),
+                    )
+                ).all()
+            )
+        else:
+            candidate_counts = {}
+            conflicted_field_ids = set()
+
+        actor = AuditActor(
+            organization_id=org_id,
+            user_id=int(user_id),
+            username=str(user_email or "").strip() or None,
+            role="us_lacey_customer",
+        )
+        accepted = 0
+        for field in found_fields:
+            if int(candidate_counts.get(field.id, 0)) > 1:
+                continue
+            if field.id in conflicted_field_ids:
+                continue
+
+            proposed = field.normalized_value or field.original_value
+            if proposed is None or not str(proposed).strip():
+                continue
+            validation = validate_ppq_value(field.field_name, proposed)
+            if validation.status.value in {"INVALID", "MISSING", "REVIEW_REQUIRED"}:
+                # FOUND is an invariant asserting a safe, valid proposal.  If that
+                # invariant is broken, fail the entire click rather than partially
+                # accepting neighboring fields.
+                raise UsLaceyReviewError(
+                    validation.error
+                    or f"Supported field {field.field_name} is no longer safe to accept."
+                )
+
+            before = {
+                "field_id": field.id,
+                "field_name": field.field_name,
+                "field_status": field.field_status,
+                "effective_value": proposed,
+            }
+            reviewed_at = _utc_now()
+            field.human_value = validation.normalized_value
+            field.field_status = "MATCHED"
+            field.validation_status = "VALID"
+            field.validation_error = None
+            field.not_required_reason_code = None
+            field.reviewed_by_user_id = int(user_id)
+            field.reviewed_at = reviewed_at
+
+            record_audit_event(
+                session,
+                actor=actor,
+                action=AuditAction.ASSURANCE_REVIEW_APPROVE,
+                entity_type="us_lacey_operation",
+                entity_id=operation.id,
+                outcome=AuditOutcome.SUCCESS,
+                metadata={
+                    "operation_public_id": str(operation.public_id),
+                    "field_id": field.id,
+                    "field_name": field.field_name,
+                    "review_action": "bulk_accept_supported",
+                    "resolved_conflict_count": 0,
+                },
+                before_data=before,
+                after_data={
+                    "field_status": "MATCHED",
+                    "effective_value": validation.normalized_value,
+                },
+                detail="U.S. supported preparation field explicitly confirmed by a customer bulk action.",
+            )
+            accepted += 1
+
+        operation_status = refresh_us_lacey_operation_status(
+            session,
+            organization_id=org_id,
+            operation=operation,
+        )
+        session.commit()
+        return UsLaceyBulkAcceptResult(
+            accepted_count=accepted,
+            operation_status=operation_status,
+        )
+    except (UsLaceyReviewError, UsLaceyOperationNotFound):
+        session.rollback()
+        raise
+    except Exception as exc:
+        session.rollback()
+        raise UsLaceyReviewError("Unable to accept supported suggestions.") from exc
+    finally:
+        session.close()

--- a/src/litoral_trace/us_lacey/operation_lock.py
+++ b/src/litoral_trace/us_lacey/operation_lock.py
@@ -1,0 +1,43 @@
+"""PostgreSQL operation locks for U.S. Lacey evidence projection.
+
+Different documents for the same shipment can be processed by independent workers.
+Plant-line materialization and projection must therefore converge under concurrency,
+not race while deciding which declaration lines already exist.
+"""
+from __future__ import annotations
+
+from contextlib import contextmanager
+
+from sqlalchemy import text
+
+from litoral_trace.db.tenant import set_tenant_db_context
+from litoral_trace.us_lacey.db import get_us_lacey_db_session
+
+
+@contextmanager
+def us_lacey_operation_projection_lock(*, organization_id: int, operation_id: int):
+    """Hold one transaction-scoped advisory lock for a shipment operation.
+
+    PostgreSQL's two-int advisory key gives us a stable ``(tenant, operation)``
+    namespace without adding schema state.  The lock is released automatically
+    when the guard transaction ends, including exception paths.  Non-PostgreSQL
+    test runtimes are a no-op because they cannot exercise database concurrency.
+    """
+    org_id = int(organization_id)
+    op_id = int(operation_id)
+    session = get_us_lacey_db_session()
+    try:
+        set_tenant_db_context(session, org_id)
+        bind = session.get_bind()
+        if bind.dialect.name == "postgresql":
+            session.execute(
+                text("SELECT pg_advisory_xact_lock(:organization_id, :operation_id)"),
+                {"organization_id": org_id, "operation_id": op_id},
+            )
+        yield
+        session.commit()
+    except Exception:
+        session.rollback()
+        raise
+    finally:
+        session.close()

--- a/src/litoral_trace/us_lacey/worker.py
+++ b/src/litoral_trace/us_lacey/worker.py
@@ -1,6 +1,7 @@
 """One-job U.S. worker execution built on the mature Assurance processor."""
 from __future__ import annotations
 
+from contextlib import nullcontext
 from dataclasses import dataclass
 import logging
 from pathlib import PurePath
@@ -28,6 +29,7 @@ from litoral_trace.us_lacey.jobs import (
     fail_us_lacey_job,
     recover_stale_us_lacey_jobs,
 )
+from litoral_trace.us_lacey.operation_lock import us_lacey_operation_projection_lock
 from litoral_trace.us_lacey.projection import (
     project_assurance_document_to_us_lacey,
     refresh_us_lacey_operation_status,
@@ -395,34 +397,47 @@ def process_one_us_lacey_job(
                 conflict_count=0,
             )
 
-        projection = project_assurance_document_to_us_lacey(
-            organization_id=job.organization_id,
-            operation_id=job.operation_id,
-            assurance_document_id=job.assurance_document_id,
+        # Same-operation documents may be processed by different workers. Serialize
+        # the entire authoritative projection/post-processing phase so plant-line
+        # materialization observes the previous document's committed result before
+        # deciding whether another declaration line is required.
+        projection_guard = (
+            us_lacey_operation_projection_lock(
+                organization_id=job.organization_id,
+                operation_id=job.operation_id,
+            )
+            if isinstance(assurance_public_id, UUID)
+            else nullcontext()
         )
+        with projection_guard:
+            projection = project_assurance_document_to_us_lacey(
+                organization_id=job.organization_id,
+                operation_id=job.operation_id,
+                assurance_document_id=job.assurance_document_id,
+            )
 
-        # Run every evidence/recommendation postprocessor while the queue job is
-        # still RUNNING. If orchestration itself ever fails unexpectedly, the outer
-        # failure boundary can still transition the owned job to retry/failed instead
-        # of leaving a false terminal COMPLETED state behind.
-        _shadow_engine2(
-            organization_id=job.organization_id,
-            operation_id=job.operation_id,
-        )
-        _project_engine2_suggestions(
-            organization_id=job.organization_id,
-            operation_id=job.operation_id,
-        )
-        _project_verified_ai_suggestions(
-            organization_id=job.organization_id,
-            operation_id=job.operation_id,
-        )
-        # AI review may annotate existing OPEN conflicts with a bounded recommendation,
-        # but the recommendation cannot resolve an issue or set a field value.
-        _run_ai_review_recommendations(
-            organization_id=job.organization_id,
-            operation_id=job.operation_id,
-        )
+            # Run every evidence/recommendation postprocessor while the queue job is
+            # still RUNNING and while same-operation projection is serialized. If
+            # orchestration itself ever fails unexpectedly, the outer failure boundary
+            # can still transition the owned job instead of leaving false terminal work.
+            _shadow_engine2(
+                organization_id=job.organization_id,
+                operation_id=job.operation_id,
+            )
+            _project_engine2_suggestions(
+                organization_id=job.organization_id,
+                operation_id=job.operation_id,
+            )
+            _project_verified_ai_suggestions(
+                organization_id=job.organization_id,
+                operation_id=job.operation_id,
+            )
+            # AI review may annotate existing OPEN conflicts with a bounded recommendation,
+            # but the recommendation cannot resolve an issue or set a field value.
+            _run_ai_review_recommendations(
+                organization_id=job.organization_id,
+                operation_id=job.operation_id,
+            )
 
         # COMPLETED is the final queue transition, after the full processing chain.
         if not complete_us_lacey_job(job_id=job.id, worker_id=worker_id):

--- a/src/litoral_trace/web/route_contracts.py
+++ b/src/litoral_trace/web/route_contracts.py
@@ -1,0 +1,98 @@
+"""Static routing contracts for customer-facing FastAPI applications.
+
+Starlette resolves routes in registration order.  A path such as
+``/review/{field_id}`` therefore matches the literal ``/review/accept-supported``
+before Pydantic gets a chance to reject the non-integer value.  These helpers
+make that class of production bug a CI-enforced contract.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+import re
+from collections.abc import Iterable
+
+
+_PARAM = re.compile(r"^\{(?P<name>[^}:]+)(?::(?P<converter>[^}]+))?\}$")
+
+
+@dataclass(frozen=True, slots=True)
+class RouteShadow:
+    method: str
+    earlier_path: str
+    later_path: str
+    segment_index: int
+
+
+def _methods(route) -> frozenset[str]:
+    return frozenset(
+        str(method).upper()
+        for method in (getattr(route, "methods", None) or ())
+        if str(method).upper() not in {"HEAD", "OPTIONS"}
+    )
+
+
+def _segments(path: str) -> tuple[str, ...]:
+    return tuple(segment for segment in str(path).strip("/").split("/") if segment)
+
+
+def _unconstrained_parameter(segment: str) -> bool:
+    match = _PARAM.fullmatch(segment)
+    if match is None:
+        return False
+    converter = (match.group("converter") or "str").lower()
+    # Starlette's default/string converter accepts arbitrary literal text.  Typed
+    # converters such as int/float/uuid cannot shadow an unrelated action slug.
+    return converter in {"str", "path"}
+
+
+def find_dynamic_literal_route_shadows(routes: Iterable[object]) -> tuple[RouteShadow, ...]:
+    """Return ordered-route cases where a dynamic path can steal a later literal.
+
+    This intentionally focuses on the dangerous pattern that caused the U.S.
+    Lacey bulk-review 422: an earlier unconstrained parameter in the same path
+    position as a later literal, with at least one overlapping HTTP method.
+    """
+    route_list = [route for route in routes if getattr(route, "path", None)]
+    shadows: list[RouteShadow] = []
+    for earlier_index, earlier in enumerate(route_list):
+        earlier_segments = _segments(earlier.path)
+        earlier_methods = _methods(earlier)
+        if not earlier_methods:
+            continue
+        for later in route_list[earlier_index + 1 :]:
+            later_segments = _segments(later.path)
+            if len(earlier_segments) != len(later_segments):
+                continue
+            methods = earlier_methods & _methods(later)
+            if not methods:
+                continue
+
+            shadow_segment: int | None = None
+            compatible = True
+            for index, (left, right) in enumerate(zip(earlier_segments, later_segments)):
+                if left == right:
+                    continue
+                left_param = _PARAM.fullmatch(left)
+                right_param = _PARAM.fullmatch(right)
+                if left_param is None:
+                    compatible = False
+                    break
+                if right_param is None and _unconstrained_parameter(left):
+                    shadow_segment = index
+                    continue
+                # Parameter-vs-parameter and typed-parameter-vs-literal are not
+                # this contract's literal-shadow case.
+                compatible = False
+                break
+
+            if compatible and shadow_segment is not None:
+                for method in sorted(methods):
+                    shadows.append(
+                        RouteShadow(
+                            method=method,
+                            earlier_path=str(earlier.path),
+                            later_path=str(later.path),
+                            segment_index=shadow_segment,
+                        )
+                    )
+    return tuple(shadows)

--- a/src/litoral_trace/web/us_lacey_intelligent_workflow.py
+++ b/src/litoral_trace/web/us_lacey_intelligent_workflow.py
@@ -8,7 +8,7 @@ customer-visible fields afterwards.
 from __future__ import annotations
 
 from datetime import datetime, timezone
-from uuid import UUID, uuid4
+from uuid import uuid4
 
 from fastapi import APIRouter, Cookie, File, Form, Request, UploadFile
 from fastapi.responses import HTMLResponse, RedirectResponse
@@ -21,6 +21,7 @@ from litoral_trace.us_lacey.access import (
     UsLaceyOperationalAccessError,
     require_us_lacey_operational_access,
 )
+from litoral_trace.us_lacey.bulk_review import accept_supported_us_lacey_fields
 from litoral_trace.us_lacey.csrf import UsLaceyCsrfError, verify_us_lacey_csrf
 from litoral_trace.us_lacey.operations import (
     UsLaceyOperationError,
@@ -59,7 +60,13 @@ def _operation_reference() -> str:
     return f"INTAKE-{stamp}-{uuid4().hex[:12].upper()}"
 
 
-def _error_page(request: Request, message: str, *, action_href: str = "/operations", status_code: int = 400) -> HTMLResponse:
+def _error_page(
+    request: Request,
+    message: str,
+    *,
+    action_href: str = "/operations",
+    status_code: int = 400,
+) -> HTMLResponse:
     return HTMLResponse(
         render_message_page(
             request=request,
@@ -169,7 +176,14 @@ def _find_supported_field(detail, field_id: int):
     return next((field for field in detail.fields if field.id == int(field_id)), None)
 
 
-@router.post("/operations/{operation_public_id}/review-supported/{field_id}", response_class=HTMLResponse)
+# Compatibility-only route for links/forms rendered before the canonical review
+# contract was introduced.  The integer path converter is deliberate: it prevents
+# this dynamic endpoint from ever consuming a literal action slug.
+@router.post(
+    "/operations/{operation_public_id}/review-supported/{field_id:int}",
+    response_class=HTMLResponse,
+    include_in_schema=False,
+)
 def review_supported_field(
     operation_public_id: str,
     field_id: int,
@@ -179,11 +193,9 @@ def review_supported_field(
     csrf_token: str = Form(...),
     us_session: str | None = Cookie(None, alias=US_LACEY_SESSION_COOKIE),
 ):
-    """Confirm or edit a high-confidence FOUND proposal without silently accepting it."""
+    """Confirm/edit a legacy high-confidence FOUND proposal explicitly."""
     try:
         identity, _entitlement = _identity_and_entitlement(us_session)
-        # Reuse the operation-level confirmation token already rendered in the terminal
-        # workspace. It authorizes a strictly less powerful action than final completion.
         verify_us_lacey_csrf(
             session_token=us_session or "",
             purpose=f"complete:{operation_public_id}",
@@ -222,14 +234,30 @@ def review_supported_field(
         )
 
 
-@router.post("/operations/{operation_public_id}/review/accept-supported", response_class=HTMLResponse)
+# Canonical action namespace.  The legacy alias is safe because the old per-field
+# route is now constrained with Starlette's :int converter rather than a catch-all
+# string parameter.
+@router.post(
+    "/operations/{operation_public_id}/review/accept-supported",
+    response_class=HTMLResponse,
+    include_in_schema=False,
+)
+@router.post(
+    "/operations/{operation_public_id}/review/actions/accept-supported",
+    response_class=HTMLResponse,
+)
 def accept_all_supported_fields(
     operation_public_id: str,
     request: Request,
     csrf_token: str = Form(...),
     us_session: str | None = Cookie(None, alias=US_LACEY_SESSION_COOKIE),
 ):
-    """Accept only unambiguous FOUND proposals; conflicts and missing data remain open."""
+    """Atomically confirm only unambiguous FOUND proposals.
+
+    REVIEW/MISSING values, multi-candidate values and fields with an open
+    reconciliation issue remain untouched.  A repeated POST is idempotent because
+    already-confirmed rows are no longer FOUND.
+    """
     try:
         identity, _entitlement = _identity_and_entitlement(us_session)
         verify_us_lacey_csrf(
@@ -237,27 +265,12 @@ def accept_all_supported_fields(
             purpose=f"complete:{operation_public_id}",
             submitted_token=csrf_token,
         )
-        service = UsLaceyOperationService()
-        detail = service.get_detail(
+        accept_supported_us_lacey_fields(
             organization_id=identity.organization_id,
             operation_public_id=operation_public_id,
+            user_id=identity.user_id,
+            user_email=identity.email,
         )
-        supported = [
-            field
-            for field in detail.fields
-            if field.status == "FOUND"
-            and field.proposed_value
-            and len(field.candidates) <= 1
-        ]
-        for field in supported:
-            review_us_lacey_field(
-                organization_id=identity.organization_id,
-                operation_public_id=operation_public_id,
-                field_id=field.id,
-                user_id=identity.user_id,
-                user_email=identity.email,
-                action="accept",
-            )
         return RedirectResponse(f"/operations/{operation_public_id}", status_code=303)
     except UsLaceyPortalAuthError:
         return _login_redirect(clear_cookie=bool(us_session))

--- a/src/litoral_trace/web/us_lacey_pilot_app.py
+++ b/src/litoral_trace/web/us_lacey_pilot_app.py
@@ -154,7 +154,7 @@ def _detail_page(*, request: Request, identity, operation_public_id: str, us_ses
         dossier = UsLaceyEngineDossierService().get_dossier(organization_id=identity.organization_id, operation_public_id=detail.public_id)
     except Exception:
         dossier = Engine2DossierView(Engine2DossierAvailability.INVALID, safe_status_message="The stored dossier could not be safely read.")
-    tokens = {field.id: us_lacey_csrf_token(session_token=us_session, purpose=f"review:{detail.public_id}:{field.id}") for field in detail.fields if field.status in {"MISSING", "REVIEW"}}
+    tokens = {field.id: us_lacey_csrf_token(session_token=us_session, purpose=f"review:{detail.public_id}:{field.id}") for field in detail.fields if field.status in {"MISSING", "REVIEW", "FOUND"}}
     return _html(render_operation_detail(request=request, identity=identity, detail=detail, engine2_dossier=dossier, upload_csrf=us_lacey_csrf_token(session_token=us_session, purpose=f"upload:{detail.public_id}"), complete_csrf=us_lacey_csrf_token(session_token=us_session, purpose=f"complete:{detail.public_id}"), review_csrf=tokens, error=error, notice=notice), status_code=status_code)
 
 
@@ -178,7 +178,7 @@ def _workspace_fragment(*, request: Request, identity, operation_public_id: str,
             purpose=f"review:{detail.public_id}:{field.id}",
         )
         for field in detail.fields
-        if field.status in {"MISSING", "REVIEW"}
+        if field.status in {"MISSING", "REVIEW", "FOUND"}
     }
     return _html(
         render_operation_workspace(
@@ -626,7 +626,18 @@ async def operation_upload_submit(
             return _operation_error_page(request, "Operation not found.", status_code=404)
 
 
-@app.post("/operations/{operation_public_id}/review/{field_id}", response_class=HTMLResponse)
+# The canonical field-review namespace cannot collide with literal review actions.
+# The legacy alias remains for already-rendered forms, but its :int converter means
+# Starlette rejects action slugs before dispatch rather than sending them to Pydantic.
+@app.post(
+    "/operations/{operation_public_id}/review/{field_id:int}",
+    response_class=HTMLResponse,
+    include_in_schema=False,
+)
+@app.post(
+    "/operations/{operation_public_id}/review/fields/{field_id:int}",
+    response_class=HTMLResponse,
+)
 def operation_review_submit(
     operation_public_id: str,
     field_id: int,

--- a/src/litoral_trace/web/us_lacey_pilot_app.py
+++ b/src/litoral_trace/web/us_lacey_pilot_app.py
@@ -626,14 +626,6 @@ async def operation_upload_submit(
             return _operation_error_page(request, "Operation not found.", status_code=404)
 
 
-# The canonical field-review namespace cannot collide with literal review actions.
-# The legacy alias remains for already-rendered forms, but its :int converter means
-# Starlette rejects action slugs before dispatch rather than sending them to Pydantic.
-@app.post(
-    "/operations/{operation_public_id}/review/{field_id:int}",
-    response_class=HTMLResponse,
-    include_in_schema=False,
-)
 @app.post(
     "/operations/{operation_public_id}/review/fields/{field_id:int}",
     response_class=HTMLResponse,

--- a/tests/test_us_lacey_active_portal_postgres_e2e.py
+++ b/tests/test_us_lacey_active_portal_postgres_e2e.py
@@ -3,14 +3,18 @@ from __future__ import annotations
 from io import BytesIO
 import os
 import re
+from threading import Event, Lock, Thread, current_thread
+import time
 from uuid import uuid4
 
 from openpyxl import load_workbook
 import pytest
 from fastapi.testclient import TestClient
 from sqlalchemy import create_engine, text
+from sqlalchemy.orm import sessionmaker
 
 import litoral_trace.us_lacey.ingestion as ingestion_module
+import litoral_trace.us_lacey.operation_lock as operation_lock_module
 import litoral_trace.us_lacey.worker as worker_module
 from litoral_trace.storage import (
     ObjectDeleteResult,
@@ -310,8 +314,11 @@ def test_active_customer_operations_upload_review_complete_exports_and_history(m
         exceptions = [field for field in operation_detail.fields if field.status in {"MISSING", "REVIEW"}]
         assert exceptions
 
+        legacy_action = f"{operation_path}/review/{exceptions[0].id}"
+        assert client.post(legacy_action, data={}).status_code == 404
+
         for field in exceptions:
-            review_action = f"{operation_path}/review/{field.id}"
+            review_action = f"{operation_path}/review/fields/{field.id}"
             field_csrf = _csrf_for(workspace.text, review_action)
             if field.proposed_value:
                 payload = {"csrf_token": field_csrf, "action": "accept", "value": ""}
@@ -387,3 +394,122 @@ def test_active_customer_operations_upload_review_complete_exports_and_history(m
         assert historical_workspace.status_code == 200
         _assert_href(historical_workspace.text, f"{operation_path}/export.xlsx")
         _assert_href(historical_workspace.text, f"{operation_path}/export.csv")
+
+
+def test_operation_projection_advisory_lock_blocks_second_postgres_session(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """The exact two-key pg_advisory_xact_lock serializes independent sessions."""
+    _configure(monkeypatch)
+    reset_us_lacey_engine_state()
+
+    engine = create_engine(
+        os.environ["US_LACEY_DATABASE_URL"],
+        pool_pre_ping=True,
+        hide_parameters=True,
+    )
+    session_factory = sessionmaker(
+        bind=engine,
+        autoflush=False,
+        autocommit=False,
+        expire_on_commit=False,
+    )
+    pid_guard = Lock()
+    session_pids: dict[str, int] = {}
+
+    def real_session_factory():
+        session = session_factory()
+        pid = int(session.execute(text("SELECT pg_backend_pid()" )).scalar_one())
+        with pid_guard:
+            session_pids[current_thread().name] = pid
+        return session
+
+    monkeypatch.setattr(
+        operation_lock_module,
+        "get_us_lacey_db_session",
+        real_session_factory,
+    )
+
+    first_entered = Event()
+    release_first = Event()
+    second_attempting = Event()
+    second_entered = Event()
+    failures: list[BaseException] = []
+    organization_id = 19031
+    operation_id = 28041
+
+    def holder() -> None:
+        try:
+            with operation_lock_module.us_lacey_operation_projection_lock(
+                organization_id=organization_id,
+                operation_id=operation_id,
+            ):
+                first_entered.set()
+                if not release_first.wait(10):
+                    raise AssertionError("Timed out waiting to release the first advisory lock")
+        except BaseException as exc:  # pragma: no cover - surfaced below
+            failures.append(exc)
+            release_first.set()
+
+    def waiter() -> None:
+        try:
+            if not first_entered.wait(10):
+                raise AssertionError("First advisory lock was never acquired")
+            second_attempting.set()
+            with operation_lock_module.us_lacey_operation_projection_lock(
+                organization_id=organization_id,
+                operation_id=operation_id,
+            ):
+                second_entered.set()
+        except BaseException as exc:  # pragma: no cover - surfaced below
+            failures.append(exc)
+            release_first.set()
+
+    holder_thread = Thread(target=holder, name="lacey-lock-holder", daemon=True)
+    waiter_thread = Thread(target=waiter, name="lacey-lock-waiter", daemon=True)
+    holder_thread.start()
+    assert first_entered.wait(10)
+    waiter_thread.start()
+    assert second_attempting.wait(10)
+
+    try:
+        deadline = time.monotonic() + 10
+        waiter_pid = None
+        observed_wait = False
+        while time.monotonic() < deadline:
+            with pid_guard:
+                holder_pid = session_pids.get("lacey-lock-holder")
+                waiter_pid = session_pids.get("lacey-lock-waiter")
+            if holder_pid and waiter_pid:
+                assert holder_pid != waiter_pid
+                with engine.connect() as control:
+                    observed_wait = bool(
+                        control.execute(
+                            text(
+                                "SELECT EXISTS ("
+                                "SELECT 1 FROM pg_locks "
+                                "WHERE pid=:pid AND locktype='advisory' AND granted=false"
+                                ")"
+                            ),
+                            {"pid": waiter_pid},
+                        ).scalar_one()
+                    )
+                if observed_wait:
+                    break
+            time.sleep(0.02)
+
+        assert waiter_pid is not None
+        assert observed_wait, "Second PostgreSQL session was not observed waiting on the advisory lock"
+        assert not second_entered.is_set(), "Second session entered before the first transaction released the lock"
+
+        release_first.set()
+        assert second_entered.wait(10), "Second session did not acquire the lock after transaction release"
+    finally:
+        release_first.set()
+        holder_thread.join(timeout=10)
+        waiter_thread.join(timeout=10)
+        engine.dispose()
+
+    assert not holder_thread.is_alive()
+    assert not waiter_thread.is_alive()
+    assert failures == []

--- a/tests/test_us_lacey_review_route_contracts.py
+++ b/tests/test_us_lacey_review_route_contracts.py
@@ -1,0 +1,119 @@
+from types import SimpleNamespace
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from litoral_trace.us_lacey.bulk_review import UsLaceyBulkAcceptResult
+from litoral_trace.us_lacey.csrf import UsLaceyCsrfError
+from litoral_trace.web import us_lacey_intelligent_workflow as workflow
+from litoral_trace.web.route_contracts import find_dynamic_literal_route_shadows
+from litoral_trace.web.us_lacey_unified_app import app as unified_app
+
+
+def test_route_shadow_detector_reproduces_the_original_accept_supported_bug():
+    sample = FastAPI()
+
+    @sample.post("/operations/{operation_id}/review/{field_id}")
+    def field_review(operation_id: str, field_id: int):
+        return {"operation_id": operation_id, "field_id": field_id}
+
+    @sample.post("/operations/{operation_id}/review/accept-supported")
+    def accept_supported(operation_id: str):
+        return {"operation_id": operation_id}
+
+    shadows = find_dynamic_literal_route_shadows(sample.routes)
+    assert len(shadows) == 1
+    assert shadows[0].method == "POST"
+    assert shadows[0].earlier_path.endswith("/review/{field_id}")
+    assert shadows[0].later_path.endswith("/review/accept-supported")
+
+
+def test_typed_field_route_cannot_shadow_a_literal_review_action():
+    sample = FastAPI()
+
+    @sample.post("/operations/{operation_id}/review/{field_id:int}")
+    def field_review(operation_id: str, field_id: int):
+        return {"operation_id": operation_id, "field_id": field_id}
+
+    @sample.post("/operations/{operation_id}/review/accept-supported")
+    def accept_supported(operation_id: str):
+        return {"operation_id": operation_id}
+
+    assert find_dynamic_literal_route_shadows(sample.routes) == ()
+
+
+def test_unified_us_lacey_review_routes_have_no_dynamic_literal_shadow():
+    review_routes = [
+        route
+        for route in unified_app.routes
+        if "/operations/" in str(getattr(route, "path", ""))
+        and "/review" in str(getattr(route, "path", ""))
+    ]
+    assert find_dynamic_literal_route_shadows(review_routes) == ()
+
+
+def _standalone_review_app(monkeypatch, calls: list[dict]):
+    app = FastAPI()
+    app.include_router(workflow.router)
+    identity = SimpleNamespace(
+        organization_id=314,
+        user_id=2718,
+        email="reviewer@example.com",
+    )
+    monkeypatch.setattr(
+        workflow,
+        "_identity_and_entitlement",
+        lambda _token, require_slot=False: (identity, SimpleNamespace()),
+    )
+    monkeypatch.setattr(workflow, "verify_us_lacey_csrf", lambda **_kwargs: None)
+
+    def accept_bulk(**kwargs):
+        calls.append(dict(kwargs))
+        return UsLaceyBulkAcceptResult(accepted_count=2, operation_status="REVIEW_REQUIRED")
+
+    monkeypatch.setattr(workflow, "accept_supported_us_lacey_fields", accept_bulk)
+    return app
+
+
+def test_canonical_and_legacy_bulk_urls_reach_bulk_handler_not_field_parser(monkeypatch):
+    calls: list[dict] = []
+    app = _standalone_review_app(monkeypatch, calls)
+    operation_id = "80d62297-c3b5-4890-8217-a6131f89c315"
+
+    with TestClient(app, follow_redirects=False) as client:
+        canonical = client.post(
+            f"/operations/{operation_id}/review/actions/accept-supported",
+            data={"csrf_token": "test-token"},
+        )
+        legacy = client.post(
+            f"/operations/{operation_id}/review/accept-supported",
+            data={"csrf_token": "test-token"},
+        )
+
+    assert canonical.status_code == 303
+    assert legacy.status_code == 303
+    assert canonical.headers["location"] == f"/operations/{operation_id}"
+    assert legacy.headers["location"] == f"/operations/{operation_id}"
+    assert len(calls) == 2
+    assert {call["organization_id"] for call in calls} == {314}
+    assert all(call["operation_public_id"] == operation_id for call in calls)
+
+
+def test_bulk_url_fails_closed_on_invalid_csrf_without_422_route_confusion(monkeypatch):
+    calls: list[dict] = []
+    app = _standalone_review_app(monkeypatch, calls)
+    operation_id = "80d62297-c3b5-4890-8217-a6131f89c315"
+
+    def reject_csrf(**_kwargs):
+        raise UsLaceyCsrfError("Invalid CSRF token.")
+
+    monkeypatch.setattr(workflow, "verify_us_lacey_csrf", reject_csrf)
+    with TestClient(app, follow_redirects=False) as client:
+        response = client.post(
+            f"/operations/{operation_id}/review/actions/accept-supported",
+            data={"csrf_token": "invalid"},
+        )
+
+    assert response.status_code == 400
+    assert response.status_code != 422
+    assert calls == []

--- a/tests/test_us_lacey_review_route_contracts.py
+++ b/tests/test_us_lacey_review_route_contracts.py
@@ -2,6 +2,7 @@ from types import SimpleNamespace
 
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
+from starlette.staticfiles import StaticFiles
 
 from litoral_trace.us_lacey.bulk_review import UsLaceyBulkAcceptResult
 from litoral_trace.us_lacey.csrf import UsLaceyCsrfError
@@ -54,6 +55,11 @@ def test_unified_us_lacey_review_routes_have_no_dynamic_literal_shadow():
 
 def _standalone_review_app(monkeypatch, calls: list[dict]):
     app = FastAPI()
+    app.mount(
+        "/static",
+        StaticFiles(directory="src/litoral_trace/static"),
+        name="static",
+    )
     app.include_router(workflow.router)
     identity = SimpleNamespace(
         organization_id=314,

--- a/tests/test_us_lacey_upload_first_ai_workflow.py
+++ b/tests/test_us_lacey_upload_first_ai_workflow.py
@@ -58,12 +58,14 @@ def test_found_values_are_suggestions_not_confirmed_data():
 
 def test_workspace_offers_safe_bulk_confirmation_but_keeps_conflicts_explicit():
     source = WORKSPACE_TEMPLATE.read_text(encoding="utf-8")
-    assert "/review/accept-supported" in source
+    assert "/review/actions/accept-supported" in source
+    assert "/review/fields/" in source
+    assert "/review/accept-supported" not in source
+    assert "/review-supported/" not in source
     assert "Accept all safe suggestions" in source
     assert "Conflicting values found." in source
     assert "The prefilled value may be wrong." in source
     assert 'field.status == "FOUND"' in source
-    assert "/review-supported/" in source
     assert "Country of origin alone is not treated as proof." in source
     assert "Shipment gross weight is not substituted automatically." in source
 

--- a/tests/test_us_lacey_worker_operation_lock.py
+++ b/tests/test_us_lacey_worker_operation_lock.py
@@ -1,0 +1,90 @@
+from contextlib import contextmanager
+from types import SimpleNamespace
+from uuid import uuid4
+
+from litoral_trace.us_lacey import worker
+
+
+def test_worker_holds_operation_lock_across_projection_postprocessors(monkeypatch):
+    events: list[str] = []
+    job = SimpleNamespace(
+        id=41,
+        organization_id=7,
+        operation_id=9,
+        assurance_document_id=13,
+    )
+    descriptor = SimpleNamespace(
+        assurance_public_id=uuid4(),
+        vault_public_id=uuid4(),
+        filename="shipment.pdf",
+        size_bytes=1200,
+    )
+
+    monkeypatch.setattr(worker, "claim_next_us_lacey_job", lambda **_kwargs: job)
+    monkeypatch.setattr(worker, "_assurance_public_id", lambda **_kwargs: descriptor.assurance_public_id)
+    monkeypatch.setattr(worker, "_document_descriptor", lambda **_kwargs: descriptor)
+    monkeypatch.setattr(worker, "_preflight_existing_document", lambda **_kwargs: None)
+    monkeypatch.setattr(
+        worker,
+        "_processing_service",
+        lambda: SimpleNamespace(process=lambda **_kwargs: "EXTRACTED"),
+    )
+
+    @contextmanager
+    def projection_lock(**kwargs):
+        assert kwargs == {"organization_id": 7, "operation_id": 9}
+        events.append("lock-enter")
+        try:
+            yield
+        finally:
+            events.append("lock-exit")
+
+    monkeypatch.setattr(worker, "us_lacey_operation_projection_lock", projection_lock)
+
+    def project(**_kwargs):
+        events.append("project")
+        return SimpleNamespace(projected_count=5, conflict_count=0)
+
+    monkeypatch.setattr(worker, "project_assurance_document_to_us_lacey", project)
+    monkeypatch.setattr(worker, "_shadow_engine2", lambda **_kwargs: events.append("engine2-shadow"))
+    monkeypatch.setattr(
+        worker,
+        "_project_engine2_suggestions",
+        lambda **_kwargs: events.append("engine2-suggestions") or 0,
+    )
+    monkeypatch.setattr(
+        worker,
+        "_project_verified_ai_suggestions",
+        lambda **_kwargs: events.append("ai-suggestions") or 0,
+    )
+    monkeypatch.setattr(
+        worker,
+        "_run_ai_review_recommendations",
+        lambda **_kwargs: events.append("ai-review"),
+    )
+    monkeypatch.setattr(
+        worker,
+        "complete_us_lacey_job",
+        lambda **_kwargs: events.append("complete") or True,
+    )
+    monkeypatch.setattr(
+        worker,
+        "_refresh_operation",
+        lambda **_kwargs: events.append("refresh") or "READY_FOR_REVIEW",
+    )
+
+    result = worker.process_one_us_lacey_job(worker_id="worker-lock-test")
+
+    assert result.job_status == "COMPLETED"
+    assert result.projected_count == 5
+    assert events == [
+        "lock-enter",
+        "project",
+        "engine2-shadow",
+        "engine2-suggestions",
+        "ai-suggestions",
+        "ai-review",
+        "lock-exit",
+        "complete",
+        "refresh",
+    ]


### PR DESCRIPTION
## Summary
- use the canonical field-review namespace `/operations/{operation_id}/review/fields/{field_id}` and remove the legacy `/review/{field_id}` compatibility route
- keep bulk review actions in their dedicated `/review/actions/...` namespace and preserve route-shadow regression coverage
- serialize same-operation authoritative projection/post-processing with the existing two-key transaction-scoped PostgreSQL advisory lock
- add real PostgreSQL concurrency acceptance coverage using two independent backend sessions and deterministic coordination
- update the ACTIVE PostgreSQL browser E2E to exercise only the canonical review route and assert the legacy route returns 404

## PostgreSQL concurrency acceptance
The new PostgreSQL test exercises the production lock implementation itself (`pg_advisory_xact_lock(organization_id, operation_id)`). It records distinct `pg_backend_pid()` values for two independent sessions, observes the second backend waiting on an ungranted advisory lock in `pg_locks`, proves it cannot enter the critical section while the first transaction holds the lock, then proves it proceeds after the first transaction releases it.

## Safety / invariants
- no tests are disabled or weakened
- human review semantics are unchanged
- no automatic regulatory submission behavior is introduced
- tenant-scoped projection remains fail-closed

This PR intentionally relies on the repository CI/PostgreSQL gates for the authoritative full-suite execution because this execution environment does not expose a local repository checkout.