### PR TITLE
feat(us-lacey): multilingual evidence snapshot schema foundations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,7 +93,7 @@ jobs:
             echo "Expected exactly one Alembic head."
             exit 1
           fi
-          grep -Fx "044_platform_admin_control_plane (head)" alembic-heads.txt
+          grep -Fx "047_lacey_semantic_graph (head)" alembic-heads.txt
 
       - name: Run pytest suite
         run: python -m pytest -q -rs
@@ -107,7 +107,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: "22"
           cache: "npm"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,7 +107,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup Node
-        uses: actions/setup-node@v5
+        uses: actions/setup-node@v4
         with:
           node-version: "22"
           cache: "npm"

--- a/.github/workflows/us-lacey-postgres-gate.yml
+++ b/.github/workflows/us-lacey-postgres-gate.yml
@@ -13,13 +13,20 @@ on:
       - "alembic/versions/041_add_us_lacey_lemon_squeezy_billing.py"
       - "alembic/versions/042_add_us_lacey_owner_admin_overview.py"
       - "alembic/versions/043_add_us_lacey_engine2_shadow.py"
+      - "alembic/versions/045_add_lacey_evidence_snapshots.py"
+      - "alembic/versions/046_add_multilingual_text_spans.py"
+      - "alembic/versions/047_add_semantic_evidence_graph.py"
       - "src/litoral_trace/us_lacey/**"
       - "src/litoral_trace/web/us_lacey_*"
       - "src/litoral_trace/services/us_lacey_admin.py"
+      - "src/litoral_trace/services/translation.py"
       - "src/litoral_trace/api/admin.py"
       - "src/litoral_trace/templates/admin_organizations.html"
       - "src/litoral_trace/templates/admin_us_lacey_accounts.html"
       - "src/litoral_trace/db/models/us_lacey.py"
+      - "src/litoral_trace/db/models/us_lacey_evidence_snapshot.py"
+      - "src/litoral_trace/db/models/document_text.py"
+      - "src/litoral_trace/db/models/semantic_evidence.py"
       - "src/litoral_trace/db/models/us_lacey_commercial.py"
       - "src/litoral_trace/db/models/us_lacey_payment_event.py"
       - "src/litoral_trace/db/models/reconciliation_issue.py"
@@ -162,7 +169,7 @@ jobs:
         run: |
           set -euo pipefail
           python -m alembic current | tee /tmp/alembic-current.txt
-          grep -Fx "044_platform_admin_control_plane (head)" /tmp/alembic-current.txt
+          grep -Fx "047_lacey_semantic_graph (head)" /tmp/alembic-current.txt
           python - <<'PY'
           import os
           from sqlalchemy import create_engine, text
@@ -183,6 +190,13 @@ jobs:
               "us_lacey_engine_document_runs": 4,
               "us_lacey_engine_shipment_runs": 4,
               "us_lacey_payment_events": 1,
+              "us_lacey_evidence_snapshots": 4,
+              "us_lacey_evidence_snapshot_documents": 4,
+              "document_text_spans": 4,
+              "document_text_translations": 4,
+              "semantic_evidence_nodes": 4,
+              "semantic_snapshot_nodes": 4,
+              "semantic_evidence_edges": 4,
           }
           ppq_tables = (
               "us_lacey_ppq_shipments",
@@ -450,6 +464,27 @@ jobs:
           assert definer_role == {"rolcanlogin": False, "rolsuper": False, "rolbypassrls": False}
           engine.dispose()
           PY
+      - name: Prove multilingual schema downgrade and re-upgrade
+        shell: bash
+        run: |
+          set -euo pipefail
+          python -m alembic downgrade 044_platform_admin_control_plane
+          python -m alembic current | tee /tmp/alembic-downgraded.txt
+          grep -Fx "044_platform_admin_control_plane" /tmp/alembic-downgraded.txt
+          python -m alembic upgrade head
+          python -m alembic current | tee /tmp/alembic-reupgraded.txt
+          grep -Fx "047_lacey_semantic_graph (head)" /tmp/alembic-reupgraded.txt
+      - name: Prove multilingual snapshot persistence and tenant constraints
+        shell: bash
+        run: |
+          set -euo pipefail
+          set -o pipefail
+          python -m pytest -q -rs tests/test_us_lacey_multilingual_snapshot_schema.py \
+            | tee /tmp/multilingual-schema-postgres.txt
+          if grep -Eq '([1-9][0-9]* skipped|BLOCKED_ENVIRONMENT|POSTGRES_SCHEMA_NOT_MIGRATED)' /tmp/multilingual-schema-postgres.txt; then
+            echo "Multilingual snapshot PostgreSQL acceptance must not skip in CI."
+            exit 1
+          fi
       - name: Prove Engine 2 shadow persistence and tenant isolation
         shell: bash
         run: |

--- a/alembic/versions/045_add_lacey_evidence_snapshots.py
+++ b/alembic/versions/045_add_lacey_evidence_snapshots.py
@@ -1,0 +1,200 @@
+"""Add immutable U.S. Lacey evidence snapshots.
+
+Revision ID: 045_lacey_evidence_snapshots
+Revises: 044_platform_admin_control_plane
+"""
+from __future__ import annotations
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+revision: str = "045_lacey_evidence_snapshots"
+down_revision: Union[str, Sequence[str], None] = "044_platform_admin_control_plane"
+branch_labels = None
+depends_on = None
+
+TABLES = (
+    "us_lacey_evidence_snapshots",
+    "us_lacey_evidence_snapshot_documents",
+)
+RUNTIME_ROLE = "litoral_trace_app"
+WORKER_EXECUTOR_ROLE = "litoral_trace_worker_executor"
+TENANT_CONTEXT_SQL = "NULLIF(current_setting('app.current_organization_id', true), '')::integer"
+
+
+def _rls(table: str) -> None:
+    predicate = f"organization_id = {TENANT_CONTEXT_SQL}"
+    op.execute(f"ALTER TABLE public.{table} ENABLE ROW LEVEL SECURITY")
+    op.execute(f"ALTER TABLE public.{table} FORCE ROW LEVEL SECURITY")
+    for action, clause in (
+        ("select", "USING"),
+        ("insert", "WITH CHECK"),
+        ("update", "USING"),
+        ("delete", "USING"),
+    ):
+        suffix = f"{clause} ({predicate})"
+        if action == "update":
+            suffix += f" WITH CHECK ({predicate})"
+        op.execute(
+            f"CREATE POLICY {table}_tenant_{action} ON public.{table} "
+            f"FOR {action.upper()} {suffix}"
+        )
+
+
+def _grant_runtime(table: str) -> None:
+    op.execute(f"REVOKE ALL PRIVILEGES ON TABLE public.{table} FROM PUBLIC")
+    op.execute(f"GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE public.{table} TO {RUNTIME_ROLE}")
+    op.execute(f"REVOKE ALL PRIVILEGES ON TABLE public.{table} FROM {WORKER_EXECUTOR_ROLE}")
+    op.execute(f"REVOKE ALL PRIVILEGES ON SEQUENCE public.{table}_id_seq FROM PUBLIC")
+    op.execute(f"GRANT USAGE, SELECT ON SEQUENCE public.{table}_id_seq TO {RUNTIME_ROLE}")
+    op.execute(f"REVOKE ALL PRIVILEGES ON SEQUENCE public.{table}_id_seq FROM {WORKER_EXECUTOR_ROLE}")
+
+
+def upgrade() -> None:
+    op.create_table(
+        "us_lacey_evidence_snapshots",
+        sa.Column("id", sa.Integer(), primary_key=True, autoincrement=True),
+        sa.Column("public_id", sa.Uuid(), nullable=False),
+        sa.Column("organization_id", sa.Integer(), nullable=False),
+        sa.Column("operation_id", sa.Integer(), nullable=False),
+        sa.Column("generation", sa.Integer(), nullable=False),
+        sa.Column("status", sa.String(16), nullable=False),
+        sa.Column("source_set_fingerprint", sa.String(64), nullable=False),
+        sa.Column("graph_version", sa.String(64), nullable=False),
+        sa.Column("ontology_version", sa.String(64), nullable=False),
+        sa.Column("translation_pipeline_version", sa.String(64), nullable=False),
+        sa.Column("document_count", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("node_count", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("conflict_count", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.text("CURRENT_TIMESTAMP")),
+        sa.Column("finalized_at", sa.DateTime(timezone=True), nullable=True),
+        sa.ForeignKeyConstraint(
+            ["operation_id", "organization_id"],
+            ["us_lacey_operations.id", "us_lacey_operations.organization_id"],
+            name="fk_lacey_evidence_snapshots_operation_tenant",
+            ondelete="CASCADE",
+        ),
+        sa.UniqueConstraint("id", "organization_id", name="uq_lacey_evidence_snapshots_id_org"),
+        sa.UniqueConstraint("public_id", name="uq_lacey_evidence_snapshots_public_id"),
+        sa.UniqueConstraint(
+            "organization_id", "operation_id", "generation",
+            name="uq_lacey_evidence_snapshots_generation",
+        ),
+        sa.UniqueConstraint(
+            "organization_id", "operation_id", "source_set_fingerprint",
+            name="uq_lacey_evidence_snapshots_fingerprint",
+        ),
+        sa.CheckConstraint("generation > 0", name="ck_lacey_evidence_snapshots_generation"),
+        sa.CheckConstraint(
+            "status IN ('BUILDING','CURRENT','SUPERSEDED','FAILED')",
+            name="ck_lacey_evidence_snapshots_status",
+        ),
+        sa.CheckConstraint("document_count >= 0", name="ck_lacey_evidence_snapshots_document_count"),
+        sa.CheckConstraint("node_count >= 0", name="ck_lacey_evidence_snapshots_node_count"),
+        sa.CheckConstraint("conflict_count >= 0", name="ck_lacey_evidence_snapshots_conflict_count"),
+    )
+    op.create_index(
+        "ix_lacey_evidence_snapshots_org_operation",
+        "us_lacey_evidence_snapshots",
+        ["organization_id", "operation_id"],
+    )
+    op.create_index(
+        "ix_lacey_evidence_snapshots_org_status",
+        "us_lacey_evidence_snapshots",
+        ["organization_id", "status"],
+    )
+
+    op.create_table(
+        "us_lacey_evidence_snapshot_documents",
+        sa.Column("id", sa.Integer(), primary_key=True, autoincrement=True),
+        sa.Column("organization_id", sa.Integer(), nullable=False),
+        sa.Column("snapshot_id", sa.Integer(), nullable=False),
+        sa.Column("operation_document_id", sa.Integer(), nullable=False),
+        sa.Column("assurance_document_id", sa.Integer(), nullable=False),
+        sa.Column("extraction_run_id", sa.Integer(), nullable=False),
+        sa.Column("source_sha256", sa.String(64), nullable=False),
+        sa.Column("document_role", sa.String(64), nullable=False, server_default="UNKNOWN"),
+        sa.Column("processing_result", sa.String(16), nullable=False, server_default="SUCCEEDED"),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.text("CURRENT_TIMESTAMP")),
+        sa.ForeignKeyConstraint(
+            ["snapshot_id", "organization_id"],
+            ["us_lacey_evidence_snapshots.id", "us_lacey_evidence_snapshots.organization_id"],
+            name="fk_lacey_snapshot_documents_snapshot_tenant",
+            ondelete="CASCADE",
+        ),
+        sa.ForeignKeyConstraint(
+            ["operation_document_id", "organization_id"],
+            ["us_lacey_operation_documents.id", "us_lacey_operation_documents.organization_id"],
+            name="fk_lacey_snapshot_documents_operation_document_tenant",
+            ondelete="RESTRICT",
+        ),
+        sa.ForeignKeyConstraint(
+            ["assurance_document_id", "organization_id"],
+            ["assurance_documents.id", "assurance_documents.organization_id"],
+            name="fk_lacey_snapshot_documents_assurance_tenant",
+            ondelete="RESTRICT",
+        ),
+        sa.ForeignKeyConstraint(
+            ["extraction_run_id", "organization_id"],
+            ["document_extraction_runs.id", "document_extraction_runs.organization_id"],
+            name="fk_lacey_snapshot_documents_extraction_run_tenant",
+            ondelete="RESTRICT",
+        ),
+        sa.UniqueConstraint("id", "organization_id", name="uq_lacey_snapshot_documents_id_org"),
+        sa.UniqueConstraint(
+            "organization_id", "snapshot_id", "operation_document_id",
+            name="uq_lacey_snapshot_documents_member",
+        ),
+        sa.CheckConstraint(
+            "processing_result IN ('SUCCEEDED','FAILED','SKIPPED')",
+            name="ck_lacey_snapshot_documents_result",
+        ),
+    )
+    op.create_index(
+        "ix_lacey_snapshot_documents_org_snapshot",
+        "us_lacey_evidence_snapshot_documents",
+        ["organization_id", "snapshot_id"],
+    )
+    op.create_index(
+        "ix_lacey_snapshot_documents_org_assurance",
+        "us_lacey_evidence_snapshot_documents",
+        ["organization_id", "assurance_document_id"],
+    )
+
+    op.add_column(
+        "us_lacey_operations",
+        sa.Column("current_evidence_snapshot_id", sa.Integer(), nullable=True),
+    )
+    op.create_foreign_key(
+        "fk_us_lacey_operations_current_snapshot_tenant",
+        "us_lacey_operations",
+        "us_lacey_evidence_snapshots",
+        ["current_evidence_snapshot_id", "organization_id"],
+        ["id", "organization_id"],
+    )
+    op.create_index(
+        "ix_us_lacey_operations_current_snapshot",
+        "us_lacey_operations",
+        ["organization_id", "current_evidence_snapshot_id"],
+    )
+
+    for table in TABLES:
+        _rls(table)
+        _grant_runtime(table)
+
+
+def downgrade() -> None:
+    op.drop_index("ix_us_lacey_operations_current_snapshot", table_name="us_lacey_operations")
+    op.drop_constraint(
+        "fk_us_lacey_operations_current_snapshot_tenant",
+        "us_lacey_operations",
+        type_="foreignkey",
+    )
+    op.drop_column("us_lacey_operations", "current_evidence_snapshot_id")
+
+    for table in reversed(TABLES):
+        for action in ("delete", "update", "insert", "select"):
+            op.execute(f"DROP POLICY IF EXISTS {table}_tenant_{action} ON public.{table}")
+        op.drop_table(table)

--- a/alembic/versions/046_add_multilingual_text_spans.py
+++ b/alembic/versions/046_add_multilingual_text_spans.py
@@ -1,0 +1,142 @@
+"""Add multilingual source spans and translation provenance.
+
+Revision ID: 046_lacey_multilingual_spans
+Revises: 045_lacey_evidence_snapshots
+"""
+from __future__ import annotations
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+revision: str = "046_lacey_multilingual_spans"
+down_revision: Union[str, Sequence[str], None] = "045_lacey_evidence_snapshots"
+branch_labels = None
+depends_on = None
+
+TABLES = ("document_text_spans", "document_text_translations")
+RUNTIME_ROLE = "litoral_trace_app"
+WORKER_EXECUTOR_ROLE = "litoral_trace_worker_executor"
+TENANT_CONTEXT_SQL = "NULLIF(current_setting('app.current_organization_id', true), '')::integer"
+
+
+def _rls(table: str) -> None:
+    predicate = f"organization_id = {TENANT_CONTEXT_SQL}"
+    op.execute(f"ALTER TABLE public.{table} ENABLE ROW LEVEL SECURITY")
+    op.execute(f"ALTER TABLE public.{table} FORCE ROW LEVEL SECURITY")
+    for action, clause in (("select", "USING"), ("insert", "WITH CHECK"), ("update", "USING"), ("delete", "USING")):
+        suffix = f"{clause} ({predicate})"
+        if action == "update":
+            suffix += f" WITH CHECK ({predicate})"
+        op.execute(f"CREATE POLICY {table}_tenant_{action} ON public.{table} FOR {action.upper()} {suffix}")
+
+
+def _grant_runtime(table: str) -> None:
+    op.execute(f"REVOKE ALL PRIVILEGES ON TABLE public.{table} FROM PUBLIC")
+    op.execute(f"GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE public.{table} TO {RUNTIME_ROLE}")
+    op.execute(f"REVOKE ALL PRIVILEGES ON TABLE public.{table} FROM {WORKER_EXECUTOR_ROLE}")
+    op.execute(f"REVOKE ALL PRIVILEGES ON SEQUENCE public.{table}_id_seq FROM PUBLIC")
+    op.execute(f"GRANT USAGE, SELECT ON SEQUENCE public.{table}_id_seq TO {RUNTIME_ROLE}")
+    op.execute(f"REVOKE ALL PRIVILEGES ON SEQUENCE public.{table}_id_seq FROM {WORKER_EXECUTOR_ROLE}")
+
+
+def upgrade() -> None:
+    op.create_table(
+        "document_text_spans",
+        sa.Column("id", sa.Integer(), primary_key=True, autoincrement=True),
+        sa.Column("public_id", sa.Uuid(), nullable=False),
+        sa.Column("organization_id", sa.Integer(), nullable=False),
+        sa.Column("assurance_document_id", sa.Integer(), nullable=False),
+        sa.Column("extraction_run_id", sa.Integer(), nullable=False),
+        sa.Column("page", sa.Integer(), nullable=False),
+        sa.Column("block_id", sa.String(255), nullable=False),
+        sa.Column("table_id", sa.String(255), nullable=True),
+        sa.Column("row_index", sa.Integer(), nullable=True),
+        sa.Column("column_index", sa.Integer(), nullable=True),
+        sa.Column("bbox_json", sa.JSON(), nullable=True),
+        sa.Column("source_locator", sa.Text(), nullable=True),
+        sa.Column("original_text", sa.Text(), nullable=False),
+        sa.Column("original_language", sa.String(32), nullable=False),
+        sa.Column("language_confidence", sa.Float(), nullable=False, server_default="0"),
+        sa.Column("extraction_method", sa.String(32), nullable=False),
+        sa.Column("ocr_engine", sa.String(100), nullable=True),
+        sa.Column("ocr_engine_version", sa.String(100), nullable=True),
+        sa.Column("ocr_confidence", sa.Float(), nullable=True),
+        sa.Column("content_hash", sa.String(64), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.text("CURRENT_TIMESTAMP")),
+        sa.ForeignKeyConstraint(
+            ["assurance_document_id", "organization_id"],
+            ["assurance_documents.id", "assurance_documents.organization_id"],
+            name="fk_document_text_spans_assurance_tenant",
+            ondelete="CASCADE",
+        ),
+        sa.ForeignKeyConstraint(
+            ["extraction_run_id", "organization_id"],
+            ["document_extraction_runs.id", "document_extraction_runs.organization_id"],
+            name="fk_document_text_spans_extraction_run_tenant",
+            ondelete="CASCADE",
+        ),
+        sa.UniqueConstraint("id", "organization_id", name="uq_document_text_spans_id_org"),
+        sa.UniqueConstraint("public_id", name="uq_document_text_spans_public_id"),
+        sa.CheckConstraint("page > 0", name="ck_document_text_spans_page"),
+        sa.CheckConstraint(
+            "language_confidence >= 0 AND language_confidence <= 1",
+            name="ck_document_text_spans_language_confidence",
+        ),
+        sa.CheckConstraint(
+            "ocr_confidence IS NULL OR (ocr_confidence >= 0 AND ocr_confidence <= 1)",
+            name="ck_document_text_spans_ocr_confidence",
+        ),
+    )
+    op.create_index("ix_document_text_spans_org_document", "document_text_spans", ["organization_id", "assurance_document_id"])
+    op.create_index("ix_document_text_spans_org_run", "document_text_spans", ["organization_id", "extraction_run_id"])
+    op.create_index("ix_document_text_spans_org_language", "document_text_spans", ["organization_id", "original_language"])
+
+    op.create_table(
+        "document_text_translations",
+        sa.Column("id", sa.Integer(), primary_key=True, autoincrement=True),
+        sa.Column("public_id", sa.Uuid(), nullable=False),
+        sa.Column("organization_id", sa.Integer(), nullable=False),
+        sa.Column("source_span_id", sa.Integer(), nullable=False),
+        sa.Column("source_language", sa.String(32), nullable=False),
+        sa.Column("target_language", sa.String(32), nullable=False, server_default="en"),
+        sa.Column("translated_text", sa.Text(), nullable=False),
+        sa.Column("provider", sa.String(64), nullable=False),
+        sa.Column("model_name", sa.String(128), nullable=False),
+        sa.Column("model_version", sa.String(128), nullable=False),
+        sa.Column("quality_score", sa.Float(), nullable=True),
+        sa.Column("input_hash", sa.String(64), nullable=False),
+        sa.Column("output_hash", sa.String(64), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.text("CURRENT_TIMESTAMP")),
+        sa.ForeignKeyConstraint(
+            ["source_span_id", "organization_id"],
+            ["document_text_spans.id", "document_text_spans.organization_id"],
+            name="fk_document_text_translations_span_tenant",
+            ondelete="CASCADE",
+        ),
+        sa.UniqueConstraint("id", "organization_id", name="uq_document_text_translations_id_org"),
+        sa.UniqueConstraint("public_id", name="uq_document_text_translations_public_id"),
+        sa.UniqueConstraint(
+            "organization_id", "source_span_id", "target_language", "provider",
+            "model_name", "model_version", "input_hash",
+            name="uq_document_text_translations_identity",
+        ),
+        sa.CheckConstraint(
+            "quality_score IS NULL OR (quality_score >= 0 AND quality_score <= 1)",
+            name="ck_document_text_translations_quality",
+        ),
+    )
+    op.create_index("ix_document_text_translations_org_span", "document_text_translations", ["organization_id", "source_span_id"])
+    op.create_index("ix_document_text_translations_org_target", "document_text_translations", ["organization_id", "target_language"])
+
+    for table in TABLES:
+        _rls(table)
+        _grant_runtime(table)
+
+
+def downgrade() -> None:
+    for table in reversed(TABLES):
+        for action in ("delete", "update", "insert", "select"):
+            op.execute(f"DROP POLICY IF EXISTS {table}_tenant_{action} ON public.{table}")
+        op.drop_table(table)

--- a/alembic/versions/047_add_semantic_evidence_graph.py
+++ b/alembic/versions/047_add_semantic_evidence_graph.py
@@ -1,0 +1,187 @@
+"""Add persistent semantic evidence graph foundations.
+
+Revision ID: 047_lacey_semantic_graph
+Revises: 046_lacey_multilingual_spans
+"""
+from __future__ import annotations
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+revision: str = "047_lacey_semantic_graph"
+down_revision: Union[str, Sequence[str], None] = "046_lacey_multilingual_spans"
+branch_labels = None
+depends_on = None
+
+TABLES = (
+    "semantic_evidence_nodes",
+    "semantic_snapshot_nodes",
+    "semantic_evidence_edges",
+)
+RUNTIME_ROLE = "litoral_trace_app"
+WORKER_EXECUTOR_ROLE = "litoral_trace_worker_executor"
+TENANT_CONTEXT_SQL = "NULLIF(current_setting('app.current_organization_id', true), '')::integer"
+
+
+def _rls(table: str) -> None:
+    predicate = f"organization_id = {TENANT_CONTEXT_SQL}"
+    op.execute(f"ALTER TABLE public.{table} ENABLE ROW LEVEL SECURITY")
+    op.execute(f"ALTER TABLE public.{table} FORCE ROW LEVEL SECURITY")
+    for action, clause in (("select", "USING"), ("insert", "WITH CHECK"), ("update", "USING"), ("delete", "USING")):
+        suffix = f"{clause} ({predicate})"
+        if action == "update":
+            suffix += f" WITH CHECK ({predicate})"
+        op.execute(f"CREATE POLICY {table}_tenant_{action} ON public.{table} FOR {action.upper()} {suffix}")
+
+
+def _grant_runtime(table: str) -> None:
+    op.execute(f"REVOKE ALL PRIVILEGES ON TABLE public.{table} FROM PUBLIC")
+    op.execute(f"GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE public.{table} TO {RUNTIME_ROLE}")
+    op.execute(f"REVOKE ALL PRIVILEGES ON TABLE public.{table} FROM {WORKER_EXECUTOR_ROLE}")
+    op.execute(f"REVOKE ALL PRIVILEGES ON SEQUENCE public.{table}_id_seq FROM PUBLIC")
+    op.execute(f"GRANT USAGE, SELECT ON SEQUENCE public.{table}_id_seq TO {RUNTIME_ROLE}")
+    op.execute(f"REVOKE ALL PRIVILEGES ON SEQUENCE public.{table}_id_seq FROM {WORKER_EXECUTOR_ROLE}")
+
+
+def upgrade() -> None:
+    op.create_table(
+        "semantic_evidence_nodes",
+        sa.Column("id", sa.Integer(), primary_key=True, autoincrement=True),
+        sa.Column("public_id", sa.Uuid(), nullable=False),
+        sa.Column("organization_id", sa.Integer(), nullable=False),
+        sa.Column("assurance_document_id", sa.Integer(), nullable=False),
+        sa.Column("extraction_run_id", sa.Integer(), nullable=False),
+        sa.Column("source_span_id", sa.Integer(), nullable=False),
+        sa.Column("target_field", sa.String(100), nullable=False),
+        sa.Column("semantic_role", sa.String(100), nullable=False),
+        sa.Column("scope", sa.String(64), nullable=False),
+        sa.Column("local_entity_key", sa.String(512), nullable=True),
+        sa.Column("original_value", sa.Text(), nullable=False),
+        sa.Column("normalized_value", sa.Text(), nullable=True),
+        sa.Column("evidence_class", sa.String(16), nullable=False),
+        sa.Column("document_type", sa.String(64), nullable=False),
+        sa.Column("extraction_confidence", sa.Float(), nullable=False, server_default="0"),
+        sa.Column("authority_score", sa.Float(), nullable=False, server_default="0"),
+        sa.Column("candidate_score", sa.Float(), nullable=False, server_default="0"),
+        sa.Column("fingerprint", sa.String(64), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.text("CURRENT_TIMESTAMP")),
+        sa.ForeignKeyConstraint(
+            ["assurance_document_id", "organization_id"],
+            ["assurance_documents.id", "assurance_documents.organization_id"],
+            name="fk_semantic_evidence_nodes_assurance_tenant",
+            ondelete="CASCADE",
+        ),
+        sa.ForeignKeyConstraint(
+            ["extraction_run_id", "organization_id"],
+            ["document_extraction_runs.id", "document_extraction_runs.organization_id"],
+            name="fk_semantic_evidence_nodes_extraction_run_tenant",
+            ondelete="CASCADE",
+        ),
+        sa.ForeignKeyConstraint(
+            ["source_span_id", "organization_id"],
+            ["document_text_spans.id", "document_text_spans.organization_id"],
+            name="fk_semantic_evidence_nodes_span_tenant",
+            ondelete="CASCADE",
+        ),
+        sa.UniqueConstraint("id", "organization_id", name="uq_semantic_evidence_nodes_id_org"),
+        sa.UniqueConstraint("public_id", name="uq_semantic_evidence_nodes_public_id"),
+        sa.UniqueConstraint("organization_id", "fingerprint", name="uq_semantic_evidence_nodes_fingerprint"),
+        sa.CheckConstraint(
+            "evidence_class IN ('EXPLICIT','DERIVED','INFERRED')",
+            name="ck_semantic_evidence_nodes_class",
+        ),
+        sa.CheckConstraint(
+            "extraction_confidence >= 0 AND extraction_confidence <= 1",
+            name="ck_semantic_evidence_nodes_confidence",
+        ),
+    )
+    op.create_index("ix_semantic_evidence_nodes_org_document", "semantic_evidence_nodes", ["organization_id", "assurance_document_id"])
+    op.create_index("ix_semantic_evidence_nodes_org_field", "semantic_evidence_nodes", ["organization_id", "target_field"])
+    op.create_index("ix_semantic_evidence_nodes_org_local_entity", "semantic_evidence_nodes", ["organization_id", "local_entity_key"])
+
+    op.create_table(
+        "semantic_snapshot_nodes",
+        sa.Column("id", sa.Integer(), primary_key=True, autoincrement=True),
+        sa.Column("organization_id", sa.Integer(), nullable=False),
+        sa.Column("snapshot_id", sa.Integer(), nullable=False),
+        sa.Column("evidence_node_id", sa.Integer(), nullable=False),
+        sa.Column("canonical_entity_id", sa.String(128), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.text("CURRENT_TIMESTAMP")),
+        sa.ForeignKeyConstraint(
+            ["snapshot_id", "organization_id"],
+            ["us_lacey_evidence_snapshots.id", "us_lacey_evidence_snapshots.organization_id"],
+            name="fk_semantic_snapshot_nodes_snapshot_tenant",
+            ondelete="CASCADE",
+        ),
+        sa.ForeignKeyConstraint(
+            ["evidence_node_id", "organization_id"],
+            ["semantic_evidence_nodes.id", "semantic_evidence_nodes.organization_id"],
+            name="fk_semantic_snapshot_nodes_node_tenant",
+            ondelete="CASCADE",
+        ),
+        sa.UniqueConstraint("id", "organization_id", name="uq_semantic_snapshot_nodes_id_org"),
+        sa.UniqueConstraint(
+            "organization_id", "snapshot_id", "evidence_node_id",
+            name="uq_semantic_snapshot_nodes_member",
+        ),
+    )
+    op.create_index("ix_semantic_snapshot_nodes_org_snapshot", "semantic_snapshot_nodes", ["organization_id", "snapshot_id"])
+    op.create_index("ix_semantic_snapshot_nodes_org_canonical", "semantic_snapshot_nodes", ["organization_id", "snapshot_id", "canonical_entity_id"])
+
+    op.create_table(
+        "semantic_evidence_edges",
+        sa.Column("id", sa.Integer(), primary_key=True, autoincrement=True),
+        sa.Column("organization_id", sa.Integer(), nullable=False),
+        sa.Column("snapshot_id", sa.Integer(), nullable=False),
+        sa.Column("from_node_id", sa.Integer(), nullable=False),
+        sa.Column("to_node_id", sa.Integer(), nullable=False),
+        sa.Column("relation_type", sa.String(32), nullable=False),
+        sa.Column("confidence", sa.Float(), nullable=False, server_default="1"),
+        sa.Column("reason_code", sa.String(100), nullable=True),
+        sa.Column("metadata_json", sa.JSON(), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.text("CURRENT_TIMESTAMP")),
+        sa.ForeignKeyConstraint(
+            ["snapshot_id", "organization_id"],
+            ["us_lacey_evidence_snapshots.id", "us_lacey_evidence_snapshots.organization_id"],
+            name="fk_semantic_evidence_edges_snapshot_tenant",
+            ondelete="CASCADE",
+        ),
+        sa.ForeignKeyConstraint(
+            ["from_node_id", "organization_id"],
+            ["semantic_evidence_nodes.id", "semantic_evidence_nodes.organization_id"],
+            name="fk_semantic_evidence_edges_from_node_tenant",
+            ondelete="CASCADE",
+        ),
+        sa.ForeignKeyConstraint(
+            ["to_node_id", "organization_id"],
+            ["semantic_evidence_nodes.id", "semantic_evidence_nodes.organization_id"],
+            name="fk_semantic_evidence_edges_to_node_tenant",
+            ondelete="CASCADE",
+        ),
+        sa.UniqueConstraint("id", "organization_id", name="uq_semantic_evidence_edges_id_org"),
+        sa.UniqueConstraint(
+            "organization_id", "snapshot_id", "from_node_id", "to_node_id", "relation_type",
+            name="uq_semantic_evidence_edges_relation",
+        ),
+        sa.CheckConstraint(
+            "relation_type IN ('CORROBORATES','CONTRADICTS','SAME_ENTITY_AS','SUPERSEDES','OUT_OF_SCOPE','DERIVED_FROM')",
+            name="ck_semantic_evidence_edges_relation_type",
+        ),
+        sa.CheckConstraint("confidence >= 0 AND confidence <= 1", name="ck_semantic_evidence_edges_confidence"),
+    )
+    op.create_index("ix_semantic_evidence_edges_org_snapshot", "semantic_evidence_edges", ["organization_id", "snapshot_id"])
+    op.create_index("ix_semantic_evidence_edges_org_from", "semantic_evidence_edges", ["organization_id", "from_node_id"])
+    op.create_index("ix_semantic_evidence_edges_org_to", "semantic_evidence_edges", ["organization_id", "to_node_id"])
+
+    for table in TABLES:
+        _rls(table)
+        _grant_runtime(table)
+
+
+def downgrade() -> None:
+    for table in reversed(TABLES):
+        for action in ("delete", "update", "insert", "select"):
+            op.execute(f"DROP POLICY IF EXISTS {table}_tenant_{action} ON public.{table}")
+        op.drop_table(table)

--- a/src/litoral_trace/db/models/__init__.py
+++ b/src/litoral_trace/db/models/__init__.py
@@ -40,6 +40,19 @@ from litoral_trace.db.models.us_lacey import (
     UsLaceyPpqShipment,
     UsLaceyPlantDeclaration,
 )
+from litoral_trace.db.models.us_lacey_evidence_snapshot import (
+    UsLaceyEvidenceSnapshot,
+    UsLaceyEvidenceSnapshotDocument,
+)
+from litoral_trace.db.models.document_text import (
+    DocumentTextSpan,
+    DocumentTextTranslation,
+)
+from litoral_trace.db.models.semantic_evidence import (
+    SemanticEvidenceEdge,
+    SemanticEvidenceNode,
+    SemanticSnapshotNode,
+)
 from litoral_trace.db.models.us_lacey_commercial import (
     UsLaceyPayment,
     UsLaceyProcessingJob,
@@ -103,6 +116,13 @@ __all__ = [
     "UsLaceyPpqPlantLine",
     "UsLaceyPpqShipment",
     "UsLaceyPlantDeclaration",
+    "UsLaceyEvidenceSnapshot",
+    "UsLaceyEvidenceSnapshotDocument",
+    "DocumentTextSpan",
+    "DocumentTextTranslation",
+    "SemanticEvidenceNode",
+    "SemanticSnapshotNode",
+    "SemanticEvidenceEdge",
     "UsLaceySubscription",
     "UsLaceyPayment",
     "UsLaceyPaymentEvent",

--- a/src/litoral_trace/db/models/document_text.py
+++ b/src/litoral_trace/db/models/document_text.py
@@ -1,0 +1,130 @@
+"""Immutable multilingual source spans and translation provenance (Phase A)."""
+from __future__ import annotations
+
+from datetime import datetime
+from uuid import UUID, uuid4
+
+from sqlalchemy import (
+    CheckConstraint,
+    DateTime,
+    Float,
+    ForeignKeyConstraint,
+    Index,
+    Integer,
+    JSON,
+    String,
+    Text,
+    UniqueConstraint,
+    Uuid,
+    func,
+)
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from litoral_trace.db.base import Base
+
+
+class DocumentTextSpan(Base):
+    """Immutable text actually observed in the original legal source document."""
+
+    __tablename__ = "document_text_spans"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    public_id: Mapped[UUID] = mapped_column(Uuid(as_uuid=True), default=uuid4, nullable=False)
+    organization_id: Mapped[int] = mapped_column(Integer, nullable=False)
+    assurance_document_id: Mapped[int] = mapped_column(Integer, nullable=False)
+    extraction_run_id: Mapped[int] = mapped_column(Integer, nullable=False)
+    page: Mapped[int] = mapped_column(Integer, nullable=False)
+    block_id: Mapped[str] = mapped_column(String(255), nullable=False)
+    table_id: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    row_index: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    column_index: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    bbox_json: Mapped[dict | None] = mapped_column(JSON, nullable=True)
+    source_locator: Mapped[str | None] = mapped_column(Text, nullable=True)
+    original_text: Mapped[str] = mapped_column(Text, nullable=False)
+    original_language: Mapped[str] = mapped_column(String(32), nullable=False)
+    language_confidence: Mapped[float] = mapped_column(Float, nullable=False, default=0.0)
+    extraction_method: Mapped[str] = mapped_column(String(32), nullable=False)
+    ocr_engine: Mapped[str | None] = mapped_column(String(100), nullable=True)
+    ocr_engine_version: Mapped[str | None] = mapped_column(String(100), nullable=True)
+    ocr_confidence: Mapped[float | None] = mapped_column(Float, nullable=True)
+    content_hash: Mapped[str] = mapped_column(String(64), nullable=False)
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now(), nullable=False)
+
+    translations: Mapped[list["DocumentTextTranslation"]] = relationship(
+        back_populates="source_span", cascade="all, delete-orphan"
+    )
+    evidence_nodes: Mapped[list["SemanticEvidenceNode"]] = relationship(back_populates="source_span")
+
+    __table_args__ = (
+        ForeignKeyConstraint(
+            ["assurance_document_id", "organization_id"],
+            ["assurance_documents.id", "assurance_documents.organization_id"],
+            name="fk_document_text_spans_assurance_tenant",
+            ondelete="CASCADE",
+        ),
+        ForeignKeyConstraint(
+            ["extraction_run_id", "organization_id"],
+            ["document_extraction_runs.id", "document_extraction_runs.organization_id"],
+            name="fk_document_text_spans_extraction_run_tenant",
+            ondelete="CASCADE",
+        ),
+        UniqueConstraint("id", "organization_id", name="uq_document_text_spans_id_org"),
+        UniqueConstraint("public_id", name="uq_document_text_spans_public_id"),
+        CheckConstraint("page > 0", name="ck_document_text_spans_page"),
+        CheckConstraint(
+            "language_confidence >= 0 AND language_confidence <= 1",
+            name="ck_document_text_spans_language_confidence",
+        ),
+        CheckConstraint(
+            "ocr_confidence IS NULL OR (ocr_confidence >= 0 AND ocr_confidence <= 1)",
+            name="ck_document_text_spans_ocr_confidence",
+        ),
+        Index("ix_document_text_spans_org_document", "organization_id", "assurance_document_id"),
+        Index("ix_document_text_spans_org_run", "organization_id", "extraction_run_id"),
+        Index("ix_document_text_spans_org_language", "organization_id", "original_language"),
+    )
+
+
+class DocumentTextTranslation(Base):
+    """Interpretation of a source span; never an independent evidence root."""
+
+    __tablename__ = "document_text_translations"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    public_id: Mapped[UUID] = mapped_column(Uuid(as_uuid=True), default=uuid4, nullable=False)
+    organization_id: Mapped[int] = mapped_column(Integer, nullable=False)
+    source_span_id: Mapped[int] = mapped_column(Integer, nullable=False)
+    source_language: Mapped[str] = mapped_column(String(32), nullable=False)
+    target_language: Mapped[str] = mapped_column(String(32), nullable=False, default="en")
+    translated_text: Mapped[str] = mapped_column(Text, nullable=False)
+    provider: Mapped[str] = mapped_column(String(64), nullable=False)
+    model_name: Mapped[str] = mapped_column(String(128), nullable=False)
+    model_version: Mapped[str] = mapped_column(String(128), nullable=False)
+    quality_score: Mapped[float | None] = mapped_column(Float, nullable=True)
+    input_hash: Mapped[str] = mapped_column(String(64), nullable=False)
+    output_hash: Mapped[str] = mapped_column(String(64), nullable=False)
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now(), nullable=False)
+
+    source_span: Mapped[DocumentTextSpan] = relationship(back_populates="translations")
+
+    __table_args__ = (
+        ForeignKeyConstraint(
+            ["source_span_id", "organization_id"],
+            ["document_text_spans.id", "document_text_spans.organization_id"],
+            name="fk_document_text_translations_span_tenant",
+            ondelete="CASCADE",
+        ),
+        UniqueConstraint("id", "organization_id", name="uq_document_text_translations_id_org"),
+        UniqueConstraint("public_id", name="uq_document_text_translations_public_id"),
+        UniqueConstraint(
+            "organization_id", "source_span_id", "target_language", "provider",
+            "model_name", "model_version", "input_hash",
+            name="uq_document_text_translations_identity",
+        ),
+        CheckConstraint(
+            "quality_score IS NULL OR (quality_score >= 0 AND quality_score <= 1)",
+            name="ck_document_text_translations_quality",
+        ),
+        Index("ix_document_text_translations_org_span", "organization_id", "source_span_id"),
+        Index("ix_document_text_translations_org_target", "organization_id", "target_language"),
+    )

--- a/src/litoral_trace/db/models/semantic_evidence.py
+++ b/src/litoral_trace/db/models/semantic_evidence.py
@@ -1,0 +1,182 @@
+"""Persistent semantic evidence graph foundations (Phase A)."""
+from __future__ import annotations
+
+from datetime import datetime
+from uuid import UUID, uuid4
+
+from sqlalchemy import (
+    CheckConstraint,
+    DateTime,
+    Float,
+    ForeignKeyConstraint,
+    Index,
+    Integer,
+    JSON,
+    String,
+    Text,
+    UniqueConstraint,
+    Uuid,
+    func,
+)
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from litoral_trace.db.base import Base
+from litoral_trace.db.models.document_text import DocumentTextSpan
+from litoral_trace.db.models.us_lacey_evidence_snapshot import UsLaceyEvidenceSnapshot
+
+
+class SemanticEvidenceNode(Base):
+    """Immutable semantic candidate rooted in one original document text span."""
+
+    __tablename__ = "semantic_evidence_nodes"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    public_id: Mapped[UUID] = mapped_column(Uuid(as_uuid=True), default=uuid4, nullable=False)
+    organization_id: Mapped[int] = mapped_column(Integer, nullable=False)
+    assurance_document_id: Mapped[int] = mapped_column(Integer, nullable=False)
+    extraction_run_id: Mapped[int] = mapped_column(Integer, nullable=False)
+    source_span_id: Mapped[int] = mapped_column(Integer, nullable=False)
+    target_field: Mapped[str] = mapped_column(String(100), nullable=False)
+    semantic_role: Mapped[str] = mapped_column(String(100), nullable=False)
+    scope: Mapped[str] = mapped_column(String(64), nullable=False)
+    local_entity_key: Mapped[str | None] = mapped_column(String(512), nullable=True)
+    original_value: Mapped[str] = mapped_column(Text, nullable=False)
+    normalized_value: Mapped[str | None] = mapped_column(Text, nullable=True)
+    evidence_class: Mapped[str] = mapped_column(String(16), nullable=False)
+    document_type: Mapped[str] = mapped_column(String(64), nullable=False)
+    extraction_confidence: Mapped[float] = mapped_column(Float, nullable=False, default=0.0)
+    authority_score: Mapped[float] = mapped_column(Float, nullable=False, default=0.0)
+    candidate_score: Mapped[float] = mapped_column(Float, nullable=False, default=0.0)
+    fingerprint: Mapped[str] = mapped_column(String(64), nullable=False)
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now(), nullable=False)
+
+    source_span: Mapped[DocumentTextSpan] = relationship(back_populates="evidence_nodes")
+    snapshot_links: Mapped[list["SemanticSnapshotNode"]] = relationship(
+        back_populates="evidence_node", cascade="all, delete-orphan", overlaps="snapshot,snapshot_nodes"
+    )
+
+    __table_args__ = (
+        ForeignKeyConstraint(
+            ["assurance_document_id", "organization_id"],
+            ["assurance_documents.id", "assurance_documents.organization_id"],
+            name="fk_semantic_evidence_nodes_assurance_tenant",
+            ondelete="CASCADE",
+        ),
+        ForeignKeyConstraint(
+            ["extraction_run_id", "organization_id"],
+            ["document_extraction_runs.id", "document_extraction_runs.organization_id"],
+            name="fk_semantic_evidence_nodes_extraction_run_tenant",
+            ondelete="CASCADE",
+        ),
+        ForeignKeyConstraint(
+            ["source_span_id", "organization_id"],
+            ["document_text_spans.id", "document_text_spans.organization_id"],
+            name="fk_semantic_evidence_nodes_span_tenant",
+            ondelete="CASCADE",
+        ),
+        UniqueConstraint("id", "organization_id", name="uq_semantic_evidence_nodes_id_org"),
+        UniqueConstraint("public_id", name="uq_semantic_evidence_nodes_public_id"),
+        UniqueConstraint("organization_id", "fingerprint", name="uq_semantic_evidence_nodes_fingerprint"),
+        CheckConstraint(
+            "evidence_class IN ('EXPLICIT','DERIVED','INFERRED')",
+            name="ck_semantic_evidence_nodes_class",
+        ),
+        CheckConstraint(
+            "extraction_confidence >= 0 AND extraction_confidence <= 1",
+            name="ck_semantic_evidence_nodes_confidence",
+        ),
+        Index("ix_semantic_evidence_nodes_org_document", "organization_id", "assurance_document_id"),
+        Index("ix_semantic_evidence_nodes_org_field", "organization_id", "target_field"),
+        Index("ix_semantic_evidence_nodes_org_local_entity", "organization_id", "local_entity_key"),
+    )
+
+
+class SemanticSnapshotNode(Base):
+    """Snapshot-scoped membership and canonical-entity resolution for a node."""
+
+    __tablename__ = "semantic_snapshot_nodes"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    organization_id: Mapped[int] = mapped_column(Integer, nullable=False)
+    snapshot_id: Mapped[int] = mapped_column(Integer, nullable=False)
+    evidence_node_id: Mapped[int] = mapped_column(Integer, nullable=False)
+    canonical_entity_id: Mapped[str | None] = mapped_column(String(128), nullable=True)
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now(), nullable=False)
+
+    snapshot: Mapped[UsLaceyEvidenceSnapshot] = relationship(back_populates="snapshot_nodes", overlaps="snapshot_links")
+    evidence_node: Mapped[SemanticEvidenceNode] = relationship(back_populates="snapshot_links", overlaps="snapshot,snapshot_nodes")
+
+    __table_args__ = (
+        ForeignKeyConstraint(
+            ["snapshot_id", "organization_id"],
+            ["us_lacey_evidence_snapshots.id", "us_lacey_evidence_snapshots.organization_id"],
+            name="fk_semantic_snapshot_nodes_snapshot_tenant",
+            ondelete="CASCADE",
+        ),
+        ForeignKeyConstraint(
+            ["evidence_node_id", "organization_id"],
+            ["semantic_evidence_nodes.id", "semantic_evidence_nodes.organization_id"],
+            name="fk_semantic_snapshot_nodes_node_tenant",
+            ondelete="CASCADE",
+        ),
+        UniqueConstraint("id", "organization_id", name="uq_semantic_snapshot_nodes_id_org"),
+        UniqueConstraint(
+            "organization_id", "snapshot_id", "evidence_node_id",
+            name="uq_semantic_snapshot_nodes_member",
+        ),
+        Index("ix_semantic_snapshot_nodes_org_snapshot", "organization_id", "snapshot_id"),
+        Index("ix_semantic_snapshot_nodes_org_canonical", "organization_id", "snapshot_id", "canonical_entity_id"),
+    )
+
+
+class SemanticEvidenceEdge(Base):
+    """Snapshot-scoped semantic relationship between two immutable evidence nodes."""
+
+    __tablename__ = "semantic_evidence_edges"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    organization_id: Mapped[int] = mapped_column(Integer, nullable=False)
+    snapshot_id: Mapped[int] = mapped_column(Integer, nullable=False)
+    from_node_id: Mapped[int] = mapped_column(Integer, nullable=False)
+    to_node_id: Mapped[int] = mapped_column(Integer, nullable=False)
+    relation_type: Mapped[str] = mapped_column(String(32), nullable=False)
+    confidence: Mapped[float] = mapped_column(Float, nullable=False, default=1.0)
+    reason_code: Mapped[str | None] = mapped_column(String(100), nullable=True)
+    metadata_json: Mapped[dict | None] = mapped_column(JSON, nullable=True)
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now(), nullable=False)
+
+    snapshot: Mapped[UsLaceyEvidenceSnapshot] = relationship(back_populates="edges")
+
+    __table_args__ = (
+        ForeignKeyConstraint(
+            ["snapshot_id", "organization_id"],
+            ["us_lacey_evidence_snapshots.id", "us_lacey_evidence_snapshots.organization_id"],
+            name="fk_semantic_evidence_edges_snapshot_tenant",
+            ondelete="CASCADE",
+        ),
+        ForeignKeyConstraint(
+            ["from_node_id", "organization_id"],
+            ["semantic_evidence_nodes.id", "semantic_evidence_nodes.organization_id"],
+            name="fk_semantic_evidence_edges_from_node_tenant",
+            ondelete="CASCADE",
+        ),
+        ForeignKeyConstraint(
+            ["to_node_id", "organization_id"],
+            ["semantic_evidence_nodes.id", "semantic_evidence_nodes.organization_id"],
+            name="fk_semantic_evidence_edges_to_node_tenant",
+            ondelete="CASCADE",
+        ),
+        UniqueConstraint("id", "organization_id", name="uq_semantic_evidence_edges_id_org"),
+        UniqueConstraint(
+            "organization_id", "snapshot_id", "from_node_id", "to_node_id", "relation_type",
+            name="uq_semantic_evidence_edges_relation",
+        ),
+        CheckConstraint(
+            "relation_type IN ('CORROBORATES','CONTRADICTS','SAME_ENTITY_AS','SUPERSEDES','OUT_OF_SCOPE','DERIVED_FROM')",
+            name="ck_semantic_evidence_edges_relation_type",
+        ),
+        CheckConstraint("confidence >= 0 AND confidence <= 1", name="ck_semantic_evidence_edges_confidence"),
+        Index("ix_semantic_evidence_edges_org_snapshot", "organization_id", "snapshot_id"),
+        Index("ix_semantic_evidence_edges_org_from", "organization_id", "from_node_id"),
+        Index("ix_semantic_evidence_edges_org_to", "organization_id", "to_node_id"),
+    )

--- a/src/litoral_trace/db/models/us_lacey_evidence_snapshot.py
+++ b/src/litoral_trace/db/models/us_lacey_evidence_snapshot.py
@@ -164,3 +164,13 @@ if not any(
             use_alter=True,
         )
     )
+
+if not any(
+    index.name == "ix_us_lacey_operations_current_snapshot"
+    for index in UsLaceyOperation.__table__.indexes
+):
+    Index(
+        "ix_us_lacey_operations_current_snapshot",
+        UsLaceyOperation.__table__.c.organization_id,
+        UsLaceyOperation.__table__.c.current_evidence_snapshot_id,
+    )

--- a/src/litoral_trace/db/models/us_lacey_evidence_snapshot.py
+++ b/src/litoral_trace/db/models/us_lacey_evidence_snapshot.py
@@ -1,0 +1,166 @@
+"""Schema-only U.S. Lacey evidence snapshot foundations (Phase A)."""
+from __future__ import annotations
+
+from datetime import datetime
+from uuid import UUID, uuid4
+
+from sqlalchemy import (
+    CheckConstraint,
+    DateTime,
+    Float,
+    ForeignKeyConstraint,
+    Index,
+    Integer,
+    JSON,
+    String,
+    Text,
+    UniqueConstraint,
+    Uuid,
+    func,
+)
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from litoral_trace.db.base import Base
+from litoral_trace.db.models.us_lacey import UsLaceyOperation
+
+
+class UsLaceyEvidenceSnapshot(Base):
+    """Immutable operation-wide source-set generation once promoted to CURRENT."""
+
+    __tablename__ = "us_lacey_evidence_snapshots"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    public_id: Mapped[UUID] = mapped_column(Uuid(as_uuid=True), default=uuid4, nullable=False)
+    organization_id: Mapped[int] = mapped_column(Integer, nullable=False)
+    operation_id: Mapped[int] = mapped_column(Integer, nullable=False)
+    generation: Mapped[int] = mapped_column(Integer, nullable=False)
+    status: Mapped[str] = mapped_column(String(16), nullable=False, default="BUILDING")
+    source_set_fingerprint: Mapped[str] = mapped_column(String(64), nullable=False)
+    graph_version: Mapped[str] = mapped_column(String(64), nullable=False)
+    ontology_version: Mapped[str] = mapped_column(String(64), nullable=False)
+    translation_pipeline_version: Mapped[str] = mapped_column(String(64), nullable=False)
+    document_count: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+    node_count: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+    conflict_count: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now(), nullable=False)
+    finalized_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+
+    documents: Mapped[list["UsLaceyEvidenceSnapshotDocument"]] = relationship(
+        back_populates="snapshot", cascade="all, delete-orphan"
+    )
+    snapshot_nodes: Mapped[list["SemanticSnapshotNode"]] = relationship(
+        back_populates="snapshot", cascade="all, delete-orphan", overlaps="snapshot_links"
+    )
+    edges: Mapped[list["SemanticEvidenceEdge"]] = relationship(
+        back_populates="snapshot", cascade="all, delete-orphan"
+    )
+
+    __table_args__ = (
+        ForeignKeyConstraint(
+            ["operation_id", "organization_id"],
+            ["us_lacey_operations.id", "us_lacey_operations.organization_id"],
+            name="fk_lacey_evidence_snapshots_operation_tenant",
+            ondelete="CASCADE",
+        ),
+        UniqueConstraint("id", "organization_id", name="uq_lacey_evidence_snapshots_id_org"),
+        UniqueConstraint("public_id", name="uq_lacey_evidence_snapshots_public_id"),
+        UniqueConstraint(
+            "organization_id", "operation_id", "generation",
+            name="uq_lacey_evidence_snapshots_generation",
+        ),
+        UniqueConstraint(
+            "organization_id", "operation_id", "source_set_fingerprint",
+            name="uq_lacey_evidence_snapshots_fingerprint",
+        ),
+        CheckConstraint("generation > 0", name="ck_lacey_evidence_snapshots_generation"),
+        CheckConstraint(
+            "status IN ('BUILDING','CURRENT','SUPERSEDED','FAILED')",
+            name="ck_lacey_evidence_snapshots_status",
+        ),
+        CheckConstraint("document_count >= 0", name="ck_lacey_evidence_snapshots_document_count"),
+        CheckConstraint("node_count >= 0", name="ck_lacey_evidence_snapshots_node_count"),
+        CheckConstraint("conflict_count >= 0", name="ck_lacey_evidence_snapshots_conflict_count"),
+        Index("ix_lacey_evidence_snapshots_org_operation", "organization_id", "operation_id"),
+        Index("ix_lacey_evidence_snapshots_org_status", "organization_id", "status"),
+    )
+
+
+class UsLaceyEvidenceSnapshotDocument(Base):
+    """Exact immutable document/extraction-run member of an evidence snapshot."""
+
+    __tablename__ = "us_lacey_evidence_snapshot_documents"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    organization_id: Mapped[int] = mapped_column(Integer, nullable=False)
+    snapshot_id: Mapped[int] = mapped_column(Integer, nullable=False)
+    operation_document_id: Mapped[int] = mapped_column(Integer, nullable=False)
+    assurance_document_id: Mapped[int] = mapped_column(Integer, nullable=False)
+    extraction_run_id: Mapped[int] = mapped_column(Integer, nullable=False)
+    source_sha256: Mapped[str] = mapped_column(String(64), nullable=False)
+    document_role: Mapped[str] = mapped_column(String(64), nullable=False, default="UNKNOWN")
+    processing_result: Mapped[str] = mapped_column(String(16), nullable=False, default="SUCCEEDED")
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now(), nullable=False)
+
+    snapshot: Mapped[UsLaceyEvidenceSnapshot] = relationship(back_populates="documents")
+
+    __table_args__ = (
+        ForeignKeyConstraint(
+            ["snapshot_id", "organization_id"],
+            ["us_lacey_evidence_snapshots.id", "us_lacey_evidence_snapshots.organization_id"],
+            name="fk_lacey_snapshot_documents_snapshot_tenant",
+            ondelete="CASCADE",
+        ),
+        ForeignKeyConstraint(
+            ["operation_document_id", "organization_id"],
+            ["us_lacey_operation_documents.id", "us_lacey_operation_documents.organization_id"],
+            name="fk_lacey_snapshot_documents_operation_document_tenant",
+            ondelete="RESTRICT",
+        ),
+        ForeignKeyConstraint(
+            ["assurance_document_id", "organization_id"],
+            ["assurance_documents.id", "assurance_documents.organization_id"],
+            name="fk_lacey_snapshot_documents_assurance_tenant",
+            ondelete="RESTRICT",
+        ),
+        ForeignKeyConstraint(
+            ["extraction_run_id", "organization_id"],
+            ["document_extraction_runs.id", "document_extraction_runs.organization_id"],
+            name="fk_lacey_snapshot_documents_extraction_run_tenant",
+            ondelete="RESTRICT",
+        ),
+        UniqueConstraint("id", "organization_id", name="uq_lacey_snapshot_documents_id_org"),
+        UniqueConstraint(
+            "organization_id", "snapshot_id", "operation_document_id",
+            name="uq_lacey_snapshot_documents_member",
+        ),
+        CheckConstraint(
+            "processing_result IN ('SUCCEEDED','FAILED','SKIPPED')",
+            name="ck_lacey_snapshot_documents_result",
+        ),
+        Index("ix_lacey_snapshot_documents_org_snapshot", "organization_id", "snapshot_id"),
+        Index("ix_lacey_snapshot_documents_org_assurance", "organization_id", "assurance_document_id"),
+    )
+
+
+# Add the nullable pointer to the legacy operation mapping without changing the
+# legacy module or runtime behavior.  use_alter mirrors migration 045 and breaks
+# the intentional operation <-> snapshot DDL cycle for fresh metadata creates.
+if "current_evidence_snapshot_id" not in UsLaceyOperation.__table__.c:
+    setattr(
+        UsLaceyOperation,
+        "current_evidence_snapshot_id",
+        mapped_column(Integer, nullable=True),
+    )
+
+if not any(
+    constraint.name == "fk_us_lacey_operations_current_snapshot_tenant"
+    for constraint in UsLaceyOperation.__table__.foreign_key_constraints
+):
+    UsLaceyOperation.__table__.append_constraint(
+        ForeignKeyConstraint(
+            ["current_evidence_snapshot_id", "organization_id"],
+            ["us_lacey_evidence_snapshots.id", "us_lacey_evidence_snapshots.organization_id"],
+            name="fk_us_lacey_operations_current_snapshot_tenant",
+            use_alter=True,
+        )
+    )

--- a/src/litoral_trace/services/translation.py
+++ b/src/litoral_trace/services/translation.py
@@ -1,0 +1,113 @@
+"""Translation-provider abstraction for multilingual evidence processing.
+
+Phase A/B foundation only: no production pipeline imports this module yet.
+Translations are interpretations of immutable source spans and must never be
+counted as independent evidence.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Mapping, Protocol, runtime_checkable
+
+import boto3
+
+
+@dataclass(frozen=True, slots=True)
+class TranslationResult:
+    translated_text: str
+    source_language: str
+    target_language: str
+    provider: str
+    model_name: str
+    model_version: str
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+
+
+@runtime_checkable
+class TranslationProvider(Protocol):
+    def translate(
+        self,
+        text: str,
+        source: str,
+        target: str = "en",
+    ) -> TranslationResult:
+        """Translate one immutable source span without altering source evidence."""
+        ...
+
+
+class NoOpEnglishProvider:
+    """Deterministic provider for already-English source text."""
+
+    provider_name = "NOOP_ENGLISH"
+    model_name = "identity"
+    model_version = "1"
+
+    def translate(
+        self,
+        text: str,
+        source: str,
+        target: str = "en",
+    ) -> TranslationResult:
+        source_norm = (source or "").strip().lower()
+        target_norm = (target or "").strip().lower()
+        if source_norm not in {"en", "eng", "en-us", "en-gb"}:
+            raise ValueError("NoOpEnglishProvider only accepts English source text")
+        if target_norm not in {"en", "eng", "en-us", "en-gb"}:
+            raise ValueError("NoOpEnglishProvider only supports an English target")
+        return TranslationResult(
+            translated_text=text,
+            source_language=source,
+            target_language=target,
+            provider=self.provider_name,
+            model_name=self.model_name,
+            model_version=self.model_version,
+            metadata={"identity_translation": True},
+        )
+
+
+class AwsTranslateProvider:
+    """Lazy AWS Translate adapter prepared for a later feature-flagged rollout.
+
+    The boto3 client is created only on first use. Nothing in the current
+    production extraction path instantiates or calls this provider in this PR.
+    A client may be injected for deterministic tests.
+    """
+
+    provider_name = "AWS_TRANSLATE"
+    model_name = "aws-translate"
+    model_version = "api-v1"
+
+    def __init__(self, *, client: Any | None = None, region_name: str | None = None) -> None:
+        self._client = client
+        self._region_name = region_name
+
+    def _get_client(self) -> Any:
+        if self._client is None:
+            self._client = boto3.client("translate", region_name=self._region_name)
+        return self._client
+
+    def translate(
+        self,
+        text: str,
+        source: str,
+        target: str = "en",
+    ) -> TranslationResult:
+        response = self._get_client().translate_text(
+            Text=text,
+            SourceLanguageCode=source,
+            TargetLanguageCode=target,
+        )
+        translated = str(response.get("TranslatedText") or "")
+        if not translated:
+            raise RuntimeError("AWS Translate returned an empty translation")
+        return TranslationResult(
+            translated_text=translated,
+            source_language=str(response.get("SourceLanguageCode") or source),
+            target_language=str(response.get("TargetLanguageCode") or target),
+            provider=self.provider_name,
+            model_name=self.model_name,
+            model_version=self.model_version,
+            metadata={
+                "applied_terminologies": response.get("AppliedTerminologies") or [],
+            },
+        )

--- a/tests/test_assurance_migration_contract.py
+++ b/tests/test_assurance_migration_contract.py
@@ -116,7 +116,7 @@ def test_us_lacey_owner_admin_follows_lemon_head():
 
 def test_ci_canonical_head_tracks_latest_platform_migration():
     text = Path(".github/workflows/ci.yml").read_text(encoding="utf-8")
-    assert "044_platform_admin_control_plane (head)" in text
+    assert "047_lacey_semantic_graph (head)" in text
 
 
 def test_us_lacey_pilot_activation_follows_portal_auth():

--- a/tests/test_ci_p26a_unittest.py
+++ b/tests/test_ci_p26a_unittest.py
@@ -59,7 +59,7 @@ def test_p26a_ci_runs_pytest_and_disables_postgres_integration():
 def test_p26a_ci_checks_single_canonical_alembic_head():
     workflow = _workflow_text()
     assert "alembic heads" in workflow
-    assert "044_platform_admin_control_plane (head)" in workflow
+    assert "047_lacey_semantic_graph (head)" in workflow
     assert "alembic upgrade head" not in workflow
 
 

--- a/tests/test_us_lacey_multilingual_snapshot_schema.py
+++ b/tests/test_us_lacey_multilingual_snapshot_schema.py
@@ -1,0 +1,299 @@
+"""Schema-only acceptance for multilingual evidence foundations (045-047)."""
+from __future__ import annotations
+
+import hashlib
+from uuid import uuid4
+
+import pytest
+from sqlalchemy import inspect
+from sqlalchemy.exc import IntegrityError
+
+from litoral_trace.db.models import (
+    DocumentExtractionRun,
+    DocumentTextSpan,
+    DocumentTextTranslation,
+    SemanticEvidenceEdge,
+    SemanticEvidenceNode,
+    SemanticSnapshotNode,
+    UsLaceyEvidenceSnapshot,
+    UsLaceyEvidenceSnapshotDocument,
+    UsLaceyOperation,
+)
+from litoral_trace.services.translation import (
+    AwsTranslateProvider,
+    NoOpEnglishProvider,
+    TranslationProvider,
+)
+from tests.us_lacey_engine2_postgres import (
+    create_test_graph,
+    engine2_postgres_engine,
+    engine2_postgres_session_factory,
+    tenant_session,
+)
+
+
+def test_schema_models_expose_snapshot_provenance_contract():
+    assert "current_evidence_snapshot_id" in UsLaceyOperation.__table__.c
+    assert {
+        "us_lacey_evidence_snapshots",
+        "us_lacey_evidence_snapshot_documents",
+        "document_text_spans",
+        "document_text_translations",
+        "semantic_evidence_nodes",
+        "semantic_snapshot_nodes",
+        "semantic_evidence_edges",
+    } <= {
+        UsLaceyEvidenceSnapshot.__tablename__,
+        UsLaceyEvidenceSnapshotDocument.__tablename__,
+        DocumentTextSpan.__tablename__,
+        DocumentTextTranslation.__tablename__,
+        SemanticEvidenceNode.__tablename__,
+        SemanticSnapshotNode.__tablename__,
+        SemanticEvidenceEdge.__tablename__,
+    }
+    current_fk = next(
+        item
+        for item in UsLaceyOperation.__table__.foreign_key_constraints
+        if item.name == "fk_us_lacey_operations_current_snapshot_tenant"
+    )
+    assert {column.name for column in current_fk.columns} == {
+        "current_evidence_snapshot_id",
+        "organization_id",
+    }
+    assert "documents" in UsLaceyEvidenceSnapshot.__mapper__.relationships
+    assert "translations" in DocumentTextSpan.__mapper__.relationships
+    assert "evidence_nodes" in DocumentTextSpan.__mapper__.relationships
+    assert "snapshot_links" in SemanticEvidenceNode.__mapper__.relationships
+
+
+def test_noop_english_translation_is_identity_and_protocol_compatible():
+    provider = NoOpEnglishProvider()
+    assert isinstance(provider, TranslationProvider)
+    result = provider.translate("Country of harvest", "en", "en")
+    assert result.translated_text == "Country of harvest"
+    assert result.provider == "NOOP_ENGLISH"
+    assert result.metadata["identity_translation"] is True
+    with pytest.raises(ValueError):
+        provider.translate("País de cosecha", "es", "en")
+
+
+class _FakeAwsTranslateClient:
+    def translate_text(self, **kwargs):
+        assert kwargs == {
+            "Text": "País de cosecha",
+            "SourceLanguageCode": "es",
+            "TargetLanguageCode": "en",
+        }
+        return {
+            "TranslatedText": "Country of harvest",
+            "SourceLanguageCode": "es",
+            "TargetLanguageCode": "en",
+            "AppliedTerminologies": [],
+        }
+
+
+def test_aws_translation_provider_is_lazy_and_injectable():
+    provider = AwsTranslateProvider(client=_FakeAwsTranslateClient())
+    result = provider.translate("País de cosecha", "es", "en")
+    assert (result.translated_text, result.provider) == (
+        "Country of harvest",
+        "AWS_TRANSLATE",
+    )
+
+
+def test_new_tables_persist_relationships_and_enforce_tenant_fks_and_uniqueness(
+    engine2_postgres_engine,
+    engine2_postgres_session_factory,
+):
+    required = {
+        "us_lacey_evidence_snapshots",
+        "us_lacey_evidence_snapshot_documents",
+        "document_text_spans",
+        "document_text_translations",
+        "semantic_evidence_nodes",
+        "semantic_snapshot_nodes",
+        "semantic_evidence_edges",
+    }
+    if not required.issubset(inspect(engine2_postgres_engine).get_table_names()):
+        pytest.skip("POSTGRES_SCHEMA_NOT_MIGRATED_TO_047")
+
+    org, operation_id, operation_document_id, assurance_id, _, source_sha = create_test_graph(
+        engine2_postgres_session_factory,
+        content=b"multilingual-schema-a",
+    )
+    other_org, _, other_operation_document_id, _, _, _ = create_test_graph(
+        engine2_postgres_session_factory,
+        content=b"multilingual-schema-b",
+    )
+    assert other_org != org
+
+    session = tenant_session(engine2_postgres_session_factory, org)
+    extraction = DocumentExtractionRun(
+        organization_id=org,
+        assurance_document_id=assurance_id,
+        engine="schema-test",
+        engine_version="1",
+        status="SUCCEEDED",
+    )
+    session.add(extraction)
+    session.flush()
+
+    fingerprint = hashlib.sha256(uuid4().bytes).hexdigest()
+    snapshot = UsLaceyEvidenceSnapshot(
+        organization_id=org,
+        operation_id=operation_id,
+        generation=1,
+        status="CURRENT",
+        source_set_fingerprint=fingerprint,
+        graph_version="semantic-graph-v2",
+        ontology_version="ontology-v1",
+        translation_pipeline_version="translation-v1",
+        document_count=1,
+    )
+    session.add(snapshot)
+    session.flush()
+
+    membership = UsLaceyEvidenceSnapshotDocument(
+        organization_id=org,
+        snapshot_id=snapshot.id,
+        operation_document_id=operation_document_id,
+        assurance_document_id=assurance_id,
+        extraction_run_id=extraction.id,
+        source_sha256=source_sha,
+        document_role="SUPPLIER_DECLARATION",
+        processing_result="SUCCEEDED",
+    )
+    session.add(membership)
+
+    source_text = "País de cosecha"
+    span = DocumentTextSpan(
+        organization_id=org,
+        assurance_document_id=assurance_id,
+        extraction_run_id=extraction.id,
+        page=1,
+        block_id="table-1-row-1-col-4",
+        table_id="table-1",
+        row_index=1,
+        column_index=4,
+        original_text=source_text,
+        original_language="es",
+        language_confidence=0.99,
+        extraction_method="NATIVE_TEXT",
+        content_hash=hashlib.sha256(source_text.encode()).hexdigest(),
+    )
+    session.add(span)
+    session.flush()
+
+    translation = DocumentTextTranslation(
+        organization_id=org,
+        source_span_id=span.id,
+        source_language="es",
+        target_language="en",
+        translated_text="Country of harvest",
+        provider="TEST",
+        model_name="deterministic",
+        model_version="1",
+        input_hash=hashlib.sha256(source_text.encode()).hexdigest(),
+        output_hash=hashlib.sha256(b"Country of harvest").hexdigest(),
+    )
+    node = SemanticEvidenceNode(
+        organization_id=org,
+        assurance_document_id=assurance_id,
+        extraction_run_id=extraction.id,
+        source_span_id=span.id,
+        target_field="country_of_harvest",
+        semantic_role="COUNTRY_OF_HARVEST",
+        scope="PLANT_COMPONENT",
+        local_entity_key=f"{assurance_id}:table-1:row:1",
+        original_value="Argentina",
+        normalized_value="ARGENTINA",
+        evidence_class="EXPLICIT",
+        document_type="SUPPLIER_DECLARATION",
+        extraction_confidence=0.99,
+        authority_score=45.0,
+        candidate_score=92.0,
+        fingerprint=hashlib.sha256(b"node-a" + uuid4().bytes).hexdigest(),
+    )
+    session.add_all((translation, node))
+    session.flush()
+
+    link = SemanticSnapshotNode(
+        organization_id=org,
+        snapshot_id=snapshot.id,
+        evidence_node_id=node.id,
+        canonical_entity_id="PLANT_COMPONENT:1",
+    )
+    node2 = SemanticEvidenceNode(
+        organization_id=org,
+        assurance_document_id=assurance_id,
+        extraction_run_id=extraction.id,
+        source_span_id=span.id,
+        target_field="country_of_harvest",
+        semantic_role="COUNTRY_OF_HARVEST",
+        scope="PLANT_COMPONENT",
+        local_entity_key=f"{assurance_id}:table-1:row:1",
+        original_value="Argentina",
+        normalized_value="ARGENTINA",
+        evidence_class="EXPLICIT",
+        document_type="SUPPLIER_DECLARATION",
+        extraction_confidence=0.95,
+        authority_score=45.0,
+        candidate_score=90.0,
+        fingerprint=hashlib.sha256(b"node-b" + uuid4().bytes).hexdigest(),
+    )
+    session.add_all((link, node2))
+    session.flush()
+    edge = SemanticEvidenceEdge(
+        organization_id=org,
+        snapshot_id=snapshot.id,
+        from_node_id=node.id,
+        to_node_id=node2.id,
+        relation_type="CORROBORATES",
+        confidence=0.98,
+        reason_code="TEST_CORROBORATION",
+    )
+    session.add(edge)
+    session.query(UsLaceyOperation).filter_by(id=operation_id).update(
+        {"current_evidence_snapshot_id": snapshot.id}
+    )
+    session.commit()
+
+    persisted = session.query(UsLaceyEvidenceSnapshot).filter_by(id=snapshot.id).one()
+    assert persisted.documents[0].extraction_run_id == extraction.id
+    assert persisted.snapshot_nodes[0].canonical_entity_id == "PLANT_COMPONENT:1"
+    assert persisted.edges[0].relation_type == "CORROBORATES"
+    assert session.query(DocumentTextSpan).filter_by(id=span.id).one().translations[0].translated_text == "Country of harvest"
+    assert session.query(UsLaceyOperation).filter_by(id=operation_id).one().current_evidence_snapshot_id == snapshot.id
+
+    session.add(
+        UsLaceyEvidenceSnapshot(
+            organization_id=org,
+            operation_id=operation_id,
+            generation=1,
+            status="BUILDING",
+            source_set_fingerprint=hashlib.sha256(uuid4().bytes).hexdigest(),
+            graph_version="x",
+            ontology_version="x",
+            translation_pipeline_version="x",
+        )
+    )
+    with pytest.raises(IntegrityError):
+        session.commit()
+    session.rollback()
+
+    session.add(
+        UsLaceyEvidenceSnapshotDocument(
+            organization_id=org,
+            snapshot_id=snapshot.id,
+            operation_document_id=other_operation_document_id,
+            assurance_document_id=assurance_id,
+            extraction_run_id=extraction.id,
+            source_sha256=source_sha,
+            document_role="UNKNOWN",
+            processing_result="SUCCEEDED",
+        )
+    )
+    with pytest.raises(IntegrityError):
+        session.commit()
+    session.rollback()
+    session.close()


### PR DESCRIPTION
## Scope
Phase A infrastructure only for Multilingual Evidence & Multi-Document Intelligence.

- Alembic 045: immutable evidence snapshots + exact snapshot-document membership + nullable operation pointer.
- Alembic 046: immutable original text spans + translation provenance.
- Alembic 047: persistent semantic evidence nodes, snapshot membership/canonical entity mapping, and semantic edges.
- Tenant-scoped composite foreign keys and FORCE RLS on all new tables.
- SQLAlchemy relationships for snapshots/documents, spans/translations, spans/nodes, snapshot/node memberships and graph edges.
- TranslationProvider protocol with NoOpEnglishProvider and lazy/injectable AwsTranslateProvider.
- Focused unit/PostgreSQL acceptance tests for metadata, relationships, uniqueness, tenant FK isolation and provider behavior.

## Non-goals / safety boundary
- No extraction, projection, review, HTMX, PPQ or production pipeline behavior changes.
- No translation provider is instantiated by the live path.
- Existing operations keep `current_evidence_snapshot_id = NULL` until a later rollout phase.
