### PR TITLE
fix(lacey): stabilize review UX and canonical evidence validation

### DIFF
--- a/src/litoral_trace/static/src/js/us-lacey-workspace.js
+++ b/src/litoral_trace/static/src/js/us-lacey-workspace.js
@@ -1,5 +1,89 @@
-// Deliberately scoped to the U.S. Lacey HTMX workspace replacement. It neither
-// wraps fetch nor scrolls a person away from where they are reading.
+// U.S. Lacey review UX helpers. Processing still uses HTMX polling, while the
+// per-field review forms are progressively enhanced here so a confirm/edit action
+// never forces a full browser navigation and loses the reader's scroll position.
+
+const REVIEW_FIELD_ACTION = /\/operations\/[0-9a-f-]{36}\/review\/fields\/\d+$/i;
+
+const restoreViewport = (x, y) => {
+  // Replacing a large workspace can slightly change layout before the next paint.
+  // Restore twice without animation so the viewport stays anchored to the review
+  // location rather than jumping to the top of the document.
+  window.scrollTo({ left: x, top: y, behavior: "instant" });
+  window.requestAnimationFrame(() => {
+    window.scrollTo({ left: x, top: y, behavior: "instant" });
+  });
+};
+
+const inlineReviewError = (card, parsedDocument) => {
+  const source = parsedDocument.querySelector(".lt-alert--danger");
+  if (!source) return false;
+  card.querySelector("[data-review-inline-error]")?.remove();
+  const wrapper = document.createElement("div");
+  wrapper.dataset.reviewInlineError = "true";
+  wrapper.className = "mb-3";
+  wrapper.append(source.cloneNode(true));
+  card.prepend(wrapper);
+  return true;
+};
+
+const submitReviewWithoutNavigation = async (form, card) => {
+  const viewportX = window.scrollX;
+  const viewportY = window.scrollY;
+  const submitters = [...form.querySelectorAll("button, input[type='submit']")];
+  submitters.forEach((element) => { element.disabled = true; });
+
+  try {
+    const response = await fetch(form.action, {
+      method: "POST",
+      body: new FormData(form),
+      credentials: "same-origin",
+      headers: {
+        "X-Requested-With": "LitoralTrace-Review",
+      },
+      redirect: "follow",
+    });
+    const html = await response.text();
+    const parsed = new DOMParser().parseFromString(html, "text/html");
+
+    if (!response.ok) {
+      inlineReviewError(card, parsed);
+      submitters.forEach((element) => { element.disabled = false; });
+      restoreViewport(viewportX, viewportY);
+      return;
+    }
+
+    const freshWorkspace = parsed.querySelector("#operation-workspace");
+    const currentWorkspace = document.querySelector("#operation-workspace");
+    if (!freshWorkspace || !currentWorkspace) {
+      // Progressive-enhancement fallback: use the browser's native form behavior
+      // only when the expected server-rendered fragment cannot be recovered.
+      HTMLFormElement.prototype.submit.call(form);
+      return;
+    }
+
+    currentWorkspace.replaceWith(freshWorkspace);
+    // The replacement came from DOMParser rather than an HTMX swap; initialize any
+    // HTMX attributes that may be present in the fresh server-rendered workspace.
+    window.htmx?.process?.(freshWorkspace);
+    restoreViewport(viewportX, viewportY);
+  } catch (_error) {
+    // Network/script failures must not make the review action unusable. Native POST
+    // remains the no-JavaScript/failure fallback and preserves the backend contract.
+    HTMLFormElement.prototype.submit.call(form);
+  }
+};
+
+document.addEventListener("submit", (event) => {
+  const form = event.target instanceof HTMLFormElement ? event.target : null;
+  const card = form?.closest?.("[data-review-field]");
+  if (!form || !card || !REVIEW_FIELD_ACTION.test(new URL(form.action, window.location.href).pathname)) {
+    return;
+  }
+  event.preventDefault();
+  void submitReviewWithoutNavigation(form, card);
+});
+
+// Existing HTMX processing/workspace swaps must also avoid moving focus/scroll.
 document.addEventListener("htmx:afterSwap", (event) => {
   const workspace = event.detail?.target?.id === "operation-workspace"
     ? event.detail.target

--- a/src/litoral_trace/us_lacey/ai_suggestions.py
+++ b/src/litoral_trace/us_lacey/ai_suggestions.py
@@ -21,6 +21,7 @@ from litoral_trace.db.models import (
 )
 from litoral_trace.db.tenant import set_tenant_db_context
 from litoral_trace.lacey_engine.ai_shadow import AI_SHADOW_SCHEMA_VERSION
+from litoral_trace.us_lacey.candidate_reconciliation import reconcile_duplicate_field_candidates
 from litoral_trace.us_lacey.db import get_us_lacey_db_session
 from litoral_trace.us_lacey.ppq505 import PPQ505_SHIPMENT_REFERENCE, validate_ppq_value
 from litoral_trace.us_lacey.projection import refresh_us_lacey_operation_status
@@ -120,7 +121,12 @@ def verified_agreement_suggestions(payload: Mapping[str, object]) -> tuple[Verif
 
 
 def project_verified_ai_suggestions(*, organization_id: int, operation_id: int) -> int:
-    """Populate MISSING fields as FOUND only from Engine2+AI agreement evidence."""
+    """Populate MISSING fields as FOUND only from Engine2+AI agreement evidence.
+
+    After the optional AI bridge, always run deterministic duplicate-value
+    reconciliation.  This keeps page/confidence metadata from creating a false
+    conflict even when no AI document run exists.
+    """
     org_id = int(organization_id)
     session = get_us_lacey_db_session()
     try:
@@ -163,7 +169,7 @@ def project_verified_ai_suggestions(*, organization_id: int, operation_id: int) 
                 targets = by_name.get(suggestion.field_name, [])
                 if len(targets) != 1:
                     # Plant-line values are safe to auto-place only while the intake has
-                    # a single line. Multi-line/component allocation needs Terra.
+                    # a single line. Multi-line/component allocation needs explicit scope.
                     continue
                 field = targets[0]
                 if field.field_status != "MISSING" or field.reviewed_at is not None:
@@ -228,7 +234,12 @@ def project_verified_ai_suggestions(*, organization_id: int, operation_id: int) 
                 operation=operation,
             )
         session.commit()
-        return promoted
+
+        duplicate_result = reconcile_duplicate_field_candidates(
+            organization_id=org_id,
+            operation_id=operation.id,
+        )
+        return promoted + int(duplicate_result.promoted_count)
     except Exception:
         session.rollback()
         raise

--- a/src/litoral_trace/us_lacey/bulk_review.py
+++ b/src/litoral_trace/us_lacey/bulk_review.py
@@ -1,6 +1,6 @@
 """Atomic customer confirmation for safe U.S. Lacey suggestions.
 
-Bulk confirmation is an explicit human review action.  It may promote only current
+Bulk confirmation is an explicit human review action. It may promote only current
 ``FOUND`` proposals that are unambiguous and have no open reconciliation issue.
 The whole click is committed as one transaction so a validation failure cannot
 leave a partially-confirmed operation.
@@ -11,7 +11,7 @@ from dataclasses import dataclass
 from datetime import datetime, timezone
 from uuid import UUID
 
-from sqlalchemy import func, select
+from sqlalchemy import select
 
 from litoral_trace.db.models import (
     ReconciliationIssue,
@@ -26,6 +26,7 @@ from litoral_trace.services.audit import (
     AuditOutcome,
     record_audit_event,
 )
+from litoral_trace.us_lacey.candidate_normalization import group_candidate_evidence
 from litoral_trace.us_lacey.db import get_us_lacey_db_session
 from litoral_trace.us_lacey.operations import UsLaceyOperationNotFound
 from litoral_trace.us_lacey.ppq505 import validate_ppq_value
@@ -53,9 +54,11 @@ def accept_supported_us_lacey_fields(
     """Confirm every currently safe ``FOUND`` field in one locked transaction.
 
     Idempotency follows from the state transition itself: after a successful click
-    each eligible field is ``MATCHED``.  A repeated request therefore sees no
+    each eligible field is ``MATCHED``. A repeated request therefore sees no
     eligible ``FOUND`` rows and writes no duplicate field-review audit events.
-    ``REVIEW``/``MISSING`` fields and fields with open conflicts are never touched.
+    ``REVIEW``/``MISSING`` fields and fields with genuinely different open conflicts
+    are never touched. Multiple provenance rows supporting the same canonical value
+    count as one safe candidate group rather than a conflict.
     """
     org_id = int(organization_id)
     try:
@@ -94,20 +97,18 @@ def accept_supported_us_lacey_fields(
 
         if found_fields:
             field_ids = [field.id for field in found_fields]
-            candidate_counts = dict(
-                session.execute(
-                    select(
-                        UsLaceyFieldCandidate.operation_field_id,
-                        func.count(UsLaceyFieldCandidate.id),
-                    )
-                    .where(
-                        UsLaceyFieldCandidate.organization_id == org_id,
-                        UsLaceyFieldCandidate.operation_id == operation.id,
-                        UsLaceyFieldCandidate.operation_field_id.in_(field_ids),
-                    )
-                    .group_by(UsLaceyFieldCandidate.operation_field_id)
-                ).all()
-            )
+            candidate_rows = session.scalars(
+                select(UsLaceyFieldCandidate)
+                .where(
+                    UsLaceyFieldCandidate.organization_id == org_id,
+                    UsLaceyFieldCandidate.operation_id == operation.id,
+                    UsLaceyFieldCandidate.operation_field_id.in_(field_ids),
+                )
+                .order_by(UsLaceyFieldCandidate.id.asc())
+            ).all()
+            candidates_by_field: dict[int, list[UsLaceyFieldCandidate]] = {}
+            for candidate in candidate_rows:
+                candidates_by_field.setdefault(int(candidate.operation_field_id), []).append(candidate)
             conflicted_field_ids = set(
                 session.scalars(
                     select(ReconciliationIssue.us_lacey_operation_field_id).where(
@@ -120,7 +121,7 @@ def accept_supported_us_lacey_fields(
                 ).all()
             )
         else:
-            candidate_counts = {}
+            candidates_by_field = {}
             conflicted_field_ids = set()
 
         actor = AuditActor(
@@ -131,7 +132,11 @@ def accept_supported_us_lacey_fields(
         )
         accepted = 0
         for field in found_fields:
-            if int(candidate_counts.get(field.id, 0)) > 1:
+            groups = group_candidate_evidence(
+                field.field_name,
+                candidates_by_field.get(int(field.id), ()),
+            )
+            if len(groups) > 1:
                 continue
             if field.id in conflicted_field_ids:
                 continue
@@ -141,7 +146,7 @@ def accept_supported_us_lacey_fields(
                 continue
             validation = validate_ppq_value(field.field_name, proposed)
             if validation.status.value in {"INVALID", "MISSING", "REVIEW_REQUIRED"}:
-                # FOUND is an invariant asserting a safe, valid proposal.  If that
+                # FOUND is an invariant asserting a safe, valid proposal. If that
                 # invariant is broken, fail the entire click rather than partially
                 # accepting neighboring fields.
                 raise UsLaceyReviewError(

--- a/src/litoral_trace/us_lacey/candidate_normalization.py
+++ b/src/litoral_trace/us_lacey/candidate_normalization.py
@@ -1,0 +1,114 @@
+"""Canonical grouping for U.S. Lacey review evidence.
+
+Evidence identity is the actual field value, not the page, extractor or confidence
+that produced it.  This module is intentionally pure so projection, bulk review and
+presentation code can share exactly the same grouping rule without changing the
+human-confirmation authority boundary.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Generic, Iterable, TypeVar
+
+from litoral_trace.us_lacey.ppq505 import canonical_ppq_value_key
+
+
+T = TypeVar("T")
+
+
+@dataclass(frozen=True, slots=True)
+class CandidateEvidenceGroup(Generic[T]):
+    canonical_value: str
+    representative: T
+    evidence: tuple[T, ...]
+    confidence: float
+    source_pages: tuple[int, ...]
+    source_document_ids: tuple[int, ...]
+
+
+def _candidate_value(candidate: object) -> object:
+    normalized = getattr(candidate, "normalized_value", None)
+    if normalized is not None and str(normalized).strip():
+        return normalized
+    return getattr(candidate, "original_value", "")
+
+
+def _confidence(candidate: object) -> float:
+    try:
+        return max(0.0, min(1.0, float(getattr(candidate, "confidence", 0.0) or 0.0)))
+    except (TypeError, ValueError):
+        return 0.0
+
+
+def _candidate_id(candidate: object) -> int:
+    try:
+        return int(getattr(candidate, "id", 0) or 0)
+    except (TypeError, ValueError):
+        return 0
+
+
+def _source_page(candidate: object) -> int | None:
+    try:
+        value = getattr(candidate, "source_page", None)
+        return None if value in (None, "") else int(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _source_document_id(candidate: object) -> int | None:
+    raw = getattr(candidate, "source_assurance_document_id", None)
+    if raw is None:
+        raw = getattr(candidate, "source_document_id", None)
+    try:
+        return None if raw in (None, "") else int(raw)
+    except (TypeError, ValueError):
+        return None
+
+
+def group_candidate_evidence(
+    field_name: str,
+    candidates: Iterable[T],
+) -> tuple[CandidateEvidenceGroup[T], ...]:
+    """Collapse same-value evidence while retaining every provenance row.
+
+    The group key is scoped by the caller's field.  In the database each operation
+    field already belongs to one shipment/plant line, so this function never merges
+    evidence across declaration lines.  The highest-confidence row is the display
+    representative; ties resolve deterministically to the lowest candidate id.
+    """
+    grouped: dict[str, list[T]] = {}
+    order: list[str] = []
+    for candidate in candidates:
+        key = canonical_ppq_value_key(field_name, _candidate_value(candidate))
+        if not key:
+            continue
+        if key not in grouped:
+            grouped[key] = []
+            order.append(key)
+        grouped[key].append(candidate)
+
+    result: list[CandidateEvidenceGroup[T]] = []
+    for key in order:
+        rows = tuple(grouped[key])
+        representative = max(rows, key=lambda row: (_confidence(row), -_candidate_id(row)))
+        pages = tuple(sorted({page for row in rows if (page := _source_page(row)) is not None}))
+        documents = tuple(
+            sorted(
+                {
+                    document_id
+                    for row in rows
+                    if (document_id := _source_document_id(row)) is not None
+                }
+            )
+        )
+        result.append(
+            CandidateEvidenceGroup(
+                canonical_value=key,
+                representative=representative,
+                evidence=rows,
+                confidence=max((_confidence(row) for row in rows), default=0.0),
+                source_pages=pages,
+                source_document_ids=documents,
+            )
+        )
+    return tuple(result)

--- a/src/litoral_trace/us_lacey/candidate_reconciliation.py
+++ b/src/litoral_trace/us_lacey/candidate_reconciliation.py
@@ -1,0 +1,163 @@
+"""Resolve duplicate-value U.S. Lacey review evidence deterministically.
+
+This pass is deliberately non-authoritative.  It may turn an unreviewed REVIEW
+field into FOUND when multiple evidence rows collapse to one valid canonical value,
+but it never creates MATCHED.  Human confirmation remains the only transition to a
+confirmed declaration value.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from uuid import UUID
+
+from sqlalchemy import select
+
+from litoral_trace.db.models import (
+    ReconciliationIssue,
+    UsLaceyFieldCandidate,
+    UsLaceyOperation,
+    UsLaceyOperationField,
+)
+from litoral_trace.db.tenant import set_tenant_db_context
+from litoral_trace.us_lacey.candidate_normalization import group_candidate_evidence
+from litoral_trace.us_lacey.db import get_us_lacey_db_session
+from litoral_trace.us_lacey.ppq505 import canonical_ppq_value_key, validate_ppq_value
+from litoral_trace.us_lacey.projection import refresh_us_lacey_operation_status
+
+
+@dataclass(frozen=True, slots=True)
+class DuplicateCandidateReconciliationResult:
+    promoted_count: int
+    resolved_conflict_count: int
+
+
+def _same_actual_value(field_name: str, left: object, right: object) -> bool:
+    left_key = canonical_ppq_value_key(field_name, left)
+    right_key = canonical_ppq_value_key(field_name, right)
+    return bool(left_key and right_key and left_key == right_key)
+
+
+def reconcile_duplicate_field_candidates(
+    *,
+    organization_id: int,
+    operation_id: int,
+) -> DuplicateCandidateReconciliationResult:
+    """Merge corroborating candidate metadata and remove duplicate-value conflicts.
+
+    Candidate rows remain stored individually for provenance.  Only their logical
+    grouping changes: page/confidence differences cannot manufacture a contradiction.
+    A field is promoted to FOUND only when at least two rows corroborate exactly one
+    canonical value, the strongest evidence is >= 0.90, PPQ validation is valid, and
+    no genuinely different OPEN conflict remains for that same field/line.
+    """
+    org_id = int(organization_id)
+    session = get_us_lacey_db_session()
+    try:
+        set_tenant_db_context(session, org_id)
+        operation = session.scalar(
+            select(UsLaceyOperation).where(
+                UsLaceyOperation.organization_id == org_id,
+                UsLaceyOperation.id == int(operation_id),
+            )
+        )
+        if operation is None:
+            return DuplicateCandidateReconciliationResult(0, 0)
+
+        fields = session.scalars(
+            select(UsLaceyOperationField).where(
+                UsLaceyOperationField.organization_id == org_id,
+                UsLaceyOperationField.operation_id == operation.id,
+            )
+        ).all()
+        candidates = session.scalars(
+            select(UsLaceyFieldCandidate)
+            .where(
+                UsLaceyFieldCandidate.organization_id == org_id,
+                UsLaceyFieldCandidate.operation_id == operation.id,
+            )
+            .order_by(UsLaceyFieldCandidate.id.asc())
+        ).all()
+        open_issues = session.scalars(
+            select(ReconciliationIssue).where(
+                ReconciliationIssue.organization_id == org_id,
+                ReconciliationIssue.operation_reference == f"us_lacey:{operation.public_id}",
+                ReconciliationIssue.status == "OPEN",
+            )
+        ).all()
+
+        candidates_by_field: dict[int, list[UsLaceyFieldCandidate]] = {}
+        for candidate in candidates:
+            candidates_by_field.setdefault(int(candidate.operation_field_id), []).append(candidate)
+        issues_by_field: dict[int, list[ReconciliationIssue]] = {}
+        for issue in open_issues:
+            if issue.us_lacey_operation_field_id is not None:
+                issues_by_field.setdefault(int(issue.us_lacey_operation_field_id), []).append(issue)
+
+        promoted = 0
+        resolved = 0
+        for field in fields:
+            if field.reviewed_at is not None or field.human_value:
+                continue
+            rows = candidates_by_field.get(int(field.id), [])
+            if len(rows) < 2:
+                continue
+            groups = group_candidate_evidence(field.field_name, rows)
+            if len(groups) != 1:
+                # Multiple canonical values are a real decision point.  Metadata
+                # normalization must never erase that distinction.
+                continue
+
+            group = groups[0]
+            representative = group.representative
+            proposed = representative.normalized_value or representative.original_value
+            validation = validate_ppq_value(field.field_name, proposed)
+            if validation.status.value != "VALID" or not validation.normalized_value:
+                continue
+            if float(group.confidence) < 0.90:
+                continue
+
+            remaining_true_issue = False
+            for issue in issues_by_field.get(int(field.id), []):
+                if _same_actual_value(field.field_name, issue.left_value, issue.right_value):
+                    issue.status = "RESOLVED"
+                    issue.resolution_justification = (
+                        "Deterministic duplicate-value reconciliation: source metadata differed "
+                        "but both references support the same canonical field value."
+                    )
+                    issue.evidence_json = {
+                        **(issue.evidence_json or {}),
+                        "duplicate_value_reconciled": True,
+                        "canonical_value": group.canonical_value,
+                    }
+                    resolved += 1
+                else:
+                    remaining_true_issue = True
+            if remaining_true_issue:
+                continue
+
+            field.original_value = representative.original_value
+            field.normalized_value = validation.normalized_value
+            field.field_status = "FOUND"
+            field.validation_status = "VALID"
+            field.validation_error = None
+            field.confidence = float(group.confidence)
+            field.source_assurance_document_id = representative.source_assurance_document_id
+            field.source_page = representative.source_page
+            field.source_locator = representative.source_locator
+            field.extractor = representative.extractor
+            field.extractor_version = representative.extractor_version
+            promoted += 1
+
+        if promoted or resolved:
+            refresh_us_lacey_operation_status(
+                session,
+                organization_id=org_id,
+                operation=operation,
+            )
+        session.commit()
+        return DuplicateCandidateReconciliationResult(promoted, resolved)
+    except Exception:
+        session.rollback()
+        raise
+    finally:
+        session.close()

--- a/src/litoral_trace/us_lacey/candidate_reconciliation.py
+++ b/src/litoral_trace/us_lacey/candidate_reconciliation.py
@@ -1,14 +1,13 @@
 """Resolve duplicate-value U.S. Lacey review evidence deterministically.
 
-This pass is deliberately non-authoritative.  It may turn an unreviewed REVIEW
-field into FOUND when multiple evidence rows collapse to one valid canonical value,
-but it never creates MATCHED.  Human confirmation remains the only transition to a
+This pass is deliberately non-authoritative. It may turn an unreviewed REVIEW
+field into FOUND only when an OPEN conflict is proven to be metadata-only, but it
+never creates MATCHED. Human confirmation remains the only transition to a
 confirmed declaration value.
 """
 from __future__ import annotations
 
 from dataclasses import dataclass
-from uuid import UUID
 
 from sqlalchemy import select
 
@@ -42,13 +41,18 @@ def reconcile_duplicate_field_candidates(
     organization_id: int,
     operation_id: int,
 ) -> DuplicateCandidateReconciliationResult:
-    """Merge corroborating candidate metadata and remove duplicate-value conflicts.
+    """Merge corroborating candidate metadata and remove false OPEN conflicts.
 
-    Candidate rows remain stored individually for provenance.  Only their logical
+    Candidate rows remain stored individually for provenance. Only their logical
     grouping changes: page/confidence differences cannot manufacture a contradiction.
-    A field is promoted to FOUND only when at least two rows corroborate exactly one
-    canonical value, the strongest evidence is >= 0.90, PPQ validation is valid, and
-    no genuinely different OPEN conflict remains for that same field/line.
+    A field is promoted to FOUND only when it already has one or more OPEN
+    reconciliation issues, every one of those issues compares canonically identical
+    values, at least two candidate rows corroborate exactly one canonical value, the
+    strongest evidence is >= 0.90, and PPQ validation is valid.
+
+    Requiring an actual false-conflict issue is important: ordinary duplicated
+    provenance can exist on fields that are intentionally still REVIEW for another
+    reason. This pass must not silently broaden the machine-safe surface.
     """
     org_id = int(organization_id)
     session = get_us_lacey_db_session()
@@ -98,13 +102,26 @@ def reconcile_duplicate_field_candidates(
         for field in fields:
             if field.reviewed_at is not None or field.human_value:
                 continue
+
+            field_issues = issues_by_field.get(int(field.id), [])
+            if not field_issues:
+                # Duplicate provenance alone is not enough to change REVIEW -> FOUND.
+                # We only repair a conflict that the reconciliation layer explicitly
+                # created for values that are actually identical.
+                continue
+            if any(
+                not _same_actual_value(field.field_name, issue.left_value, issue.right_value)
+                for issue in field_issues
+            ):
+                # At least one OPEN issue is a genuine value contradiction.
+                continue
+
             rows = candidates_by_field.get(int(field.id), [])
             if len(rows) < 2:
                 continue
             groups = group_candidate_evidence(field.field_name, rows)
             if len(groups) != 1:
-                # Multiple canonical values are a real decision point.  Metadata
-                # normalization must never erase that distinction.
+                # Multiple canonical candidate values are a real decision point.
                 continue
 
             group = groups[0]
@@ -116,24 +133,18 @@ def reconcile_duplicate_field_candidates(
             if float(group.confidence) < 0.90:
                 continue
 
-            remaining_true_issue = False
-            for issue in issues_by_field.get(int(field.id), []):
-                if _same_actual_value(field.field_name, issue.left_value, issue.right_value):
-                    issue.status = "RESOLVED"
-                    issue.resolution_justification = (
-                        "Deterministic duplicate-value reconciliation: source metadata differed "
-                        "but both references support the same canonical field value."
-                    )
-                    issue.evidence_json = {
-                        **(issue.evidence_json or {}),
-                        "duplicate_value_reconciled": True,
-                        "canonical_value": group.canonical_value,
-                    }
-                    resolved += 1
-                else:
-                    remaining_true_issue = True
-            if remaining_true_issue:
-                continue
+            for issue in field_issues:
+                issue.status = "RESOLVED"
+                issue.resolution_justification = (
+                    "Deterministic duplicate-value reconciliation: source metadata differed "
+                    "but both references support the same canonical field value."
+                )
+                issue.evidence_json = {
+                    **(issue.evidence_json or {}),
+                    "duplicate_value_reconciled": True,
+                    "canonical_value": group.canonical_value,
+                }
+                resolved += 1
 
             field.original_value = representative.original_value
             field.normalized_value = validation.normalized_value

--- a/src/litoral_trace/us_lacey/ppq505.py
+++ b/src/litoral_trace/us_lacey/ppq505.py
@@ -12,6 +12,7 @@ from decimal import Decimal, InvalidOperation
 from enum import StrEnum
 import re
 from typing import Callable
+import unicodedata
 
 
 class PpqScope(StrEnum):
@@ -103,6 +104,8 @@ _UNIT_ALIASES = {
 }
 
 NOT_REQUIRED_REASON_CODES = frozenset({"NOT_PAPER_OR_PAPERBOARD"})
+_NUMERIC_FIELDS = frozenset({"entered_value", "plant_quantity", "percent_recycled"})
+_CURRENCY_SYMBOLS = frozenset({"$", "€", "£", "¥"})
 
 
 def _missing(value: object) -> bool:
@@ -164,11 +167,29 @@ def normalize_hts(value: object) -> PpqValidation:
     return _result(normalized)
 
 
+def _sanitize_decimal_text(value: object) -> str:
+    """Normalize customer/document numeric formatting before Decimal conversion.
+
+    Source documents and the review UI commonly carry display formatting such as
+    ``$18,600.00`` or non-breaking spaces.  Those presentation characters are not
+    part of the PPQ numeric value, so remove them before strict numeric validation.
+    Alphabetic currency codes and other unexpected text remain invalid rather than
+    being guessed away.
+    """
+    text = unicodedata.normalize("NFKC", str(value)).strip()
+    text = "".join(ch for ch in text if ch not in _CURRENCY_SYMBOLS)
+    text = re.sub(r"[\s\u00a0\u202f]+", "", text)
+    text = text.replace(",", "")
+    if not re.fullmatch(r"[+-]?(?:\d+(?:\.\d*)?|\.\d+)", text):
+        raise InvalidOperation
+    return text
+
+
 def _decimal(value: object, *, label: str, positive: bool, maximum: Decimal | None = None) -> PpqValidation:
     if missing := _required(value):
         return missing
     try:
-        number = Decimal(str(value).replace(",", "").strip())
+        number = Decimal(_sanitize_decimal_text(value))
     except (InvalidOperation, ValueError):
         return _result(None, f"{label} must be numeric.")
     if not number.is_finite() or (number <= 0 if positive else number < 0):
@@ -268,6 +289,28 @@ def validate_ppq_value(field_key: str, value: object) -> PpqValidation:
     if len(normalized) > 4000:
         return _result(None, f"{field.label} is too long.")
     return _result(normalized)
+
+
+def canonical_ppq_value_key(field_key: str, value: object) -> str:
+    """Return a comparison-only identity for candidate grouping/conflict checks.
+
+    Provenance, source page and confidence are deliberately excluded.  Values are
+    validated first so formatted numerics collapse to their numeric identity, then
+    Unicode/whitespace and casing are normalized for text comparison.  The caller
+    still keeps every original evidence row for auditability.
+    """
+    validation = validate_ppq_value(field_key, value)
+    candidate = validation.normalized_value
+    if candidate is None:
+        candidate = str(value or "").strip()
+    text = unicodedata.normalize("NFKC", str(candidate))
+    text = re.sub(r"\s+", " ", text).strip()
+    if not text:
+        return ""
+    if field_key in _NUMERIC_FIELDS:
+        # The numeric validator already provides a canonical decimal representation.
+        return text
+    return text.casefold()
 
 
 def is_paper_or_paperboard(article_or_product: object) -> bool:

--- a/src/litoral_trace/web/us_lacey_operational_views.py
+++ b/src/litoral_trace/web/us_lacey_operational_views.py
@@ -70,8 +70,16 @@ def _present_review_field(field):
     canonical value, using the highest confidence while merging page references into
     the representative page label. Thus page/confidence differences do not render as
     separate conflicting choices.
+
+    ``_review_field_sets`` is also exercised with deliberately lightweight view
+    doubles in contract tests. Candidate presentation is optional enrichment, so a
+    field without the full candidate shape must retain the legacy behavior unchanged.
     """
-    groups = group_candidate_evidence(field.field_name, field.candidates)
+    field_name = getattr(field, "field_name", None)
+    candidates = getattr(field, "candidates", ())
+    if not field_name or not candidates:
+        return field
+    groups = group_candidate_evidence(field_name, candidates)
     if not groups:
         return field
     presented = []

--- a/src/litoral_trace/web/us_lacey_operational_views.py
+++ b/src/litoral_trace/web/us_lacey_operational_views.py
@@ -2,8 +2,9 @@
 from __future__ import annotations
 
 from collections.abc import Mapping, Sequence
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 
+from litoral_trace.us_lacey.candidate_normalization import group_candidate_evidence
 from litoral_trace.web.templates import templates
 
 
@@ -62,12 +63,43 @@ def _field_has_displayable_resolution(field) -> bool:
     return value is not None and bool(str(value).strip())
 
 
+def _present_review_field(field):
+    """Collapse same-value candidate metadata for the customer review card.
+
+    Database candidate rows remain intact. The view exposes one representative per
+    canonical value, using the highest confidence while merging page references into
+    the representative page label. Thus page/confidence differences do not render as
+    separate conflicting choices.
+    """
+    groups = group_candidate_evidence(field.field_name, field.candidates)
+    if not groups:
+        return field
+    presented = []
+    for group in groups:
+        representative = group.representative
+        page_value = representative.source_page
+        if len(group.source_pages) > 1:
+            page_value = ", ".join(str(page) for page in group.source_pages)
+        elif len(group.source_pages) == 1:
+            page_value = group.source_pages[0]
+        presented.append(
+            replace(
+                representative,
+                confidence=float(group.confidence),
+                source_page=page_value,
+            )
+        )
+    return replace(field, candidates=tuple(presented))
+
+
 def _review_field_sets(detail):
     # FOUND means the pipeline has a supported proposal but no human has accepted it
     # yet. Keeping FOUND in the review queue makes the UI truthful and enables a safe
     # one-click confirmation workflow without presenting AI/extraction as final data.
     exception_fields = [
-        field for field in detail.fields if field.status in {"MISSING", "REVIEW", "FOUND"}
+        _present_review_field(field)
+        for field in detail.fields
+        if field.status in {"MISSING", "REVIEW", "FOUND"}
     ]
     settled_fields = [
         field

--- a/tests/test_us_lacey_review_ux_normalization.py
+++ b/tests/test_us_lacey_review_ux_normalization.py
@@ -1,0 +1,111 @@
+from dataclasses import dataclass
+from pathlib import Path
+
+from litoral_trace.us_lacey.candidate_normalization import group_candidate_evidence
+from litoral_trace.us_lacey.ppq505 import (
+    PpqValidationStatus,
+    canonical_ppq_value_key,
+    validate_ppq_value,
+)
+from litoral_trace.web.us_lacey_operational_views import _present_review_field
+
+
+@dataclass(frozen=True)
+class _Candidate:
+    id: int
+    original_value: str
+    normalized_value: str | None
+    validation_status: str = "VALID"
+    validation_error: str | None = None
+    confidence: float = 0.90
+    source_document_id: int = 10
+    source_page: int | None = 4
+    source_locator: str | None = None
+    decision: str = "PENDING"
+
+
+@dataclass(frozen=True)
+class _Field:
+    field_name: str
+    candidates: tuple[_Candidate, ...]
+
+
+def test_formatted_entered_value_is_sanitized_before_decimal_validation():
+    result = validate_ppq_value("entered_value", "$18,600.00")
+
+    assert result.status is PpqValidationStatus.VALID
+    assert result.normalized_value == "18600"
+    assert result.error is None
+
+
+def test_numeric_sanitizer_handles_grouping_and_unicode_spaces_without_guessing_text():
+    quantity = validate_ppq_value("plant_quantity", " 1,\u202f440.00 ")
+    malformed = validate_ppq_value("entered_value", "USD $18,600.00")
+
+    assert quantity.status is PpqValidationStatus.VALID
+    assert quantity.normalized_value == "1440"
+    assert malformed.status is PpqValidationStatus.INVALID
+    assert malformed.error == "Entered value must be numeric."
+
+
+def test_candidate_identity_ignores_case_whitespace_page_and_confidence_metadata():
+    assert canonical_ppq_value_key("species", " brasiliensis ") == canonical_ppq_value_key(
+        "species", "BRASILIENSIS"
+    )
+    assert canonical_ppq_value_key("entered_value", "$18,600.00") == canonical_ppq_value_key(
+        "entered_value", "18600"
+    )
+
+
+def test_same_species_evidence_collapses_to_one_group_and_uses_highest_confidence():
+    candidates = (
+        _Candidate(1, "brasiliensis", "brasiliensis", confidence=0.90, source_page=4),
+        _Candidate(2, "BRASILIENSIS", "BRASILIENSIS", confidence=0.98, source_page=4),
+    )
+
+    groups = group_candidate_evidence("species", candidates)
+
+    assert len(groups) == 1
+    assert groups[0].representative.id == 2
+    assert groups[0].confidence == 0.98
+    assert groups[0].source_pages == (4,)
+    assert len(groups[0].evidence) == 2
+
+
+def test_same_component_across_pages_merges_references_for_review_display():
+    field = _Field(
+        field_name="article_component",
+        candidates=(
+            _Candidate(1, "Solid rubberwood coasters", "Solid rubberwood coasters", source_page=4),
+            _Candidate(2, "solid rubberwood coasters", "solid rubberwood coasters", confidence=0.98, source_page=5),
+        ),
+    )
+
+    presented = _present_review_field(field)
+
+    assert len(presented.candidates) == 1
+    assert presented.candidates[0].id == 2
+    assert presented.candidates[0].confidence == 0.98
+    assert presented.candidates[0].source_page == "4, 5"
+
+
+def test_genuinely_different_entered_values_remain_separate_candidate_groups():
+    candidates = (
+        _Candidate(1, "$18,600.00", "18600", confidence=0.98, source_page=1),
+        _Candidate(2, "$14,880.00", "14880", confidence=0.98, source_page=5),
+    )
+
+    groups = group_candidate_evidence("entered_value", candidates)
+
+    assert len(groups) == 2
+    assert {group.canonical_value for group in groups} == {"18600", "14880"}
+
+
+def test_review_workspace_js_uses_async_post_and_explicit_viewport_restore():
+    source = Path("src/litoral_trace/static/src/js/us-lacey-workspace.js").read_text(encoding="utf-8")
+
+    assert 'document.addEventListener("submit"' in source
+    assert "fetch(form.action" in source
+    assert "event.preventDefault()" in source
+    assert "currentWorkspace.replaceWith(freshWorkspace)" in source
+    assert "restoreViewport(viewportX, viewportY)" in source


### PR DESCRIPTION
## Summary

Stabilizes the U.S. Lacey human-review workflow around the three production issues reproduced in the latest Golden packet review exports.

### 1. Preserve review position
- Progressively enhances per-field review forms with asynchronous `fetch` submission.
- Reuses the server-rendered operation workspace returned after the existing POST/303 flow and replaces it in-place without a browser navigation.
- Explicitly restores the previous viewport after the DOM swap.
- Keeps native form POST as the failure/no-JavaScript fallback; CSRF and backend review contracts are unchanged.

### 2. Accept formatted numeric evidence
- Centralizes display-format cleanup at the authoritative PPQ numeric validation boundary.
- Supports currency symbols, thousands separators, regular/NBSP/narrow spaces before strict `Decimal` parsing.
- `$18,600.00` now validates as `18600`; arbitrary alphabetic currency text is still rejected rather than guessed.

### 3. Remove metadata-only false conflicts
- Adds canonical candidate identity based on the actual validated value, excluding page/confidence metadata.
- Text identity is Unicode/whitespace normalized and case-insensitive; formatted numeric identity uses its canonical decimal value.
- Same-value evidence keeps every provenance row, chooses the strongest-confidence representative, and merges page references for display.
- A deterministic postprocessor promotes duplicate corroboration only to `FOUND` (never `MATCHED`) and resolves only OPEN issues whose left/right values are canonically identical.
- Bulk accept counts canonical candidate groups instead of raw provenance-row count.
- Distinct values such as `18600` vs `14880` remain separate and blocked for human review.
- Candidate grouping remains scoped to one `UsLaceyOperationField`, so evidence is never merged across plant/declaration lines.

## Safety invariants preserved
- Machine processing never creates `MATCHED`.
- Human confirmation remains required for final declaration values.
- Genuine contradictions remain REVIEW/OPEN.
- Existing tenant isolation, CSRF, operation locking and audit behavior are unchanged.
- No ACE/LAWGS filing or legal-compliance semantics are introduced.

## Regression coverage
Adds focused tests for:
- `$18,600.00` numeric acceptance;
- Unicode/thousands-separator cleanup;
- refusal to guess `USD $...` text;
- `brasiliensis` case/whitespace/page/confidence deduplication;
- strongest-confidence representative selection;
- multi-page component-reference merging;
- preservation of the real `$18,600` vs `$14,880` distinction;
- asynchronous review submission + viewport restoration contract.
