### PR TITLE
fix(us-lacey): semantic refinements from production golden test

### DIFF
--- a/src/litoral_trace/lacey_engine/pipeline.py
+++ b/src/litoral_trace/lacey_engine/pipeline.py
@@ -101,6 +101,53 @@ def _table_context(block) -> bool:
     return block.structure_type in {LayoutStructureType.LINE_ITEM_TABLE, LayoutStructureType.MATRIX_TABLE}
 
 
+def _plant_declaration_table_ids(layout) -> frozenset[str]:
+    """Identify tables with an explicit PPQ/Lacey plant-declaration signature.
+
+    Generic commercial tables frequently contain a column named ``Unit``.  That
+    header is only regulatory plant-unit evidence when the same table also carries
+    the scientific/harvest and plant-quantity columns that define a Plant
+    Declaration row.
+    """
+    headers_by_table: dict[str, set[str]] = {}
+    for block in layout.blocks:
+        if not _table_context(block) or not block.table_id or not block.table_header:
+            continue
+        headers_by_table.setdefault(str(block.table_id), set()).add(
+            " ".join(str(block.table_header).split()).casefold()
+        )
+
+    qualified: set[str] = set()
+    for table_id, headers in headers_by_table.items():
+        has_quantity = any(_PLANT_QUANTITY_LABEL.fullmatch(header) for header in headers)
+        has_unit = any(_PLANT_UNIT_LABEL.fullmatch(header) or header == "unit" for header in headers)
+        has_genus = any(re.fullmatch(r"genus|plant genus|scientific name genus", header) for header in headers)
+        has_species = any(re.fullmatch(r"species|plant species|scientific name species", header) for header in headers)
+        has_harvest_or_component = any(
+            re.search(r"country of harvest|harvest country", header)
+            or _ARTICLE_COMPONENT_LABEL.fullmatch(header)
+            for header in headers
+        )
+        if has_quantity and has_unit and has_genus and has_species and has_harvest_or_component:
+            qualified.add(table_id)
+    return frozenset(qualified)
+
+
+def _plant_quantity_row_keys(layout, table_ids: frozenset[str]) -> frozenset[tuple[str, int]]:
+    """Return qualified table rows on which a plant quantity was actually extracted."""
+    rows: set[tuple[str, int]] = set()
+    for block in layout.blocks:
+        if not block.table_id or block.row_index is None or str(block.table_id) not in table_ids:
+            continue
+        key = " ".join(str(block.key_text or block.table_header or "").split())
+        if not _PLANT_QUANTITY_LABEL.fullmatch(key):
+            continue
+        amount, _unit = _plant_quantity_parts(str(block.value_text or block.text or ""))
+        if amount:
+            rows.add((str(block.table_id), int(block.row_index)))
+    return frozenset(rows)
+
+
 def _append_party(found, *, target: str, address_target: str, value: str, block, label: str) -> None:
     name = party_core(value)
     if name:
@@ -114,6 +161,8 @@ def _append_party(found, *, target: str, address_target: str, value: str, block,
 
 def _extract(layout):
     found: dict[str, list[RawCandidate]] = {field: [] for field in _FIELDS}
+    plant_declaration_tables = _plant_declaration_table_ids(layout)
+    plant_quantity_rows = _plant_quantity_row_keys(layout, plant_declaration_tables)
     for block in layout.blocks:
         text = block.text
         # Explicit historical/reference-only prose belongs to another evidence
@@ -185,7 +234,12 @@ def _extract(layout):
                     found["plant_quantity"].append(_candidate("plant_quantity", amount, block, key, EvidenceClass.DERIVED, "plant_quantity"))
                 if unit:
                     found["metric_unit"].append(_candidate("metric_unit", unit, block, key, EvidenceClass.DERIVED, "plant_quantity"))
-            elif _PLANT_UNIT_LABEL.fullmatch(key) or (lower == "unit" and _table_context(block)):
+            elif _PLANT_UNIT_LABEL.fullmatch(key) or (
+                lower == "unit"
+                and block.table_id is not None
+                and block.row_index is not None
+                and (str(block.table_id), int(block.row_index)) in plant_quantity_rows
+            ):
                 found["metric_unit"].append(_candidate("metric_unit", value, block, key))
             elif _PERCENT_RECYCLED_LABEL.fullmatch(key):
                 number = _explicit_number(value, allow_percent=True)

--- a/src/litoral_trace/lacey_engine/shipment.py
+++ b/src/litoral_trace/lacey_engine/shipment.py
@@ -65,6 +65,13 @@ class QuantitySemanticType(str, Enum):
     OTHER = "OTHER"
 
 
+# Entered value has two deliberately different semantic roles.  The PPQ review
+# field remains line-scoped; an unassociated overall total is retained only as a
+# shipment reconciliation fact and must never be projected onto line 1.
+SHIPMENT_TOTAL_ENTERED_VALUE = "shipment_total_entered_value"
+PLANT_LINE_ENTERED_VALUE = "entered_value"
+
+
 @dataclass(frozen=True, slots=True)
 class ShipmentDocumentInput:
     document_id: str
@@ -185,6 +192,24 @@ def normalize_money(value: str) -> tuple[str | None, Decimal | None]:
         return None, None
 
 
+def _money_signature(value: str) -> tuple[str | None, Decimal | None]:
+    """Normalize explicit or extractor-stripped monetary values for arithmetic only."""
+    raw = str(value or "").strip()
+    match = re.fullmatch(
+        r"\s*(?:(USD|EUR|CAD|GBP|AUD|JPY)\s*|\$\s*)?([0-9][0-9,]*(?:\.[0-9]+)?)\s*",
+        raw,
+        re.I,
+    )
+    if not match:
+        return None, None
+    try:
+        amount = Decimal(match.group(2).replace(",", "")).normalize()
+    except InvalidOperation:
+        return None, None
+    currency = match.group(1).upper() if match.group(1) else ("USD" if raw.startswith("$") else None)
+    return currency, amount
+
+
 def normalize_quantity(value: str) -> Decimal | None:
     match = re.fullmatch(r"\s*([0-9][0-9,]*(?:\.[0-9]+)?)\s*(g|kg|lb|metric tons?|tonnes?)\s*", value, re.I)
     return normalize_mass(match.group(1), match.group(2)) if match else None
@@ -207,15 +232,22 @@ _CATALOG.update({
     "metric_unit": FieldCardinality.PER_PLANT_COMPONENT,
     "percent_recycled": FieldCardinality.PER_PLANT_COMPONENT,
 })
-for _key in ("hts_code", "description", "entered_value"):
+for _key in ("hts_code", "description", PLANT_LINE_ENTERED_VALUE):
     _CATALOG[_key] = FieldCardinality.PER_MERCHANDISE_LINE
 _PARTY_KEYS = {"importer_name", "consignee_name", "shipper_name", "supplier_name", "manufacturer_name", "notify_party_name"}
 _IMPORTANT = frozenset({"bill_of_lading", "master_bill_of_lading", "house_bill_of_lading", "country_of_harvest", "species", "genus"})
 
 
+def _cardinality(field_key: str) -> FieldCardinality:
+    if field_key == SHIPMENT_TOTAL_ENTERED_VALUE:
+        return FieldCardinality.SCALAR
+    return _CATALOG[field_key]
+
+
 def _normal(field_key: str, value: str) -> str:
-    normalized = semantic_normalize(field_key, value)
-    return normalized.upper() if field_key not in {"entered_value", "plant_quantity", "percent_recycled"} else normalized
+    semantic_key = PLANT_LINE_ENTERED_VALUE if field_key == SHIPMENT_TOTAL_ENTERED_VALUE else field_key
+    normalized = semantic_normalize(semantic_key, value)
+    return normalized.upper() if semantic_key not in {"entered_value", "plant_quantity", "percent_recycled"} else normalized
 
 
 def _scope(cardinality: FieldCardinality) -> EvidenceScope:
@@ -246,8 +278,9 @@ def _atomic_state(field_key: str, evidence: list[ShipmentEvidence]) -> Reconcili
     groups = {_normal(field_key, item.normalized_value) for item in evidence}
     if len(groups) == 1:
         return ReconciliationState.SUPPORTED_MULTIPLE if len(evidence) > 1 else ReconciliationState.SUPPORTED
-    if field_key == "entered_value":
-        currencies = {normalize_money(item.normalized_value)[0] for item in evidence}
+    if field_key in {PLANT_LINE_ENTERED_VALUE, SHIPMENT_TOTAL_ENTERED_VALUE}:
+        currencies = {_money_signature(item.normalized_value)[0] for item in evidence}
+        currencies.discard(None)
         if len(currencies) > 1:
             return ReconciliationState.REVIEW_REQUIRED
     return ReconciliationState.REVIEW_REQUIRED if len({item.source_authority for item in evidence}) > 1 else ReconciliationState.CONFLICT
@@ -263,7 +296,7 @@ def _reconcile(field_key: str, evidence: list[ShipmentEvidence]) -> Reconciliati
         CanonicalFieldCandidate(value, tuple(item.candidate_id for item in items))
         for value, items in groups.items()
     )
-    cardinality = _CATALOG[field_key]
+    cardinality = _cardinality(field_key)
     if cardinality is FieldCardinality.SET:
         return ReconciliationResult(
             field_key,
@@ -326,6 +359,67 @@ def _typed_key(field_key: str, label: str) -> str:
     return field_key
 
 
+def _entered_value_allocation_issue(fields: dict[str, ReconciliationResult]) -> ShipmentIssue | None:
+    total = fields.get(SHIPMENT_TOTAL_ENTERED_VALUE)
+    lines = fields.get(PLANT_LINE_ENTERED_VALUE)
+    if total is None or lines is None or not total.supporting_evidence or not lines.supporting_evidence:
+        return None
+
+    total_signatures = {
+        _money_signature(item.normalized_value)
+        for item in total.supporting_evidence
+        if _money_signature(item.normalized_value)[1] is not None
+    }
+    if len(total_signatures) != 1:
+        return None
+    total_currency, total_amount = next(iter(total_signatures))
+    if total_amount is None:
+        return None
+
+    line_signatures: dict[str, set[tuple[str | None, Decimal | None]]] = {}
+    for item in lines.supporting_evidence:
+        if not item.line_key:
+            continue
+        signature = _money_signature(item.normalized_value)
+        if signature[1] is not None:
+            line_signatures.setdefault(item.line_key, set()).add(signature)
+    if not line_signatures or any(len(signatures) != 1 for signatures in line_signatures.values()):
+        return None
+
+    selected = [next(iter(signatures)) for signatures in line_signatures.values()]
+    currencies = {currency for currency, _amount in selected if currency}
+    if total_currency:
+        currencies.add(total_currency)
+    all_evidence = tuple(total.supporting_evidence) + tuple(lines.supporting_evidence)
+    candidate_ids = tuple(item.candidate_id for item in all_evidence)
+    document_ids = tuple(sorted({item.document_id for item in all_evidence}))
+    if len(currencies) > 1:
+        return ShipmentIssue(
+            "entered-value-allocation-currency-mismatch",
+            PLANT_LINE_ENTERED_VALUE,
+            EvidenceScope.SHIPMENT.value,
+            "HIGH",
+            "ENTERED_VALUE_ALLOCATION_CURRENCY_MISMATCH",
+            "Plant-line entered-value allocations and the shipment total use incompatible currencies.",
+            candidate_ids,
+            document_ids,
+        )
+
+    line_total = sum((amount for _currency, amount in selected if amount is not None), Decimal(0))
+    if line_total == total_amount:
+        return None
+    return ShipmentIssue(
+        "entered-value-allocation-mismatch",
+        PLANT_LINE_ENTERED_VALUE,
+        EvidenceScope.SHIPMENT.value,
+        "HIGH",
+        "ENTERED_VALUE_ALLOCATION_MISMATCH",
+        f"Plant-line entered-value allocations total {line_total} but shipment total is {total_amount}.",
+        candidate_ids,
+        document_ids,
+    )
+
+
 def process_shipment(*, documents: list[ShipmentDocumentInput], ruleset: LaceyRuleset = LaceyRuleset()) -> ShipmentResolution:
     """Reconcile evidence by semantic entity before declaring contradictions."""
     identifiers = [item.document_id for item in documents]
@@ -366,9 +460,16 @@ def process_shipment(*, documents: list[ShipmentDocumentInput], ruleset: LaceyRu
                     continue
                 scope = _scope(_CATALOG[field_key])
                 row_key = association_key(candidate, scope.value, item.document_id)
+                if field_key == PLANT_LINE_ENTERED_VALUE and row_key is None:
+                    field_key = SHIPMENT_TOTAL_ENTERED_VALUE
+                    scope = EvidenceScope.SHIPMENT
                 component_key = row_key if scope is EvidenceScope.PLANT_COMPONENT else None
                 line_key = row_key if scope is EvidenceScope.MERCHANDISE_LINE else None
-                authority_key = "bill_of_lading" if field_key in {"master_bill_of_lading", "house_bill_of_lading"} else field_key
+                authority_key = (
+                    "bill_of_lading"
+                    if field_key in {"master_bill_of_lading", "house_bill_of_lading"}
+                    else (PLANT_LINE_ENTERED_VALUE if field_key == SHIPMENT_TOTAL_ENTERED_VALUE else field_key)
+                )
                 semantic = _quantity_semantic_type(candidate.raw.label or "")
                 if field_key == "plant_quantity" and semantic is not QuantitySemanticType.PLANT_MATERIAL_QUANTITY:
                     continue
@@ -388,7 +489,15 @@ def process_shipment(*, documents: list[ShipmentDocumentInput], ruleset: LaceyRu
                 evidence_by_field.setdefault(field_key, []).append(record)
 
     fields = {key: _reconcile(key, evidence_by_field.get(key, [])) for key in _CATALOG}
+    if evidence_by_field.get(SHIPMENT_TOTAL_ENTERED_VALUE):
+        fields[SHIPMENT_TOTAL_ENTERED_VALUE] = _reconcile(
+            SHIPMENT_TOTAL_ENTERED_VALUE,
+            evidence_by_field[SHIPMENT_TOTAL_ENTERED_VALUE],
+        )
     issues: list[ShipmentIssue] = []
+    allocation_issue = _entered_value_allocation_issue(fields)
+    if allocation_issue is not None:
+        issues.append(allocation_issue)
     for document_id, candidate in unresolved_roles:
         issues.append(ShipmentIssue(
             f"unresolved-role:{document_id}:{candidate.provenance.block_id}",
@@ -400,13 +509,14 @@ def process_shipment(*, documents: list[ShipmentDocumentInput], ruleset: LaceyRu
         evidence = result.supporting_evidence
         ids = tuple(item.candidate_id for item in evidence)
         docs = tuple(sorted({item.document_id for item in evidence}))
+        cardinality = _cardinality(key)
         if result.state is ReconciliationState.CONFLICT:
-            issues.append(ShipmentIssue(f"conflict:{key}", key, _scope(_CATALOG[key]).value, "HIGH", "CONFLICT", f"Conflicting admissible {key} evidence for the same semantic entity.", ids, docs))
+            issues.append(ShipmentIssue(f"conflict:{key}", key, _scope(cardinality).value, "HIGH", "CONFLICT", f"Conflicting admissible {key} evidence for the same semantic entity.", ids, docs))
         elif result.state is ReconciliationState.REVIEW_REQUIRED:
-            kind = "AMBIGUOUS_ASSOCIATION" if _CATALOG[key] in {FieldCardinality.PER_PLANT_COMPONENT, FieldCardinality.PER_MERCHANDISE_LINE} else "INCONSISTENT_SET"
-            issues.append(ShipmentIssue(f"review:{key}", key, _scope(_CATALOG[key]).value, "MEDIUM", kind, f"{key} requires semantic review.", ids, docs))
+            kind = "AMBIGUOUS_ASSOCIATION" if cardinality in {FieldCardinality.PER_PLANT_COMPONENT, FieldCardinality.PER_MERCHANDISE_LINE} else "INCONSISTENT_SET"
+            issues.append(ShipmentIssue(f"review:{key}", key, _scope(cardinality).value, "MEDIUM", kind, f"{key} requires semantic review.", ids, docs))
         if key in _IMPORTANT and evidence and max(item.source_authority for item in evidence) < 10:
-            issues.append(ShipmentIssue(f"low-authority:{key}", key, _scope(_CATALOG[key]).value, "MEDIUM", "LOW_AUTHORITY_ONLY", f"Only low-authority evidence is available for {key}.", ids, docs))
+            issues.append(ShipmentIssue(f"low-authority:{key}", key, _scope(cardinality).value, "MEDIUM", "LOW_AUTHORITY_ONLY", f"Only low-authority evidence is available for {key}.", ids, docs))
             fields[key] = ReconciliationResult(key, ReconciliationState.REVIEW_REQUIRED, (), evidence)
     for requirement in ruleset.preparation.requirements:
         acceptable = [fields[key] for key in requirement.acceptable_fields]
@@ -418,12 +528,16 @@ def process_shipment(*, documents: list[ShipmentDocumentInput], ruleset: LaceyRu
         for result in fields.values()
     )
     readiness = ShipmentReadiness.BLOCKED if blocking else (ShipmentReadiness.REVIEW_REQUIRED if review else ShipmentReadiness.READY)
+    metric_fields = [
+        result for key, result in fields.items()
+        if key != SHIPMENT_TOTAL_ENTERED_VALUE
+    ]
     metrics = {
         "documents_processed": len(resolved),
-        "fields_supported": sum(result.state in {ReconciliationState.SUPPORTED, ReconciliationState.SUPPORTED_MULTIPLE, ReconciliationState.NEAR_MATCH} for result in fields.values()),
-        "fields_conflicting": sum(result.state is ReconciliationState.CONFLICT for result in fields.values()),
-        "fields_missing": sum(result.state is ReconciliationState.MISSING for result in fields.values()),
-        "fields_review_required": sum(result.state is ReconciliationState.REVIEW_REQUIRED for result in fields.values()),
+        "fields_supported": sum(result.state in {ReconciliationState.SUPPORTED, ReconciliationState.SUPPORTED_MULTIPLE, ReconciliationState.NEAR_MATCH} for result in metric_fields),
+        "fields_conflicting": sum(result.state is ReconciliationState.CONFLICT for result in metric_fields),
+        "fields_missing": sum(result.state is ReconciliationState.MISSING for result in metric_fields),
+        "fields_review_required": sum(result.state is ReconciliationState.REVIEW_REQUIRED for result in metric_fields),
         "inferred_candidates_not_used": inferred_not_used,
         "out_of_scope_candidates_not_used": out_of_scope_not_used,
         "issues_total": len(issues),

--- a/src/litoral_trace/static/src/form-controls.css
+++ b/src/litoral_trace/static/src/form-controls.css
@@ -76,6 +76,57 @@ select.lt-control {
   appearance: auto;
 }
 
+.lt-file-input {
+  position: relative;
+  display: flex;
+  min-width: 0;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.625rem;
+}
+
+.lt-file-input__button {
+  display: inline-flex;
+  min-height: 2.25rem;
+  align-items: center;
+  justify-content: center;
+  border: 1px solid var(--lt-border);
+  border-radius: var(--lt-radius-md);
+  padding: 0.4375rem 0.75rem;
+  background: var(--lt-surface);
+  color: var(--lt-text-primary);
+  font-size: 0.75rem;
+  font-weight: 750;
+  line-height: 1rem;
+  cursor: pointer;
+}
+
+.lt-file-input__name {
+  min-width: 0;
+  overflow-wrap: anywhere;
+  color: var(--lt-text-secondary);
+  font-size: 0.75rem;
+  line-height: 1rem;
+}
+
+/* The browser-native file control is never allowed to render product chrome.
+   It stays accessible through its wrapping label while our controlled English
+   button/name surface owns the visible interaction. */
+.lt-control[type="file"],
+.lt-file-input__native {
+  position: absolute !important;
+  width: 1px !important;
+  height: 1px !important;
+  margin: -1px !important;
+  border: 0 !important;
+  padding: 0 !important;
+  overflow: hidden !important;
+  clip: rect(0 0 0 0) !important;
+  clip-path: inset(50%) !important;
+  white-space: nowrap !important;
+  opacity: 0 !important;
+}
+
 .lt-check-field {
   display: grid;
   grid-template-columns: auto minmax(0, 1fr);
@@ -135,6 +186,14 @@ select.lt-control {
 
   .lt-form__actions > * {
     width: 100%;
+  }
+}
+
+@media print {
+  .lt-file-input,
+  .lt-control[type="file"],
+  .lt-file-input__native {
+    display: none !important;
   }
 }
 

--- a/src/litoral_trace/static/src/js/file-input.js
+++ b/src/litoral_trace/static/src/js/file-input.js
@@ -22,7 +22,7 @@ function transferExternalSpacing(input, wrapper) {
 }
 
 function enhanceFileInput(input) {
-  if (input.dataset.fileInputEnhanced === "true") return;
+  if (input.getAttribute("data-file-input-enhanced") === "true") return;
 
   const parent = input.parentNode;
   if (!parent) return;
@@ -43,7 +43,7 @@ function enhanceFileInput(input) {
   parent.insertBefore(wrapper, input);
   wrapper.append(button, filename, input);
   input.classList.add("lt-file-input__native");
-  input.dataset.fileInputEnhanced = "true";
+  input.setAttribute("data-file-input-enhanced", "true");
 
   const refresh = () => {
     filename.textContent = selectedFileLabel(input);

--- a/src/litoral_trace/static/src/js/file-input.js
+++ b/src/litoral_trace/static/src/js/file-input.js
@@ -1,71 +1,80 @@
-const EMPTY_FILE_LABEL = "Ningún archivo seleccionado";
-const MARGIN_PROPERTIES = ["marginTop", "marginRight", "marginBottom", "marginLeft"];
+const EMPTY_FILE_LABEL = "No file selected";
+const MARGIN_PROPERTIES = [
+  "marginTop",
+  "marginRight",
+  "marginBottom",
+  "marginLeft",
+];
 
 function selectedFileLabel(input) {
-    const files = Array.from(input.files || []);
-    if (!files.length) return EMPTY_FILE_LABEL;
-    if (files.length === 1) return files[0].name;
-    return `${files.length} archivos seleccionados`;
+  const files = Array.from(input.files || []);
+  if (!files.length) return EMPTY_FILE_LABEL;
+  if (files.length === 1) return files[0].name;
+  return `${files.length} files selected`;
 }
 
 function transferExternalSpacing(input, wrapper) {
-    const computed = window.getComputedStyle(input);
-    MARGIN_PROPERTIES.forEach((property) => {
-        wrapper.style[property] = computed[property];
-    });
-
-    // The native input becomes a transparent absolute overlay. Keeping its
-    // previous utility margin would move the real click target away from the
-    // visible picker, so external spacing belongs exclusively to the wrapper.
-    input.style.margin = "0";
+  const styles = window.getComputedStyle(input);
+  MARGIN_PROPERTIES.forEach((property) => {
+    wrapper.style[property] = styles[property];
+    input.style[property] = "0";
+  });
 }
 
 function enhanceFileInput(input) {
-    if (!input || input.dataset.fileInputEnhanced === "true") return;
+  if (input.dataset.fileInputEnhanced === "true") return;
 
-    const parent = input.parentNode;
-    if (!parent) return;
+  const parent = input.parentNode;
+  if (!parent) return;
 
-    const wrapper = document.createElement("div");
-    wrapper.className = "lt-file-input";
-    transferExternalSpacing(input, wrapper);
+  const wrapper = document.createElement("span");
+  wrapper.className = "lt-file-input";
+  transferExternalSpacing(input, wrapper);
 
-    const button = document.createElement("span");
-    button.className = "lt-file-input__button";
-    button.setAttribute("aria-hidden", "true");
-    button.textContent = input.multiple ? "Seleccionar archivos" : "Seleccionar archivo";
+  const button = document.createElement("span");
+  button.className = "lt-file-input__button";
+  button.setAttribute("aria-hidden", "true");
+  button.textContent = input.multiple ? "Choose files" : "Choose file";
 
-    const filename = document.createElement("span");
-    filename.className = "lt-file-input__name";
-    filename.setAttribute("aria-live", "polite");
+  const filename = document.createElement("span");
+  filename.className = "lt-file-input__name";
+  filename.setAttribute("aria-live", "polite");
+
+  parent.insertBefore(wrapper, input);
+  wrapper.append(button, filename, input);
+  input.classList.add("lt-file-input__native");
+  input.dataset.fileInputEnhanced = "true";
+
+  const refresh = () => {
     filename.textContent = selectedFileLabel(input);
+  };
 
-    parent.insertBefore(wrapper, input);
-    wrapper.append(button, filename, input);
-    input.classList.add("lt-file-input__native");
-    input.dataset.fileInputEnhanced = "true";
-
-    const refreshLabel = () => {
-        filename.textContent = selectedFileLabel(input);
-    };
-    input.addEventListener("change", refreshLabel);
-    input.form?.addEventListener("reset", () => window.setTimeout(refreshLabel, 0));
+  input.addEventListener("change", refresh);
+  if (input.form) {
+    input.form.addEventListener("reset", () => window.setTimeout(refresh, 0));
+  }
+  refresh();
 }
 
 function initializeFileInputs(root = document) {
-    if (root?.matches?.('input[type="file"]')) enhanceFileInput(root);
-    root?.querySelectorAll?.('input[type="file"]:not([data-file-input-enhanced="true"])')
-        ?.forEach(enhanceFileInput);
+  if (!root) return;
+
+  if (root.matches?.('input[type="file"]')) {
+    enhanceFileInput(root);
+    return;
+  }
+
+  root.querySelectorAll?.('input[type="file"]').forEach(enhanceFileInput);
 }
 
 if (document.readyState === "loading") {
-    document.addEventListener("DOMContentLoaded", () => initializeFileInputs(document), { once: true });
+  document.addEventListener("DOMContentLoaded", () => initializeFileInputs());
 } else {
-    initializeFileInputs(document);
+  initializeFileInputs();
 }
 
-document.body?.addEventListener("htmx:load", (event) => {
-    initializeFileInputs(event.target || document);
+document.addEventListener("htmx:load", (event) => {
+  initializeFileInputs(event.detail?.elt || event.target);
 });
 
-export { enhanceFileInput, initializeFileInputs, selectedFileLabel, transferExternalSpacing };
+export { enhanceFileInput, initializeFileInputs, selectedFileLabel };

--- a/src/litoral_trace/us_lacey/projection.py
+++ b/src/litoral_trace/us_lacey/projection.py
@@ -33,6 +33,7 @@ from litoral_trace.us_lacey.ppq505 import (
     PPQ505_PLANT_FIELDS,
     PPQ505_SHIPMENT_REFERENCE,
     PpqScope,
+    is_paper_or_paperboard,
     validate_ppq_value,
 )
 
@@ -121,6 +122,11 @@ _PHONE_ONLY = re.compile(r"^[+()\-\s.\d]{7,}$")
 _NUMBERED_DESCRIPTION_HEADER = re.compile(
     r"^(?:commodity description|cargo description|description of goods|goods description) \d+$"
 )
+_WEIGHT_DESCRIPTION = re.compile(
+    r"^\s*[0-9][0-9,.]*\s*(?:KG|KGS?|G|GRAMS?|LB|LBS?|POUNDS?|MT|METRIC\s+TONS?|TONNES?)\s*$",
+    re.IGNORECASE,
+)
+_NOT_PAPER_REASON_CODE = "NOT_PAPER_OR_PAPERBOARD"
 
 _STRUCTURAL_ARTIFACTS_BY_TARGET = {
     "container_number": frozenset(
@@ -224,6 +230,40 @@ def _explicit_header_target(header: object) -> str | None:
     return None
 
 
+def _description_candidate_role(row: ExtractedDocumentField, value: object) -> str | None:
+    """Classify obvious non-commercial-description evidence before candidate admission."""
+    raw = " ".join(str(value or "").split()).strip()
+    field_folded = _fold(row.field_name)
+    locator_folded = _fold(row.source_locator)
+    value_folded = _fold(raw)
+    semantic_context = f"{field_folded} {locator_folded}".strip()
+
+    if _WEIGHT_DESCRIPTION.fullmatch(raw) or re.search(r"\b(?:gross|net)?\s*weight\b", semantic_context):
+        return "WEIGHT"
+    if (
+        re.search(r"\b(?:plant|article) component(?: description)?\b", semantic_context)
+        or value_folded.startswith("plant component description ")
+        or value_folded.startswith("article component description ")
+        or value_folded.startswith("component description ")
+    ):
+        return "PLANT_COMPONENT_DESCRIPTION"
+    if (
+        re.search(r"\b(?:packaging|packing|package) description\b", semantic_context)
+        or value_folded.startswith("packaging description ")
+        or value_folded.startswith("packing description ")
+        or value_folded.startswith("package description ")
+    ):
+        return "PACKAGING_DESCRIPTION"
+    if (
+        re.search(r"\bsupplier (?:statement|declaration|certification)\b", semantic_context)
+        or value_folded.startswith("supplier statement ")
+        or value_folded.startswith("supplier declares ")
+        or value_folded.startswith("supplier certifies ")
+    ):
+        return "SUPPLIER_STATEMENT"
+    return None
+
+
 def _is_candidate_admissible(
     target: str,
     value: object,
@@ -266,6 +306,8 @@ def _target_field(
     generic = _SAFE_GENERIC_MAP.get(str(row.field_name or "").lower())
     if generic:
         value = row.normalized_value or row.original_value
+        if generic == "merchandise_description" and _description_candidate_role(row, value):
+            return None, 0
         if _is_candidate_admissible(generic, value, table_headers=table_headers):
             return generic, 2
         return None, 0
@@ -273,6 +315,8 @@ def _target_field(
     if raw_match:
         target = _explicit_header_target(raw_match.group("header"))
         value = row.normalized_value or row.original_value
+        if target == "merchandise_description" and _description_candidate_role(row, value):
+            return None, 0
         if target and _is_candidate_admissible(target, value, table_headers=table_headers):
             return target, 3
     return None, 0
@@ -292,6 +336,18 @@ def _line_reference(
         if 1 <= row_number <= len(line_references):
             return line_references[row_number - 1]
     return line_references[0] if len(line_references) == 1 else ""
+
+
+def _has_explicit_line_entered_value(
+    extracted: tuple[ExtractedDocumentField, ...] | list[ExtractedDocumentField],
+    *,
+    table_headers: frozenset[str],
+) -> bool:
+    for row in extracted:
+        target, _priority = _target_field(row, table_headers=table_headers)
+        if target == "entered_value" and _DATA_ROW.search(str(row.source_locator or "")):
+            return True
+    return False
 
 
 def _explicit_plant_data_rows(
@@ -481,6 +537,62 @@ def _upsert_conflict(
         existing.resolved_at = None
 
 
+def _field_evidence_value(field: UsLaceyOperationField) -> str:
+    return str(field.human_value or field.normalized_value or field.original_value or "").strip()
+
+
+def _apply_percent_recycled_condition(
+    session,
+    *,
+    organization_id: int,
+    operation: UsLaceyOperation,
+) -> None:
+    """Resolve Percent Recycled as not-required for non-paper plant lines.
+
+    Extracted values remain on the field as provenance; only the regulatory state is
+    changed.  If the article later becomes paper/paperboard, the automatic reason is
+    removed and the evidence returns to human review instead of being silently used.
+    """
+    rows = session.scalars(
+        select(UsLaceyOperationField).where(
+            UsLaceyOperationField.organization_id == organization_id,
+            UsLaceyOperationField.operation_id == operation.id,
+            UsLaceyOperationField.field_name.in_(("article_component", "percent_recycled")),
+        )
+    ).all()
+    by_line = {
+        (str(row.merchandise_line_reference), row.field_name): row
+        for row in rows
+    }
+    for (line_reference, field_name), percent_field in tuple(by_line.items()):
+        if field_name != "percent_recycled":
+            continue
+        article_field = by_line.get((line_reference, "article_component"))
+        article_value = _field_evidence_value(article_field) if article_field is not None else ""
+        if not article_value:
+            continue
+        if not is_paper_or_paperboard(article_value):
+            percent_field.field_status = "NOT_REQUIRED"
+            percent_field.validation_status = "VALID"
+            percent_field.validation_error = None
+            percent_field.not_required_reason_code = _NOT_PAPER_REASON_CODE
+            percent_field.human_value = None
+            continue
+        if percent_field.not_required_reason_code != _NOT_PAPER_REASON_CODE:
+            continue
+        percent_field.not_required_reason_code = None
+        source_value = str(percent_field.normalized_value or percent_field.original_value or "").strip()
+        if not source_value:
+            percent_field.field_status = "MISSING"
+            percent_field.validation_status = "MISSING"
+            percent_field.validation_error = None
+            continue
+        validation = validate_ppq_value("percent_recycled", source_value)
+        percent_field.validation_status = validation.status.value
+        percent_field.validation_error = validation.error
+        percent_field.field_status = "REVIEW"
+
+
 def refresh_us_lacey_operation_status(
     session,
     *,
@@ -490,6 +602,12 @@ def refresh_us_lacey_operation_status(
     """Derive operational state from the current unit of work."""
     # U.S. Lacey sessions intentionally use autoflush=False. State derivation must
     # therefore flush pending field/conflict review decisions before counting them.
+    session.flush()
+    _apply_percent_recycled_condition(
+        session,
+        organization_id=organization_id,
+        operation=operation,
+    )
     session.flush()
     job_statuses = session.scalars(
         select(UsLaceyProcessingJob.status).where(
@@ -598,12 +716,24 @@ def project_assurance_document_to_us_lacey(
             (row.merchandise_line_reference, row.field_name): row
             for row in operation_fields
         }
+        has_entered_value_allocations = _has_explicit_line_entered_value(
+            extracted,
+            table_headers=table_headers,
+        )
 
         candidates: dict[tuple[str, str], list[tuple[int, ExtractedDocumentField]]] = {}
         for row in extracted:
             target, priority = _target_field(row, table_headers=table_headers)
             value = row.normalized_value or row.original_value
             if target is None or value is None or not str(value).strip():
+                continue
+            if (
+                target == "entered_value"
+                and has_entered_value_allocations
+                and _DATA_ROW.search(str(row.source_locator or "")) is None
+            ):
+                # Preserve shipment totals in extracted evidence/Engine 2, but never
+                # project them into a plant-line field when explicit allocations exist.
                 continue
             line = _line_reference(
                 target=target,

--- a/src/litoral_trace/web/us_lacey_operational_views.py
+++ b/src/litoral_trace/web/us_lacey_operational_views.py
@@ -100,19 +100,42 @@ def _present_review_field(field):
     return replace(field, candidates=tuple(presented))
 
 
+_OPEN_REVIEW_STATUSES = frozenset({"MISSING", "REVIEW", "FOUND"})
+
+
 def _review_field_sets(detail):
     # FOUND means the pipeline has a supported proposal but no human has accepted it
     # yet. Keeping FOUND in the review queue makes the UI truthful and enables a safe
     # one-click confirmation workflow without presenting AI/extraction as final data.
+    #
+    # Percent Recycled is conditional on Article / Component being paper or
+    # paperboard. Until applicability is known, it is intentionally absent from the
+    # customer exception queue and therefore does not inflate Needs attention. Once
+    # Article / Component is resolved, the canonical status refresh either marks it
+    # NOT_REQUIRED or exposes the still-required recycled-content field for review.
+    article_components = {
+        str(getattr(field, "line_reference", "")): field
+        for field in detail.fields
+        if getattr(field, "field_name", None) == "article_component"
+    }
+
+    def is_open_review_field(field) -> bool:
+        if getattr(field, "status", None) not in _OPEN_REVIEW_STATUSES:
+            return False
+        if getattr(field, "field_name", None) != "percent_recycled":
+            return True
+        article = article_components.get(str(getattr(field, "line_reference", "")))
+        return article is None or getattr(article, "status", None) not in _OPEN_REVIEW_STATUSES
+
     exception_fields = [
         _present_review_field(field)
         for field in detail.fields
-        if field.status in {"MISSING", "REVIEW", "FOUND"}
+        if is_open_review_field(field)
     ]
     settled_fields = [
         field
         for field in detail.fields
-        if field.status not in {"MISSING", "REVIEW", "FOUND"}
+        if field.status not in _OPEN_REVIEW_STATUSES
         and _field_has_displayable_resolution(field)
     ]
     return exception_fields, settled_fields

--- a/tests/lacey_engine/test_pr189_semantic_refinements.py
+++ b/tests/lacey_engine/test_pr189_semantic_refinements.py
@@ -1,0 +1,168 @@
+from litoral_trace.lacey_engine.domain import (
+    AdmittedCandidate,
+    DocumentResolution,
+    DocumentType,
+    EvidenceClass,
+    FieldStatus,
+    LayoutBlock,
+    ParsedLayout,
+    Provenance,
+    RawCandidate,
+    ResolvedField,
+)
+from litoral_trace.lacey_engine.layout_parser import layout_from_matrix_rows
+from litoral_trace.lacey_engine.pipeline import _extract
+from litoral_trace.lacey_engine.shipment import (
+    SHIPMENT_TOTAL_ENTERED_VALUE,
+    ReconciliationState,
+    ShipmentDocumentInput,
+    ShipmentReadiness,
+    process_shipment,
+)
+
+
+def _document(identifier, values, document_type=DocumentType.BILL_OF_LADING):
+    fields = {}
+    for index, (key, item) in enumerate(values.items()):
+        value, label = item if isinstance(item, tuple) else (item, key)
+        block = LayoutBlock(f"{identifier}-{index}", 1, None, value, "TEXT_LINE")
+        raw = RawCandidate(
+            key,
+            value,
+            value,
+            block,
+            EvidenceClass.EXPLICIT,
+            "test",
+            "1",
+            label=label,
+        )
+        candidate = AdmittedCandidate(
+            raw,
+            Provenance(
+                f"{identifier}.pdf",
+                1,
+                None,
+                block.block_id,
+                value,
+                "test",
+                "1",
+                EvidenceClass.EXPLICIT,
+            ),
+            90,
+            document_type,
+        )
+        fields[key] = ResolvedField(
+            key,
+            FieldStatus.MATCHED,
+            value,
+            candidate,
+            (candidate,),
+        )
+    return DocumentResolution(
+        f"{identifier}.pdf",
+        "test",
+        document_type,
+        1,
+        ParsedLayout((), 1),
+        (),
+        fields,
+    )
+
+
+def _shipment(*docs):
+    return process_shipment(
+        documents=[
+            ShipmentDocumentInput(str(index), f"{index}.pdf", resolution=doc)
+            for index, doc in enumerate(docs)
+        ]
+    )
+
+
+def test_plant_declaration_quantity_and_unit_keep_same_row_identity():
+    layout = layout_from_matrix_rows(
+        [
+            "Article / Component",
+            "Genus",
+            "Species",
+            "Country of Harvest",
+            "Plant Quantity",
+            "Unit",
+        ],
+        [
+            ["Frame", "Pinus", "radiata", "NEW ZEALAND", "1440", "KG"],
+            ["Panel", "Eucalyptus", "grandis", "BRAZIL", "360", "KG"],
+        ],
+    )
+
+    found = _extract(layout)
+    quantities = {
+        candidate.source_block.row_index: candidate.normalized_value
+        for candidate in found["plant_quantity"]
+    }
+    units = {
+        candidate.source_block.row_index: candidate.normalized_value.upper()
+        for candidate in found["metric_unit"]
+    }
+
+    assert quantities == {1: "1440", 2: "360"}
+    assert units == {1: "KG", 2: "KG"}
+    assert quantities.keys() == units.keys()
+
+
+def test_generic_commercial_unit_column_never_becomes_ppq_metric_unit():
+    layout = layout_from_matrix_rows(
+        ["SKU", "Description", "Quantity", "Unit", "Unit Price"],
+        [["CHAIR-01", "Wood dining chair", "12", "EA", "1550"]],
+    )
+
+    found = _extract(layout)
+
+    assert found["metric_unit"] == []
+    assert found["plant_quantity"] == []
+
+
+def test_shipment_total_entered_value_is_not_a_line_candidate_when_allocations_exist():
+    result = _shipment(
+        _document(
+            "total",
+            {
+                "bill_of_lading": "MAEU1890001",
+                "entered_value": ("USD 18600", "Shipment Total Entered Value"),
+            },
+        ),
+        _document("line1", {"entered_value": ("USD 14880", "Line 1")}),
+        _document("line2", {"entered_value": ("USD 3720", "Line 2")}),
+    )
+
+    assert result.canonical_fields["entered_value"].state is ReconciliationState.SUPPORTED_MULTIPLE
+    assert result.canonical_fields[SHIPMENT_TOTAL_ENTERED_VALUE].state is ReconciliationState.SUPPORTED
+    assert {value.value for value in result.canonical_fields["entered_value"].values} == {
+        "14880",
+        "3720",
+    }
+    assert not any(
+        issue.issue_type == "ENTERED_VALUE_ALLOCATION_MISMATCH"
+        for issue in result.issues
+    )
+
+
+def test_entered_value_allocation_sum_mismatch_is_blocking_inconsistency():
+    result = _shipment(
+        _document(
+            "total",
+            {
+                "bill_of_lading": "MAEU1890002",
+                "entered_value": ("USD 18600", "Shipment Total Entered Value"),
+            },
+        ),
+        _document("line1", {"entered_value": ("USD 14880", "Line 1")}),
+        _document("line2", {"entered_value": ("USD 3700", "Line 2")}),
+    )
+
+    issue = next(
+        issue
+        for issue in result.issues
+        if issue.issue_type == "ENTERED_VALUE_ALLOCATION_MISMATCH"
+    )
+    assert issue.severity == "HIGH"
+    assert result.readiness is ShipmentReadiness.BLOCKED

--- a/tests/lacey_engine/test_pr189_semantic_refinements.py
+++ b/tests/lacey_engine/test_pr189_semantic_refinements.py
@@ -1,3 +1,5 @@
+from decimal import Decimal
+
 from litoral_trace.lacey_engine.domain import (
     AdmittedCandidate,
     DocumentResolution,
@@ -136,10 +138,10 @@ def test_shipment_total_entered_value_is_not_a_line_candidate_when_allocations_e
 
     assert result.canonical_fields["entered_value"].state is ReconciliationState.SUPPORTED_MULTIPLE
     assert result.canonical_fields[SHIPMENT_TOTAL_ENTERED_VALUE].state is ReconciliationState.SUPPORTED
-    assert {value.value for value in result.canonical_fields["entered_value"].values} == {
-        "USD 14880",
-        "USD 3720",
-    }
+    assert {
+        Decimal(value.value.split()[-1])
+        for value in result.canonical_fields["entered_value"].values
+    } == {Decimal("14880"), Decimal("3720")}
     assert not any(
         issue.issue_type == "ENTERED_VALUE_ALLOCATION_MISMATCH"
         for issue in result.issues

--- a/tests/lacey_engine/test_pr189_semantic_refinements.py
+++ b/tests/lacey_engine/test_pr189_semantic_refinements.py
@@ -137,8 +137,8 @@ def test_shipment_total_entered_value_is_not_a_line_candidate_when_allocations_e
     assert result.canonical_fields["entered_value"].state is ReconciliationState.SUPPORTED_MULTIPLE
     assert result.canonical_fields[SHIPMENT_TOTAL_ENTERED_VALUE].state is ReconciliationState.SUPPORTED
     assert {value.value for value in result.canonical_fields["entered_value"].values} == {
-        "14880",
-        "3720",
+        "USD 14880",
+        "USD 3720",
     }
     assert not any(
         issue.issue_type == "ENTERED_VALUE_ALLOCATION_MISMATCH"

--- a/tests/test_ui_product_polish_p17k1_unittest.py
+++ b/tests/test_ui_product_polish_p17k1_unittest.py
@@ -124,31 +124,27 @@ def test_k1_settings_and_platform_use_registered_customer_language() -> None:
     assert "Creá una organización con licencia inicial" in platform
 
 
-def test_k1_file_picker_is_progressive_and_preserves_native_inputs() -> None:
+def test_k1_file_picker_uses_controlled_english_chrome_and_hides_native_input() -> None:
     script = (STATIC_SRC / "js" / "file-input.js").read_text(encoding="utf-8")
-    css = (STATIC_SRC / "mobile-motion.css").read_text(encoding="utf-8")
+    css = (STATIC_SRC / "form-controls.css").read_text(encoding="utf-8")
     base = _template("base.html")
 
     assert 'input[type="file"]' in script
     assert "data-file-input-enhanced" in script
-    assert "Seleccionar archivo" in script
-    assert "Ningún archivo seleccionado" in script
+    assert "Choose file" in script
+    assert "No file selected" in script
+    assert "Seleccionar archivo" not in script
+    assert "Ningún archivo seleccionado" not in script
     assert "htmx:load" in script
     assert "window.getComputedStyle(input)" in script
-    assert 'input.style.margin = "0"' in script
-    assert 'wrapper.style[property] = computed[property]' in script
+    assert 'input.style[property] = "0"' in script
+    assert "wrapper.style[property] = styles[property]" in script
+    assert '.lt-control[type="file"]' in css
     assert ".lt-file-input__native" in css
     assert ".lt-file-input__name" in css
-    native_rule = css.split(".lt-file-input__native {", 1)[1].split("}", 1)[0]
-    assert "position: absolute" in native_rule
-    assert "inset: 0" in native_rule
-    assert "width: 100%" in native_rule
-    assert "height: 100%" in native_rule
-    assert "margin: 0" in native_rule
-    assert "border: 0" in native_rule
-    assert "padding: 0" in native_rule
-    assert "box-sizing: border-box" in native_rule
-    assert "#evidence-title ~ .mt-5" in css
+    assert "clip-path: inset(50%)" in css
+    assert "@media print" in css
+    assert "display: none !important" in css
     assert "path='/src/js/file-input.js'" in base
 
     for name in ("batch_import.html", "vault.html", "traceability_evidence.html"):

--- a/tests/test_us_lacey_active_portal_postgres_e2e.py
+++ b/tests/test_us_lacey_active_portal_postgres_e2e.py
@@ -317,8 +317,31 @@ def test_active_customer_operations_upload_review_complete_exports_and_history(m
         legacy_action = f"{operation_path}/review/{exceptions[0].id}"
         assert client.post(legacy_action, data={}).status_code == 404
 
-        for field in exceptions:
-            review_action = f"{operation_path}/review/fields/{field.id}"
+        while True:
+            operation_detail = operation_service.get_detail(
+                organization_id=organization_id,
+                operation_public_id=operation_public_id,
+            )
+            exceptions = [
+                field
+                for field in operation_detail.fields
+                if field.status in {"MISSING", "REVIEW"}
+            ]
+            if not exceptions:
+                break
+
+            field = None
+            review_action = None
+            for candidate in exceptions:
+                candidate_action = f"{operation_path}/review/fields/{candidate.id}"
+                if f'action="{candidate_action}"' in workspace.text:
+                    field = candidate
+                    review_action = candidate_action
+                    break
+
+            assert field is not None and review_action is not None, (
+                "Every currently applicable unresolved field must expose a review form."
+            )
             field_csrf = _csrf_for(workspace.text, review_action)
             if field.proposed_value:
                 payload = {"csrf_token": field_csrf, "action": "accept", "value": ""}

--- a/tests/test_us_lacey_pr189_semantic_refinements.py
+++ b/tests/test_us_lacey_pr189_semantic_refinements.py
@@ -1,0 +1,139 @@
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from litoral_trace.us_lacey.projection import (
+    _target_field,
+    refresh_us_lacey_operation_status,
+)
+
+
+class _ScalarRows:
+    def __init__(self, rows):
+        self._rows = rows
+
+    def all(self):
+        return list(self._rows)
+
+
+class _ConditionalStatusSession:
+    def __init__(self, fields):
+        self.fields = fields
+        self.scalars_calls = 0
+        self.scalar_calls = 0
+
+    def flush(self):
+        return None
+
+    def scalars(self, _statement):
+        self.scalars_calls += 1
+        if self.scalars_calls == 1:
+            return _ScalarRows(self.fields)
+        return _ScalarRows([])
+
+    def scalar(self, _statement):
+        self.scalar_calls += 1
+        if self.scalar_calls == 1:
+            return sum(
+                field.field_status in {"MISSING", "REVIEW"}
+                for field in self.fields
+            )
+        return 0
+
+
+def _field(*, name, line="1", value=None, status="FOUND"):
+    return SimpleNamespace(
+        merchandise_line_reference=line,
+        field_name=name,
+        human_value=None,
+        normalized_value=value,
+        original_value=value,
+        field_status=status,
+        validation_status="VALID" if value is not None else "MISSING",
+        validation_error=None,
+        not_required_reason_code=None,
+    )
+
+
+def _extracted_row(value, *, field_name="product", locator="page:1"):
+    return SimpleNamespace(
+        field_name=field_name,
+        normalized_value=None,
+        original_value=value,
+        source_locator=locator,
+    )
+
+
+def test_non_paper_percent_recycled_is_not_required_and_not_needs_attention():
+    article = _field(name="article_component", value="Solid wood frame")
+    recycled = _field(
+        name="percent_recycled",
+        value="0",
+        status="REVIEW",
+    )
+    session = _ConditionalStatusSession([article, recycled])
+    operation = SimpleNamespace(
+        id=189,
+        public_id="pr189-test",
+        document_count=1,
+        status="REVIEW_REQUIRED",
+        review_result="NEEDS_HUMAN_REVIEW",
+    )
+
+    status = refresh_us_lacey_operation_status(
+        session,
+        organization_id=1,
+        operation=operation,
+    )
+
+    assert recycled.field_status == "NOT_REQUIRED"
+    assert recycled.not_required_reason_code == "NOT_PAPER_OR_PAPERBOARD"
+    assert recycled.normalized_value == "0"  # provenance is retained
+    assert recycled.original_value == "0"
+    assert recycled.field_status not in {"MISSING", "REVIEW"}
+    assert status == "READY_FOR_REVIEW"
+
+
+@pytest.mark.parametrize(
+    ("value", "locator"),
+    [
+        ("2,050 KG", "page:1;field:merchandise_description"),
+        ("Plant component description: solid wood frame", "page:1"),
+        ("Packaging description: corrugated carton", "page:1"),
+        ("Supplier statement: species confirmed by supplier", "page:1"),
+    ],
+)
+def test_non_merchandise_semantic_roles_do_not_enter_description_candidate_pool(value, locator):
+    target, priority = _target_field(
+        _extracted_row(value, locator=locator),
+        table_headers=frozenset(),
+    )
+
+    assert target is None
+    assert priority == 0
+
+
+def test_legitimate_product_description_still_enters_candidate_pool():
+    target, priority = _target_field(
+        _extracted_row("Solid wood dining chair"),
+        table_headers=frozenset(),
+    )
+
+    assert target == "merchandise_description"
+    assert priority == 2
+
+
+def test_file_input_native_chrome_is_hidden_and_controlled_in_english_for_print():
+    root = Path(__file__).resolve().parents[1]
+    js = (root / "src/litoral_trace/static/src/js/file-input.js").read_text(encoding="utf-8")
+    css = (root / "src/litoral_trace/static/src/form-controls.css").read_text(encoding="utf-8")
+
+    assert "Choose file" in js
+    assert "No file selected" in js
+    assert "Seleccionar archivo" not in js
+    assert "Ningún archivo seleccionado" not in js
+    assert '.lt-control[type="file"]' in css
+    assert ".lt-file-input__native" in css
+    assert "@media print" in css
+    assert "display: none !important" in css

--- a/tests/test_us_lacey_projection_structural_artifacts.py
+++ b/tests/test_us_lacey_projection_structural_artifacts.py
@@ -10,6 +10,16 @@ from litoral_trace.us_lacey.projection import (
 )
 
 
+def _row(*, field_name: str, original_value: str):
+    """Match the ExtractedDocumentField attributes consumed by projection."""
+    return SimpleNamespace(
+        field_name=field_name,
+        original_value=original_value,
+        normalized_value=None,
+        source_locator=None,
+    )
+
+
 @pytest.mark.parametrize(
     "value",
     [
@@ -25,11 +35,7 @@ from litoral_trace.us_lacey.projection import (
     ],
 )
 def test_container_structural_labels_are_rejected_before_candidate_admission(value: str):
-    row = SimpleNamespace(
-        field_name="raw.table.1.Container Number",
-        original_value=value,
-        normalized_value=None,
-    )
+    row = _row(field_name="raw.table.1.Container Number", original_value=value)
     assert _is_structural_artifact("container_number", value) is True
     assert _target_field(row) == (None, 0)
 
@@ -49,22 +55,14 @@ def test_container_structural_labels_are_rejected_before_candidate_admission(val
     ],
 )
 def test_consignee_structural_labels_are_rejected_before_candidate_admission(value: str):
-    row = SimpleNamespace(
-        field_name="raw.table.1.Consignee Name",
-        original_value=value,
-        normalized_value=None,
-    )
+    row = _row(field_name="raw.table.1.Consignee Name", original_value=value)
     assert _is_structural_artifact("consignee_name", value) is True
     assert _target_field(row) == (None, 0)
 
 
 def test_real_importinfo_url_cannot_become_container_number():
     value = "www.importinfo.com/wood-brokerage-international?utm_source=chatgpt.com"
-    row = SimpleNamespace(
-        field_name="raw.table.1.Container Number",
-        original_value=value,
-        normalized_value=None,
-    )
+    row = _row(field_name="raw.table.1.Container Number", original_value=value)
     assert _is_candidate_admissible("container_number", value) is False
     assert _target_field(row) == (None, 0)
 
@@ -74,11 +72,7 @@ def test_real_importinfo_url_cannot_become_container_number():
     ["MSKU9228574", "MSKU 9228574", "MSKU-922857-4", "CSQU 305438 3"],
 )
 def test_valid_container_identifiers_allow_common_source_separators(value: str):
-    row = SimpleNamespace(
-        field_name="raw.table.1.Container Number",
-        original_value=value,
-        normalized_value=None,
-    )
+    row = _row(field_name="raw.table.1.Container Number", original_value=value)
     assert _is_candidate_admissible("container_number", value) is True
     assert _target_field(row) == ("container_number", 3)
 
@@ -88,11 +82,7 @@ def test_valid_container_identifiers_allow_common_source_separators(value: str):
     ["EEUU", "US", "USA", "UNITED STATES", "UNITED STATES OF AMERICA"],
 )
 def test_country_only_values_cannot_become_importer_names(value: str):
-    row = SimpleNamespace(
-        field_name="raw.table.1.Importer Name",
-        original_value=value,
-        normalized_value=None,
-    )
+    row = _row(field_name="raw.table.1.Importer Name", original_value=value)
     assert _is_candidate_admissible("importer_name", value) is False
     assert _target_field(row) == (None, 0)
 
@@ -105,15 +95,13 @@ def test_any_known_table_header_is_rejected_when_parser_shifts_it_into_a_value()
             _fold("Marks and Numbers 1"),
         }
     )
-    consignee = SimpleNamespace(
+    consignee = _row(
         field_name="raw.table.1.Consignee Name",
         original_value="COMM Number Qualifier",
-        normalized_value=None,
     )
-    description = SimpleNamespace(
+    description = _row(
         field_name="raw.table.2.Cargo Description 1",
         original_value="Marks and Numbers 1",
-        normalized_value=None,
     )
 
     assert _target_field(consignee, table_headers=table_headers) == (None, 0)
@@ -121,20 +109,17 @@ def test_any_known_table_header_is_rejected_when_parser_shifts_it_into_a_value()
 
 
 def test_explicit_lading_and_description_headers_map_to_safe_targets():
-    bol = SimpleNamespace(
+    bol = _row(
         field_name="raw.table.1.Master BOL #",
         original_value="MAEU274342495",
-        normalized_value=None,
     )
-    cargo = SimpleNamespace(
+    cargo = _row(
         field_name="raw.table.2.Cargo Description 1",
         original_value="SINGLE PACKS OF PINUS RADIATA TIMBER PINUS RADIATA",
-        normalized_value=None,
     )
-    commodity = SimpleNamespace(
+    commodity = _row(
         field_name="raw.table.2.Commodity Description",
         original_value="SINGLE PACKS OF PINUS RADIATA TIMBER",
-        normalized_value=None,
     )
 
     assert _target_field(bol) == ("bill_of_lading", 3)
@@ -143,25 +128,21 @@ def test_explicit_lading_and_description_headers_map_to_safe_targets():
 
 
 def test_valid_container_consignee_importer_and_description_controls_remain_admissible():
-    container = SimpleNamespace(
+    container = _row(
         field_name="raw.table.1.Container Number",
         original_value="MSKU9228574",
-        normalized_value=None,
     )
-    consignee = SimpleNamespace(
+    consignee = _row(
         field_name="raw.table.1.Consignee Name",
         original_value="WOOD BROKERAGE INTERNATIONAL",
-        normalized_value=None,
     )
-    importer = SimpleNamespace(
+    importer = _row(
         field_name="raw.table.1.Importer Name",
         original_value="WOOD BROKERAGE INTERNATIONAL LLC",
-        normalized_value=None,
     )
-    description = SimpleNamespace(
+    description = _row(
         field_name="raw.table.2.Cargo Description 1",
         original_value="SINGLE PACKS OF PINUS RADIATA TIMBER",
-        normalized_value=None,
     )
 
     assert _target_field(container) == ("container_number", 3)


### PR DESCRIPTION
## Summary

Applies the five narrowly-scoped semantic refinements identified by the production Golden Test after PR #188. Core architecture and human-confirmation boundaries are unchanged.

### Changes
- Scope generic `Unit` evidence to rows in tables with a strong Plant Declaration signature and an extracted plant quantity on the same row.
- Resolve `percent_recycled` to `NOT_REQUIRED / NOT_PAPER_OR_PAPERBOARD` for non-paper components while retaining extracted values as provenance.
- Separate shipment-total entered value from plant-line allocations; totals are retained for arithmetic reconciliation and never compete with line values when explicit allocations exist.
- Emit a blocking `ENTERED_VALUE_ALLOCATION_MISMATCH` when line allocations do not reconcile to the shipment total.
- Deterministically exclude WEIGHT, PLANT_COMPONENT_DESCRIPTION, PACKAGING_DESCRIPTION and SUPPLIER_STATEMENT evidence from the merchandise-description candidate pool without deleting the underlying extracted evidence.
- Fully hide native file-input chrome, use controlled English file-selection text, and suppress the control in print CSS.

## Tests added
- Plant Declaration `1440 -> KG` and `360 -> KG` row-pair regression.
- Commercial `Unit` contamination regression.
- Shipment total vs explicit line allocation regression and adversarial sum mismatch.
- Non-paper recycled-content conditional state / Needs-attention regression.
- Description semantic-role filtering regressions.
- File-input English/native-chrome/print contract regression.

No schema migration and no Semantic Evidence Graph redesign.