### PR TITLE
feat(us-lacey): multilingual evidence shadow dual-write

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -18,6 +18,7 @@ ocrmypdf>=17.10,<18
 rapidfuzz>=3.14,<4
 dateparser>=1.2,<2
 price-parser>=0.5,<1
+lingua-language-detector>=2.0,<3
 plotly>=5.18.0
 sqlalchemy>=2.0.0
 psycopg[binary]

--- a/src/litoral_trace/us_lacey/shadow_evidence_snapshot.py
+++ b/src/litoral_trace/us_lacey/shadow_evidence_snapshot.py
@@ -1,0 +1,704 @@
+"""Shadow multilingual evidence snapshots for the U.S. Lacey pilot.
+
+This module is deliberately write-only with respect to the new Phase A schema.
+The legacy Assurance/U.S. Lacey projection remains authoritative. A failure here
+must never mutate legacy job state or become a prerequisite for the UI.
+"""
+from __future__ import annotations
+
+from contextlib import AbstractContextManager
+from dataclasses import asdict, dataclass
+from datetime import datetime, timezone
+from functools import lru_cache
+import hashlib
+import json
+import logging
+import os
+from typing import Callable, Mapping
+
+from lingua import Language, LanguageDetectorBuilder
+from sqlalchemy import and_, func, select
+from sqlalchemy.orm import Session
+
+from litoral_trace.db.models import (
+    AssuranceDocument,
+    DocumentExtractionRun,
+    DocumentTextSpan,
+    DocumentTextTranslation,
+    ExtractedDocumentField,
+    SemanticEvidenceNode,
+    SemanticSnapshotNode,
+    UsLaceyEvidenceSnapshot,
+    UsLaceyEvidenceSnapshotDocument,
+    UsLaceyOperation,
+    UsLaceyOperationDocument,
+    VaultDocument,
+)
+from litoral_trace.db.tenant import set_tenant_db_context
+from litoral_trace.services.translation import (
+    AwsTranslateProvider,
+    NoOpEnglishProvider,
+    TranslationProvider,
+)
+from litoral_trace.us_lacey.db import get_us_lacey_db_session
+from litoral_trace.us_lacey.operation_lock import us_lacey_operation_projection_lock
+
+
+LOGGER = logging.getLogger(__name__)
+
+SHADOW_FLAG = "LT_LACEY_MULTILINGUAL_SHADOW"
+TRANSLATION_PROVIDER_ENV = "LT_LACEY_TRANSLATION_PROVIDER"
+TRANSLATION_AWS_REGION_ENV = "LT_LACEY_TRANSLATION_AWS_REGION"
+GRAPH_VERSION = "semantic-evidence-shadow-v1"
+ONTOLOGY_VERSION = "legacy-adapter-v1"
+TRANSLATION_PIPELINE_VERSION = "multilingual-shadow-v1"
+
+SessionFactory = Callable[[], Session]
+LockFactory = Callable[..., AbstractContextManager[None]]
+
+
+class ShadowEvidenceSnapshotError(RuntimeError):
+    """A shadow-only failure. Callers must isolate it from the legacy job state."""
+
+
+@dataclass(frozen=True, slots=True)
+class LanguageDetection:
+    code: str
+    confidence: float
+
+
+@dataclass(slots=True)
+class SnapshotMetrics:
+    generation: int = 0
+    documents_included: int = 0
+    spans_created: int = 0
+    spans_without_page: int = 0
+    language_en: int = 0
+    language_es: int = 0
+    language_pt: int = 0
+    language_zh: int = 0
+    language_und: int = 0
+    translations_created: int = 0
+    translations_omitted: int = 0
+    semantic_nodes_created: int = 0
+
+    def count_language(self, code: str) -> None:
+        attr = f"language_{code if code in {'en', 'es', 'pt', 'zh'} else 'und'}"
+        setattr(self, attr, int(getattr(self, attr)) + 1)
+
+    def as_dict(self) -> dict[str, int]:
+        return {key: int(value) for key, value in asdict(self).items()}
+
+
+@dataclass(frozen=True, slots=True)
+class SnapshotBuildResult:
+    created: bool
+    snapshot_id: int | None
+    source_set_fingerprint: str | None
+    reason: str
+    metrics: SnapshotMetrics
+
+
+@dataclass(frozen=True, slots=True)
+class _DocumentSource:
+    operation_document_id: int
+    assurance_document_id: int
+    extraction_run_id: int
+    source_sha256: str
+    document_role: str
+    document_type: str
+    version_number: int
+
+
+_LANGUAGE_TO_CODE: Mapping[Language, str] = {
+    Language.ENGLISH: "en",
+    Language.SPANISH: "es",
+    Language.PORTUGUESE: "pt",
+    Language.CHINESE: "zh",
+}
+
+
+@lru_cache(maxsize=1)
+def _language_detector():
+    return LanguageDetectorBuilder.from_languages(
+        Language.ENGLISH,
+        Language.SPANISH,
+        Language.PORTUGUESE,
+        Language.CHINESE,
+    ).build()
+
+
+def multilingual_shadow_enabled(environ: Mapping[str, str] | None = None) -> bool:
+    env = os.environ if environ is None else environ
+    return str(env.get(SHADOW_FLAG, "0")).strip().lower() in {
+        "1",
+        "true",
+        "yes",
+        "on",
+        "enabled",
+    }
+
+
+def _is_substantive_text(text: str) -> bool:
+    value = str(text or "").strip()
+    if len(value) < 6:
+        return False
+    if all(ch.isdigit() or ch.isspace() or ch in ".,;:/%$€¥+-_#()[]" for ch in value):
+        return False
+    cjk_count = sum("\u4e00" <= ch <= "\u9fff" for ch in value)
+    if cjk_count >= 4:
+        return True
+    words = []
+    current: list[str] = []
+    for char in value:
+        if char.isalpha():
+            current.append(char)
+        elif current:
+            words.append("".join(current))
+            current = []
+    if current:
+        words.append("".join(current))
+    alpha_count = sum(len(word) for word in words)
+    return len(words) >= 2 and alpha_count >= 6
+
+
+def detect_supported_language(text: str) -> LanguageDetection:
+    """Detect only EN/ES/PT/ZH; codes, numbers and short fragments stay ``und``."""
+    if not _is_substantive_text(text):
+        return LanguageDetection(code="und", confidence=0.0)
+    detector = _language_detector()
+    detected = detector.detect_language_of(text)
+    code = _LANGUAGE_TO_CODE.get(detected, "und")
+    if code == "und" or detected is None:
+        return LanguageDetection(code="und", confidence=0.0)
+    confidence = 0.0
+    try:
+        for item in detector.compute_language_confidence_values(text):
+            if item.language == detected:
+                confidence = float(item.value)
+                break
+    except Exception:
+        confidence = 0.0
+    return LanguageDetection(code=code, confidence=max(0.0, min(1.0, confidence)))
+
+
+def configured_translation_provider() -> TranslationProvider | None:
+    provider = str(os.environ.get(TRANSLATION_PROVIDER_ENV, "")).strip().upper()
+    if provider in {"", "NONE", "DISABLED", "OFF"}:
+        return None
+    if provider in {"AWS", "AWS_TRANSLATE"}:
+        region = str(os.environ.get(TRANSLATION_AWS_REGION_ENV, "")).strip() or None
+        return AwsTranslateProvider(region_name=region)
+    raise ShadowEvidenceSnapshotError(
+        f"Unsupported {TRANSLATION_PROVIDER_ENV} value: {provider}"
+    )
+
+
+def _sha256_text(value: str) -> str:
+    return hashlib.sha256(value.encode("utf-8")).hexdigest()
+
+
+def _source_set_fingerprint(sources: list[_DocumentSource]) -> str:
+    payload = [
+        {
+            "operation_document_id": item.operation_document_id,
+            "assurance_document_id": item.assurance_document_id,
+            "source_sha256": item.source_sha256,
+            "version_number": item.version_number,
+        }
+        for item in sorted(sources, key=lambda source: source.operation_document_id)
+    ]
+    canonical = json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=True)
+    return _sha256_text(canonical)
+
+
+def _bounded(value: str, limit: int) -> str:
+    text = str(value or "")
+    if len(text) <= limit:
+        return text
+    digest = _sha256_text(text)[:12]
+    keep = max(1, limit - len(digest) - 1)
+    return f"{text[:keep]}:{digest}"
+
+
+def _target_field(field_name: str) -> str:
+    return _bounded(field_name or "unknown", 100)
+
+
+def _semantic_role(field_name: str) -> str:
+    normalized = "".join(
+        char if char.isalnum() else "_" for char in str(field_name or "unknown").upper()
+    )
+    normalized = "_".join(part for part in normalized.split("_") if part)
+    return _bounded(normalized or "UNKNOWN", 100)
+
+
+def _semantic_scope(field_name: str) -> str:
+    name = str(field_name or "").lower()
+    if any(token in name for token in ("genus", "species", "harvest", "plant", "quantity", "percent_recycled")):
+        return "PLANT_COMPONENT"
+    if name.startswith("raw."):
+        return "DOCUMENT"
+    return "SHIPMENT"
+
+
+def _local_entity_key(*, assurance_document_id: int, field: ExtractedDocumentField) -> str:
+    locator = str(field.source_locator or f"field:{field.id}")
+    return _bounded(f"doc:{assurance_document_id}:{locator}", 512)
+
+
+def _node_fingerprint(
+    *,
+    assurance_document_id: int,
+    extraction_run_id: int,
+    field: ExtractedDocumentField,
+    span: DocumentTextSpan,
+) -> str:
+    payload = "|".join(
+        (
+            str(assurance_document_id),
+            str(extraction_run_id),
+            str(field.id),
+            str(field.field_name),
+            str(span.content_hash),
+        )
+    )
+    return _sha256_text(payload)
+
+
+def _translate_span_if_eligible(
+    *,
+    span: DocumentTextSpan,
+    provider: TranslationProvider | None,
+    metrics: SnapshotMetrics,
+    session: Session,
+) -> None:
+    language = str(span.original_language or "und")
+    if language in {"en", "und"}:
+        return
+    if provider is None or isinstance(provider, NoOpEnglishProvider):
+        metrics.translations_omitted += 1
+        return
+    try:
+        result = provider.translate(span.original_text, language, "en")
+        translated_text = str(result.translated_text or "").strip()
+        if not translated_text:
+            metrics.translations_omitted += 1
+            return
+        input_hash = _sha256_text(span.original_text)
+        existing = session.scalar(
+            select(DocumentTextTranslation).where(
+                DocumentTextTranslation.organization_id == span.organization_id,
+                DocumentTextTranslation.source_span_id == span.id,
+                DocumentTextTranslation.target_language == "en",
+                DocumentTextTranslation.provider == result.provider,
+                DocumentTextTranslation.model_name == result.model_name,
+                DocumentTextTranslation.model_version == result.model_version,
+                DocumentTextTranslation.input_hash == input_hash,
+            )
+        )
+        if existing is not None:
+            return
+        quality = result.metadata.get("quality_score") if result.metadata else None
+        quality_score = float(quality) if isinstance(quality, (int, float)) else None
+        session.add(
+            DocumentTextTranslation(
+                organization_id=span.organization_id,
+                source_span_id=span.id,
+                source_language=language,
+                target_language="en",
+                translated_text=translated_text,
+                provider=result.provider,
+                model_name=result.model_name,
+                model_version=result.model_version,
+                quality_score=quality_score,
+                input_hash=input_hash,
+                output_hash=_sha256_text(translated_text),
+            )
+        )
+        metrics.translations_created += 1
+    except Exception:
+        metrics.translations_omitted += 1
+        LOGGER.warning(
+            "Lacey multilingual shadow translation failed; original evidence retained",
+            exc_info=True,
+            extra={
+                "organization_id": span.organization_id,
+                "assurance_document_id": span.assurance_document_id,
+                "source_span_id": span.id,
+                "source_language": language,
+            },
+        )
+
+
+def _load_document_sources(
+    session: Session,
+    *,
+    organization_id: int,
+    operation_id: int,
+) -> tuple[list[_DocumentSource], str | None]:
+    rows = session.execute(
+        select(UsLaceyOperationDocument, AssuranceDocument, VaultDocument)
+        .join(
+            AssuranceDocument,
+            and_(
+                AssuranceDocument.id == UsLaceyOperationDocument.assurance_document_id,
+                AssuranceDocument.organization_id == UsLaceyOperationDocument.organization_id,
+            ),
+        )
+        .join(
+            VaultDocument,
+            and_(
+                VaultDocument.id == AssuranceDocument.vault_document_id,
+                VaultDocument.organization_id == AssuranceDocument.organization_id,
+            ),
+        )
+        .where(
+            UsLaceyOperationDocument.organization_id == organization_id,
+            UsLaceyOperationDocument.operation_id == operation_id,
+            UsLaceyOperationDocument.is_current.is_(True),
+            VaultDocument.status == "available",
+        )
+        .order_by(UsLaceyOperationDocument.id.asc())
+    ).all()
+    if not rows:
+        return [], "NO_CURRENT_DOCUMENTS"
+
+    sources: list[_DocumentSource] = []
+    for operation_document, assurance_document, vault_document in rows:
+        extraction_run = session.scalar(
+            select(DocumentExtractionRun)
+            .where(
+                DocumentExtractionRun.organization_id == organization_id,
+                DocumentExtractionRun.assurance_document_id == assurance_document.id,
+                DocumentExtractionRun.status == "SUCCEEDED",
+            )
+            .order_by(DocumentExtractionRun.id.desc())
+            .limit(1)
+        )
+        if extraction_run is None:
+            return [], "SOURCE_SET_NOT_FULLY_EXTRACTED"
+        sources.append(
+            _DocumentSource(
+                operation_document_id=operation_document.id,
+                assurance_document_id=assurance_document.id,
+                extraction_run_id=extraction_run.id,
+                source_sha256=vault_document.sha256,
+                document_role=operation_document.document_role,
+                document_type=assurance_document.semantic_document_type,
+                version_number=operation_document.version_number,
+            )
+        )
+    return sources, None
+
+
+def _log_metrics(
+    *,
+    organization_id: int,
+    operation_id: int,
+    fingerprint: str | None,
+    reason: str,
+    metrics: SnapshotMetrics,
+) -> None:
+    data = metrics.as_dict()
+    LOGGER.info(
+        "Lacey multilingual shadow metrics generation=%s documents_included=%s "
+        "spans_created=%s spans_without_page=%s en=%s es=%s pt=%s zh=%s und=%s "
+        "translations_created=%s translations_omitted=%s semantic_nodes_created=%s reason=%s",
+        data["generation"],
+        data["documents_included"],
+        data["spans_created"],
+        data["spans_without_page"],
+        data["language_en"],
+        data["language_es"],
+        data["language_pt"],
+        data["language_zh"],
+        data["language_und"],
+        data["translations_created"],
+        data["translations_omitted"],
+        data["semantic_nodes_created"],
+        reason,
+        extra={
+            "organization_id": organization_id,
+            "operation_id": operation_id,
+            "source_set_fingerprint": fingerprint,
+            "shadow_metrics": data,
+            "shadow_reason": reason,
+        },
+    )
+
+
+def build_shadow_evidence_snapshot(
+    *,
+    organization_id: int,
+    operation_id: int,
+    translation_provider: TranslationProvider | None = None,
+    use_configured_translation_provider: bool = True,
+    session_factory: SessionFactory = get_us_lacey_db_session,
+    lock_factory: LockFactory = us_lacey_operation_projection_lock,
+) -> SnapshotBuildResult:
+    """Build one operation-wide shadow snapshot without affecting legacy state.
+
+    The operation advisory lock serializes same-operation builds. The snapshot,
+    memberships, spans, translations, semantic nodes, CURRENT/SUPERSEDED transition
+    and operation pointer are committed in one database transaction.
+    """
+    org_id = int(organization_id)
+    op_id = int(operation_id)
+    metrics = SnapshotMetrics()
+    if not multilingual_shadow_enabled():
+        result = SnapshotBuildResult(False, None, None, "DISABLED", metrics)
+        _log_metrics(
+            organization_id=org_id,
+            operation_id=op_id,
+            fingerprint=None,
+            reason=result.reason,
+            metrics=metrics,
+        )
+        return result
+
+    provider = translation_provider
+    if provider is None and use_configured_translation_provider:
+        provider = configured_translation_provider()
+
+    with lock_factory(organization_id=org_id, operation_id=op_id):
+        session = session_factory()
+        try:
+            set_tenant_db_context(session, org_id)
+            operation = session.scalar(
+                select(UsLaceyOperation)
+                .where(
+                    UsLaceyOperation.organization_id == org_id,
+                    UsLaceyOperation.id == op_id,
+                )
+                .with_for_update()
+            )
+            if operation is None:
+                raise ShadowEvidenceSnapshotError("U.S. Lacey operation not found in tenant scope")
+
+            sources, blocked_reason = _load_document_sources(
+                session,
+                organization_id=org_id,
+                operation_id=op_id,
+            )
+            metrics.documents_included = len(sources)
+            if blocked_reason is not None:
+                session.rollback()
+                result = SnapshotBuildResult(False, None, None, blocked_reason, metrics)
+                _log_metrics(
+                    organization_id=org_id,
+                    operation_id=op_id,
+                    fingerprint=None,
+                    reason=result.reason,
+                    metrics=metrics,
+                )
+                return result
+
+            fingerprint = _source_set_fingerprint(sources)
+            existing = session.scalar(
+                select(UsLaceyEvidenceSnapshot).where(
+                    UsLaceyEvidenceSnapshot.organization_id == org_id,
+                    UsLaceyEvidenceSnapshot.operation_id == op_id,
+                    UsLaceyEvidenceSnapshot.source_set_fingerprint == fingerprint,
+                )
+            )
+            if existing is not None and existing.status == "CURRENT":
+                metrics.generation = existing.generation
+                session.rollback()
+                result = SnapshotBuildResult(
+                    False,
+                    existing.id,
+                    fingerprint,
+                    "IDEMPOTENT_CURRENT",
+                    metrics,
+                )
+                _log_metrics(
+                    organization_id=org_id,
+                    operation_id=op_id,
+                    fingerprint=fingerprint,
+                    reason=result.reason,
+                    metrics=metrics,
+                )
+                return result
+            if existing is not None:
+                raise ShadowEvidenceSnapshotError(
+                    f"Non-current snapshot already owns source fingerprint ({existing.status})"
+                )
+
+            generation = int(
+                session.scalar(
+                    select(func.coalesce(func.max(UsLaceyEvidenceSnapshot.generation), 0)).where(
+                        UsLaceyEvidenceSnapshot.organization_id == org_id,
+                        UsLaceyEvidenceSnapshot.operation_id == op_id,
+                    )
+                )
+                or 0
+            ) + 1
+            metrics.generation = generation
+
+            snapshot = UsLaceyEvidenceSnapshot(
+                organization_id=org_id,
+                operation_id=op_id,
+                generation=generation,
+                status="BUILDING",
+                source_set_fingerprint=fingerprint,
+                graph_version=GRAPH_VERSION,
+                ontology_version=ONTOLOGY_VERSION,
+                translation_pipeline_version=TRANSLATION_PIPELINE_VERSION,
+                document_count=len(sources),
+                node_count=0,
+                conflict_count=0,
+            )
+            session.add(snapshot)
+            session.flush()
+
+            snapshot_node_count = 0
+            for source in sources:
+                session.add(
+                    UsLaceyEvidenceSnapshotDocument(
+                        organization_id=org_id,
+                        snapshot_id=snapshot.id,
+                        operation_document_id=source.operation_document_id,
+                        assurance_document_id=source.assurance_document_id,
+                        extraction_run_id=source.extraction_run_id,
+                        source_sha256=source.source_sha256,
+                        document_role=source.document_role,
+                        processing_result="SUCCEEDED",
+                    )
+                )
+                fields = session.scalars(
+                    select(ExtractedDocumentField)
+                    .where(
+                        ExtractedDocumentField.organization_id == org_id,
+                        ExtractedDocumentField.assurance_document_id == source.assurance_document_id,
+                        ExtractedDocumentField.extraction_run_id == source.extraction_run_id,
+                    )
+                    .order_by(ExtractedDocumentField.id.asc())
+                ).all()
+                for field in fields:
+                    original_text = str(field.original_value or "").strip()
+                    if field.source_page is None or int(field.source_page) <= 0:
+                        metrics.spans_without_page += 1
+                        continue
+                    if not original_text:
+                        continue
+
+                    block_id = f"legacy-field:{field.id}"
+                    span = session.scalar(
+                        select(DocumentTextSpan).where(
+                            DocumentTextSpan.organization_id == org_id,
+                            DocumentTextSpan.assurance_document_id == source.assurance_document_id,
+                            DocumentTextSpan.extraction_run_id == source.extraction_run_id,
+                            DocumentTextSpan.block_id == block_id,
+                        )
+                    )
+                    if span is None:
+                        detection = detect_supported_language(original_text)
+                        metrics.count_language(detection.code)
+                        span = DocumentTextSpan(
+                            organization_id=org_id,
+                            assurance_document_id=source.assurance_document_id,
+                            extraction_run_id=source.extraction_run_id,
+                            page=int(field.source_page),
+                            block_id=block_id,
+                            source_locator=field.source_locator,
+                            original_text=original_text,
+                            original_language=detection.code,
+                            language_confidence=detection.confidence,
+                            extraction_method="LEGACY_ADAPTER",
+                            content_hash=_sha256_text(original_text),
+                        )
+                        session.add(span)
+                        session.flush()
+                        metrics.spans_created += 1
+                    else:
+                        metrics.count_language(span.original_language)
+
+                    _translate_span_if_eligible(
+                        span=span,
+                        provider=provider,
+                        metrics=metrics,
+                        session=session,
+                    )
+
+                    fingerprint_node = _node_fingerprint(
+                        assurance_document_id=source.assurance_document_id,
+                        extraction_run_id=source.extraction_run_id,
+                        field=field,
+                        span=span,
+                    )
+                    node = session.scalar(
+                        select(SemanticEvidenceNode).where(
+                            SemanticEvidenceNode.organization_id == org_id,
+                            SemanticEvidenceNode.fingerprint == fingerprint_node,
+                        )
+                    )
+                    if node is None:
+                        confidence = max(0.0, min(1.0, float(field.confidence or 0.0)))
+                        score = confidence * 100.0
+                        node = SemanticEvidenceNode(
+                            organization_id=org_id,
+                            assurance_document_id=source.assurance_document_id,
+                            extraction_run_id=source.extraction_run_id,
+                            source_span_id=span.id,
+                            target_field=_target_field(field.field_name),
+                            semantic_role=_semantic_role(field.field_name),
+                            scope=_semantic_scope(field.field_name),
+                            local_entity_key=_local_entity_key(
+                                assurance_document_id=source.assurance_document_id,
+                                field=field,
+                            ),
+                            original_value=original_text,
+                            normalized_value=field.normalized_value,
+                            evidence_class="EXPLICIT",
+                            document_type=source.document_type or "UNKNOWN",
+                            extraction_confidence=confidence,
+                            authority_score=score,
+                            candidate_score=score,
+                            fingerprint=fingerprint_node,
+                        )
+                        session.add(node)
+                        session.flush()
+                        metrics.semantic_nodes_created += 1
+
+                    session.add(
+                        SemanticSnapshotNode(
+                            organization_id=org_id,
+                            snapshot_id=snapshot.id,
+                            evidence_node_id=node.id,
+                            canonical_entity_id=None,
+                        )
+                    )
+                    snapshot_node_count += 1
+
+            snapshot.node_count = snapshot_node_count
+            snapshot.conflict_count = 0
+            current_snapshots = session.scalars(
+                select(UsLaceyEvidenceSnapshot).where(
+                    UsLaceyEvidenceSnapshot.organization_id == org_id,
+                    UsLaceyEvidenceSnapshot.operation_id == op_id,
+                    UsLaceyEvidenceSnapshot.status == "CURRENT",
+                    UsLaceyEvidenceSnapshot.id != snapshot.id,
+                )
+            ).all()
+            for previous in current_snapshots:
+                previous.status = "SUPERSEDED"
+            snapshot.status = "CURRENT"
+            snapshot.finalized_at = datetime.now(timezone.utc)
+            operation.current_evidence_snapshot_id = snapshot.id
+            session.commit()
+
+            result = SnapshotBuildResult(True, snapshot.id, fingerprint, "CREATED", metrics)
+            _log_metrics(
+                organization_id=org_id,
+                operation_id=op_id,
+                fingerprint=fingerprint,
+                reason=result.reason,
+                metrics=metrics,
+            )
+            return result
+        except Exception:
+            session.rollback()
+            raise
+        finally:
+            session.close()

--- a/src/litoral_trace/us_lacey/shadow_evidence_snapshot.py
+++ b/src/litoral_trace/us_lacey/shadow_evidence_snapshot.py
@@ -337,6 +337,7 @@ def _load_document_sources(
     organization_id: int,
     operation_id: int,
 ) -> tuple[list[_DocumentSource], str | None]:
+    """Return the complete current source set or refuse to build a partial snapshot."""
     rows = session.execute(
         select(UsLaceyOperationDocument, AssuranceDocument, VaultDocument)
         .join(
@@ -357,7 +358,6 @@ def _load_document_sources(
             UsLaceyOperationDocument.organization_id == organization_id,
             UsLaceyOperationDocument.operation_id == operation_id,
             UsLaceyOperationDocument.is_current.is_(True),
-            VaultDocument.status == "available",
         )
         .order_by(UsLaceyOperationDocument.id.asc())
     ).all()
@@ -366,6 +366,8 @@ def _load_document_sources(
 
     sources: list[_DocumentSource] = []
     for operation_document, assurance_document, vault_document in rows:
+        if vault_document.status != "available":
+            return [], "SOURCE_SET_NOT_FULLY_AVAILABLE"
         extraction_run = session.scalar(
             select(DocumentExtractionRun)
             .where(

--- a/src/litoral_trace/us_lacey/worker.py
+++ b/src/litoral_trace/us_lacey/worker.py
@@ -35,6 +35,10 @@ from litoral_trace.us_lacey.projection import (
     refresh_us_lacey_operation_status,
 )
 from litoral_trace.us_lacey.lacey_engine_service import ENGINE2_SHADOW, UsLaceyEngine2Service, engine2_mode
+from litoral_trace.us_lacey.shadow_evidence_snapshot import (
+    build_shadow_evidence_snapshot,
+    multilingual_shadow_enabled,
+)
 from litoral_trace.us_lacey.storage import (
     build_us_lacey_storage_settings,
     get_us_lacey_storage_client,
@@ -153,6 +157,22 @@ def _run_ai_review_recommendations(*, organization_id: int, operation_id: int) -
     except Exception:
         LOGGER.exception(
             "Lacey AI review recommendation failed",
+            extra={"organization_id": organization_id, "operation_id": operation_id},
+        )
+
+
+def _shadow_multilingual_evidence_snapshot(*, organization_id: int, operation_id: int) -> None:
+    """Best-effort Phase B dual-write; legacy completion is authoritative."""
+    if not multilingual_shadow_enabled():
+        return
+    try:
+        build_shadow_evidence_snapshot(
+            organization_id=organization_id,
+            operation_id=operation_id,
+        )
+    except Exception:
+        LOGGER.exception(
+            "Lacey multilingual evidence shadow snapshot failed",
             extra={"organization_id": organization_id, "operation_id": operation_id},
         )
 
@@ -435,6 +455,16 @@ def process_one_us_lacey_job(
             # AI review may annotate existing OPEN conflicts with a bounded recommendation,
             # but the recommendation cannot resolve an issue or set a field value.
             _run_ai_review_recommendations(
+                organization_id=job.organization_id,
+                operation_id=job.operation_id,
+            )
+
+        # The multilingual dual-write owns its own operation advisory lock. Run it
+        # only after the authoritative projection lock has been released to avoid a
+        # nested lock on a separate connection. Any shadow failure is swallowed by
+        # the wrapper and cannot alter the legacy queue state.
+        if isinstance(assurance_public_id, UUID):
+            _shadow_multilingual_evidence_snapshot(
                 organization_id=job.organization_id,
                 operation_id=job.operation_id,
             )

--- a/tests/test_us_lacey_multilingual_shadow_legacy_regression.py
+++ b/tests/test_us_lacey_multilingual_shadow_legacy_regression.py
@@ -1,0 +1,107 @@
+from __future__ import annotations
+
+from contextlib import nullcontext
+from types import SimpleNamespace
+from uuid import UUID
+
+from litoral_trace.us_lacey import worker
+
+
+class _ProcessingService:
+    def __init__(self, calls: list[str]) -> None:
+        self._calls = calls
+
+    def process(self, **_: object) -> str:
+        self._calls.append("process")
+        return "NEEDS_REVIEW"
+
+
+def _run_authoritative_path(monkeypatch, *, shadow_enabled: bool):
+    legacy_calls: list[str] = []
+    shadow_calls: list[str] = []
+    assurance_public_id = UUID("11111111-1111-1111-1111-111111111111")
+    job = SimpleNamespace(
+        id=91,
+        organization_id=17,
+        operation_id=23,
+        assurance_document_id=29,
+    )
+
+    if shadow_enabled:
+        monkeypatch.setenv("LT_LACEY_MULTILINGUAL_SHADOW", "1")
+    else:
+        monkeypatch.setenv("LT_LACEY_MULTILINGUAL_SHADOW", "0")
+
+    monkeypatch.setattr(worker, "claim_next_us_lacey_job", lambda **_: job)
+    monkeypatch.setattr(worker, "_assurance_public_id", lambda **_: assurance_public_id)
+    monkeypatch.setattr(
+        worker,
+        "_document_descriptor",
+        lambda **_: SimpleNamespace(
+            assurance_public_id=assurance_public_id,
+            vault_public_id=UUID("22222222-2222-2222-2222-222222222222"),
+            filename="invoice.pdf",
+            size_bytes=1024,
+        ),
+    )
+    monkeypatch.setattr(worker, "_preflight_existing_document", lambda **_: legacy_calls.append("preflight"))
+    monkeypatch.setattr(worker, "_processing_service", lambda: _ProcessingService(legacy_calls))
+    monkeypatch.setattr(worker, "us_lacey_operation_projection_lock", lambda **_: nullcontext())
+
+    def project(**_: object):
+        legacy_calls.append("project")
+        return SimpleNamespace(projected_count=4, conflict_count=2)
+
+    monkeypatch.setattr(worker, "project_assurance_document_to_us_lacey", project)
+    monkeypatch.setattr(worker, "_shadow_engine2", lambda **_: legacy_calls.append("engine2"))
+    monkeypatch.setattr(worker, "_project_engine2_suggestions", lambda **_: legacy_calls.append("engine2_suggestions") or 0)
+    monkeypatch.setattr(worker, "_project_verified_ai_suggestions", lambda **_: legacy_calls.append("ai_suggestions") or 0)
+    monkeypatch.setattr(worker, "_run_ai_review_recommendations", lambda **_: legacy_calls.append("ai_review"))
+
+    def failing_shadow(**_: object):
+        shadow_calls.append("shadow_attempt")
+        raise RuntimeError("shadow storage unavailable")
+
+    monkeypatch.setattr(worker, "build_shadow_evidence_snapshot", failing_shadow)
+    monkeypatch.setattr(worker, "complete_us_lacey_job", lambda **_: legacy_calls.append("complete") or True)
+    monkeypatch.setattr(worker, "_refresh_operation", lambda **_: legacy_calls.append("refresh") or "REVIEW_REQUIRED")
+    monkeypatch.setattr(
+        worker,
+        "fail_us_lacey_job",
+        lambda **_: (_ for _ in ()).throw(AssertionError("shadow must never fail the legacy job")),
+    )
+
+    result = worker.process_one_us_lacey_job(worker_id="phase-b-regression")
+    return result, legacy_calls, shadow_calls
+
+
+def test_legacy_projection_and_operation_result_are_identical_with_shadow_off_and_on(monkeypatch):
+    off_result, off_legacy_calls, off_shadow_calls = _run_authoritative_path(
+        monkeypatch,
+        shadow_enabled=False,
+    )
+    on_result, on_legacy_calls, on_shadow_calls = _run_authoritative_path(
+        monkeypatch,
+        shadow_enabled=True,
+    )
+
+    assert off_result == on_result
+    assert off_result.job_status == "COMPLETED"
+    assert off_result.document_status == "NEEDS_REVIEW"
+    assert off_result.operation_status == "REVIEW_REQUIRED"
+    assert off_result.projected_count == 4
+    assert off_result.conflict_count == 2
+
+    assert off_legacy_calls == on_legacy_calls == [
+        "preflight",
+        "process",
+        "project",
+        "engine2",
+        "engine2_suggestions",
+        "ai_suggestions",
+        "ai_review",
+        "complete",
+        "refresh",
+    ]
+    assert off_shadow_calls == []
+    assert on_shadow_calls == ["shadow_attempt"]

--- a/tests/test_us_lacey_multilingual_shadow_postgres.py
+++ b/tests/test_us_lacey_multilingual_shadow_postgres.py
@@ -1,0 +1,314 @@
+from __future__ import annotations
+
+from contextlib import nullcontext
+
+import pytest
+from sqlalchemy import func, inspect, select
+
+from litoral_trace.db.models import (
+    DocumentExtractionRun,
+    DocumentTextSpan,
+    ExtractedDocumentField,
+    SemanticEvidenceNode,
+    UsLaceyEvidenceSnapshot,
+    UsLaceyEvidenceSnapshotDocument,
+    UsLaceyOperation,
+)
+from litoral_trace.us_lacey import shadow_evidence_snapshot as shadow
+from litoral_trace.us_lacey.shadow_evidence_snapshot import ShadowEvidenceSnapshotError
+from tests.us_lacey_engine2_postgres import (
+    add_test_document,
+    create_test_graph,
+    engine2_postgres_engine,
+    engine2_postgres_session_factory,
+    tenant_session,
+)
+
+
+def _no_lock(**_: object):
+    return nullcontext()
+
+
+def _add_extraction(
+    factory,
+    *,
+    organization_id: int,
+    assurance_document_id: int,
+    values: list[tuple[str, str, int | None]],
+) -> int:
+    session = tenant_session(factory, organization_id)
+    run = DocumentExtractionRun(
+        organization_id=organization_id,
+        assurance_document_id=assurance_document_id,
+        engine="phase-b-test",
+        engine_version="1",
+        status="SUCCEEDED",
+    )
+    session.add(run)
+    session.flush()
+    for index, (field_name, original_value, source_page) in enumerate(values, start=1):
+        session.add(
+            ExtractedDocumentField(
+                organization_id=organization_id,
+                assurance_document_id=assurance_document_id,
+                extraction_run_id=run.id,
+                field_name=field_name,
+                original_value=original_value,
+                normalized_value=original_value,
+                value_type="text",
+                confidence=0.95,
+                confidence_level="HIGH",
+                source_page=source_page,
+                source_locator=f"table:1;data_row:{index};column:1",
+                auto_accepted=False,
+                needs_review=True,
+            )
+        )
+    session.commit()
+    run_id = run.id
+    session.close()
+    return run_id
+
+
+def _require_phase_b_schema(engine) -> None:
+    required = {
+        "us_lacey_evidence_snapshots",
+        "us_lacey_evidence_snapshot_documents",
+        "document_text_spans",
+        "document_text_translations",
+        "semantic_evidence_nodes",
+        "semantic_snapshot_nodes",
+    }
+    if not required.issubset(inspect(engine).get_table_names()):
+        pytest.skip("POSTGRES_SCHEMA_NOT_MIGRATED_TO_047")
+
+
+def test_shadow_snapshot_is_operation_wide_idempotent_and_supersedes_atomically(
+    monkeypatch,
+    engine2_postgres_engine,
+    engine2_postgres_session_factory,
+):
+    _require_phase_b_schema(engine2_postgres_engine)
+    monkeypatch.setenv(shadow.SHADOW_FLAG, "1")
+
+    org, operation_id, first_link_id, first_assurance_id, _, _ = create_test_graph(
+        engine2_postgres_session_factory,
+        role="COMMERCIAL_INVOICE",
+        content=b"phase-b-first",
+    )
+    _add_extraction(
+        engine2_postgres_session_factory,
+        organization_id=org,
+        assurance_document_id=first_assurance_id,
+        values=[
+            ("country_of_harvest", "País de cosecha declarado en Brasil", 1),
+            ("raw.document_text", "texto sin pagina demostrable", None),
+        ],
+    )
+
+    first = shadow.build_shadow_evidence_snapshot(
+        organization_id=org,
+        operation_id=operation_id,
+        use_configured_translation_provider=False,
+        session_factory=engine2_postgres_session_factory,
+        lock_factory=_no_lock,
+    )
+    assert first.created is True
+    assert first.metrics.generation == 1
+    assert first.metrics.documents_included == 1
+    assert first.metrics.spans_created == 1
+    assert first.metrics.spans_without_page == 1
+
+    session = tenant_session(engine2_postgres_session_factory, org)
+    snapshot1 = session.get(UsLaceyEvidenceSnapshot, first.snapshot_id)
+    assert snapshot1 is not None
+    assert snapshot1.status == "CURRENT"
+    assert snapshot1.document_count == 1
+    assert {member.operation_document_id for member in snapshot1.documents} == {first_link_id}
+    operation = session.get(UsLaceyOperation, operation_id)
+    assert operation.current_evidence_snapshot_id == snapshot1.id
+    session.close()
+
+    again = shadow.build_shadow_evidence_snapshot(
+        organization_id=org,
+        operation_id=operation_id,
+        use_configured_translation_provider=False,
+        session_factory=engine2_postgres_session_factory,
+        lock_factory=_no_lock,
+    )
+    assert again.created is False
+    assert again.reason == "IDEMPOTENT_CURRENT"
+    assert again.snapshot_id == first.snapshot_id
+
+    second_link_id, second_assurance_id, _, _ = add_test_document(
+        engine2_postgres_session_factory,
+        organization_id=org,
+        operation_id=operation_id,
+        role="SUPPLIER_DECLARATION",
+        filename="supplier.pdf",
+        content=b"phase-b-second",
+    )
+    _add_extraction(
+        engine2_postgres_session_factory,
+        organization_id=org,
+        assurance_document_id=second_assurance_id,
+        values=[("country_of_harvest", "País de colheita declarado no Brasil", 2)],
+    )
+
+    second = shadow.build_shadow_evidence_snapshot(
+        organization_id=org,
+        operation_id=operation_id,
+        use_configured_translation_provider=False,
+        session_factory=engine2_postgres_session_factory,
+        lock_factory=_no_lock,
+    )
+    assert second.created is True
+    assert second.metrics.generation == 2
+    assert second.metrics.documents_included == 2
+
+    session = tenant_session(engine2_postgres_session_factory, org)
+    snapshots = session.scalars(
+        select(UsLaceyEvidenceSnapshot)
+        .where(
+            UsLaceyEvidenceSnapshot.organization_id == org,
+            UsLaceyEvidenceSnapshot.operation_id == operation_id,
+        )
+        .order_by(UsLaceyEvidenceSnapshot.generation)
+    ).all()
+    assert [(item.generation, item.status) for item in snapshots] == [
+        (1, "SUPERSEDED"),
+        (2, "CURRENT"),
+    ]
+    snapshot2 = snapshots[1]
+    assert {member.operation_document_id for member in snapshot2.documents} == {
+        first_link_id,
+        second_link_id,
+    }
+    operation = session.get(UsLaceyOperation, operation_id)
+    assert operation.current_evidence_snapshot_id == snapshot2.id
+    assert session.scalar(
+        select(func.count()).select_from(UsLaceyEvidenceSnapshot).where(
+            UsLaceyEvidenceSnapshot.organization_id == org,
+            UsLaceyEvidenceSnapshot.operation_id == operation_id,
+            UsLaceyEvidenceSnapshot.status == "BUILDING",
+        )
+    ) == 0
+    for node in session.scalars(
+        select(SemanticEvidenceNode).where(SemanticEvidenceNode.organization_id == org)
+    ).all():
+        assert node.source_span_id is not None
+        assert session.get(DocumentTextSpan, node.source_span_id) is not None
+    session.close()
+
+
+def test_shadow_snapshot_rolls_back_new_generation_if_build_fails(
+    monkeypatch,
+    engine2_postgres_engine,
+    engine2_postgres_session_factory,
+):
+    _require_phase_b_schema(engine2_postgres_engine)
+    monkeypatch.setenv(shadow.SHADOW_FLAG, "1")
+
+    org, operation_id, _, assurance_id, _, _ = create_test_graph(
+        engine2_postgres_session_factory,
+        content=b"phase-b-atomic-first",
+    )
+    _add_extraction(
+        engine2_postgres_session_factory,
+        organization_id=org,
+        assurance_document_id=assurance_id,
+        values=[("description", "Wooden furniture component", 1)],
+    )
+    first = shadow.build_shadow_evidence_snapshot(
+        organization_id=org,
+        operation_id=operation_id,
+        use_configured_translation_provider=False,
+        session_factory=engine2_postgres_session_factory,
+        lock_factory=_no_lock,
+    )
+    assert first.created is True
+
+    _, second_assurance_id, _, _ = add_test_document(
+        engine2_postgres_session_factory,
+        organization_id=org,
+        operation_id=operation_id,
+        role="PACKING_LIST",
+        filename="packing.pdf",
+        content=b"phase-b-atomic-second",
+    )
+    _add_extraction(
+        engine2_postgres_session_factory,
+        organization_id=org,
+        assurance_document_id=second_assurance_id,
+        values=[("description", "Lista de empaque de madera", 1)],
+    )
+
+    monkeypatch.setattr(
+        shadow,
+        "_semantic_role",
+        lambda _field_name: (_ for _ in ()).throw(RuntimeError("forced shadow build failure")),
+    )
+    with pytest.raises(RuntimeError, match="forced shadow build failure"):
+        shadow.build_shadow_evidence_snapshot(
+            organization_id=org,
+            operation_id=operation_id,
+            use_configured_translation_provider=False,
+            session_factory=engine2_postgres_session_factory,
+            lock_factory=_no_lock,
+        )
+
+    session = tenant_session(engine2_postgres_session_factory, org)
+    snapshots = session.scalars(
+        select(UsLaceyEvidenceSnapshot).where(
+            UsLaceyEvidenceSnapshot.organization_id == org,
+            UsLaceyEvidenceSnapshot.operation_id == operation_id,
+        )
+    ).all()
+    assert len(snapshots) == 1
+    assert snapshots[0].id == first.snapshot_id
+    assert snapshots[0].status == "CURRENT"
+    operation = session.get(UsLaceyOperation, operation_id)
+    assert operation.current_evidence_snapshot_id == first.snapshot_id
+    session.close()
+
+
+def test_shadow_snapshot_rejects_cross_tenant_operation_scope(
+    monkeypatch,
+    engine2_postgres_engine,
+    engine2_postgres_session_factory,
+):
+    _require_phase_b_schema(engine2_postgres_engine)
+    monkeypatch.setenv(shadow.SHADOW_FLAG, "1")
+
+    org_a, _, _, _, _, _ = create_test_graph(
+        engine2_postgres_session_factory,
+        content=b"phase-b-tenant-a",
+    )
+    org_b, operation_b, _, assurance_b, _, _ = create_test_graph(
+        engine2_postgres_session_factory,
+        content=b"phase-b-tenant-b",
+    )
+    _add_extraction(
+        engine2_postgres_session_factory,
+        organization_id=org_b,
+        assurance_document_id=assurance_b,
+        values=[("description", "Wooden shipment evidence", 1)],
+    )
+
+    with pytest.raises(ShadowEvidenceSnapshotError, match="tenant scope"):
+        shadow.build_shadow_evidence_snapshot(
+            organization_id=org_a,
+            operation_id=operation_b,
+            use_configured_translation_provider=False,
+            session_factory=engine2_postgres_session_factory,
+            lock_factory=_no_lock,
+        )
+
+    session_b = tenant_session(engine2_postgres_session_factory, org_b)
+    assert session_b.scalar(
+        select(func.count()).select_from(UsLaceyEvidenceSnapshot).where(
+            UsLaceyEvidenceSnapshot.organization_id == org_b,
+            UsLaceyEvidenceSnapshot.operation_id == operation_b,
+        )
+    ) == 0
+    session_b.close()

--- a/tests/test_us_lacey_multilingual_shadow_postgres.py
+++ b/tests/test_us_lacey_multilingual_shadow_postgres.py
@@ -6,13 +6,14 @@ import pytest
 from sqlalchemy import func, inspect, select
 
 from litoral_trace.db.models import (
+    AssuranceDocument,
     DocumentExtractionRun,
     DocumentTextSpan,
     ExtractedDocumentField,
     SemanticEvidenceNode,
     UsLaceyEvidenceSnapshot,
-    UsLaceyEvidenceSnapshotDocument,
     UsLaceyOperation,
+    VaultDocument,
 )
 from litoral_trace.us_lacey import shadow_evidence_snapshot as shadow
 from litoral_trace.us_lacey.shadow_evidence_snapshot import ShadowEvidenceSnapshotError
@@ -198,6 +199,82 @@ def test_shadow_snapshot_is_operation_wide_idempotent_and_supersedes_atomically(
     ).all():
         assert node.source_span_id is not None
         assert session.get(DocumentTextSpan, node.source_span_id) is not None
+    session.close()
+
+
+def test_shadow_snapshot_refuses_partial_snapshot_when_any_current_source_is_unavailable(
+    monkeypatch,
+    engine2_postgres_engine,
+    engine2_postgres_session_factory,
+):
+    _require_phase_b_schema(engine2_postgres_engine)
+    monkeypatch.setenv(shadow.SHADOW_FLAG, "1")
+
+    org, operation_id, _, first_assurance_id, _, _ = create_test_graph(
+        engine2_postgres_session_factory,
+        content=b"phase-b-complete-source",
+    )
+    _add_extraction(
+        engine2_postgres_session_factory,
+        organization_id=org,
+        assurance_document_id=first_assurance_id,
+        values=[("description", "Wooden furniture component", 1)],
+    )
+    first = shadow.build_shadow_evidence_snapshot(
+        organization_id=org,
+        operation_id=operation_id,
+        use_configured_translation_provider=False,
+        session_factory=engine2_postgres_session_factory,
+        lock_factory=_no_lock,
+    )
+    assert first.created is True
+
+    _, second_assurance_id, _, _ = add_test_document(
+        engine2_postgres_session_factory,
+        organization_id=org,
+        operation_id=operation_id,
+        role="PACKING_LIST",
+        filename="unavailable.pdf",
+        content=b"phase-b-unavailable-source",
+    )
+    _add_extraction(
+        engine2_postgres_session_factory,
+        organization_id=org,
+        assurance_document_id=second_assurance_id,
+        values=[("description", "Documento de embalaje de madera", 1)],
+    )
+    session = tenant_session(engine2_postgres_session_factory, org)
+    assurance = session.get(AssuranceDocument, second_assurance_id)
+    assert assurance is not None
+    vault = session.get(VaultDocument, assurance.vault_document_id)
+    assert vault is not None
+    vault.status = "delete_pending"
+    session.commit()
+    session.close()
+
+    blocked = shadow.build_shadow_evidence_snapshot(
+        organization_id=org,
+        operation_id=operation_id,
+        use_configured_translation_provider=False,
+        session_factory=engine2_postgres_session_factory,
+        lock_factory=_no_lock,
+    )
+    assert blocked.created is False
+    assert blocked.reason == "SOURCE_SET_NOT_FULLY_AVAILABLE"
+    assert blocked.snapshot_id is None
+
+    session = tenant_session(engine2_postgres_session_factory, org)
+    snapshots = session.scalars(
+        select(UsLaceyEvidenceSnapshot).where(
+            UsLaceyEvidenceSnapshot.organization_id == org,
+            UsLaceyEvidenceSnapshot.operation_id == operation_id,
+        )
+    ).all()
+    assert len(snapshots) == 1
+    assert snapshots[0].id == first.snapshot_id
+    assert snapshots[0].status == "CURRENT"
+    operation = session.get(UsLaceyOperation, operation_id)
+    assert operation.current_evidence_snapshot_id == first.snapshot_id
     session.close()
 
 

--- a/tests/test_us_lacey_multilingual_shadow_unit.py
+++ b/tests/test_us_lacey_multilingual_shadow_unit.py
@@ -1,0 +1,141 @@
+from __future__ import annotations
+
+from litoral_trace.db.models import DocumentTextSpan, DocumentTextTranslation
+from litoral_trace.services.translation import NoOpEnglishProvider, TranslationResult
+from litoral_trace.us_lacey.shadow_evidence_snapshot import (
+    SHADOW_FLAG,
+    SnapshotMetrics,
+    _translate_span_if_eligible,
+    detect_supported_language,
+    multilingual_shadow_enabled,
+)
+
+
+def test_supported_language_detector_handles_en_es_pt_zh_and_keeps_codes_undefined():
+    assert detect_supported_language("Country of harvest declared in Brazil").code == "en"
+    assert detect_supported_language("País de cosecha declarado en Brasil").code == "es"
+    assert detect_supported_language("País de colheita declarado no Brasil").code == "pt"
+    assert detect_supported_language("采伐国家为中国，植物材料来自该地区").code == "zh"
+
+    for fragment in ("4419199010", "KG", "TGHU4821932", "1440"):
+        detection = detect_supported_language(fragment)
+        assert detection.code == "und"
+        assert detection.confidence == 0.0
+
+
+def test_multilingual_shadow_feature_flag_is_fail_closed():
+    assert multilingual_shadow_enabled({}) is False
+    assert multilingual_shadow_enabled({SHADOW_FLAG: "0"}) is False
+    assert multilingual_shadow_enabled({SHADOW_FLAG: "false"}) is False
+    assert multilingual_shadow_enabled({SHADOW_FLAG: "1"}) is True
+    assert multilingual_shadow_enabled({SHADOW_FLAG: "true"}) is True
+
+
+class _CapturingSession:
+    def __init__(self) -> None:
+        self.added: list[object] = []
+
+    def scalar(self, _statement):
+        return None
+
+    def add(self, value: object) -> None:
+        self.added.append(value)
+
+
+class _FakeTranslationProvider:
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, str, str]] = []
+
+    def translate(self, text: str, source: str, target: str = "en") -> TranslationResult:
+        self.calls.append((text, source, target))
+        return TranslationResult(
+            translated_text="Country of harvest declared in Brazil",
+            source_language=source,
+            target_language=target,
+            provider="TEST_TRANSLATOR",
+            model_name="deterministic",
+            model_version="1",
+        )
+
+
+def _span(*, language: str, text: str) -> DocumentTextSpan:
+    return DocumentTextSpan(
+        id=17,
+        organization_id=3,
+        assurance_document_id=4,
+        extraction_run_id=5,
+        page=1,
+        block_id="legacy-field:7",
+        original_text=text,
+        original_language=language,
+        language_confidence=0.99,
+        extraction_method="LEGACY_ADAPTER",
+        content_hash="a" * 64,
+    )
+
+
+def test_non_english_span_is_translated_only_with_real_active_provider():
+    metrics = SnapshotMetrics()
+    session = _CapturingSession()
+    provider = _FakeTranslationProvider()
+    span = _span(language="es", text="País de cosecha declarado en Brasil")
+
+    _translate_span_if_eligible(
+        span=span,
+        provider=provider,
+        metrics=metrics,
+        session=session,  # type: ignore[arg-type]
+    )
+
+    assert provider.calls == [(span.original_text, "es", "en")]
+    assert metrics.translations_created == 1
+    assert metrics.translations_omitted == 0
+    translation = next(item for item in session.added if isinstance(item, DocumentTextTranslation))
+    assert translation.source_span_id == span.id
+    assert translation.source_language == "es"
+    assert translation.target_language == "en"
+    assert translation.translated_text == "Country of harvest declared in Brazil"
+
+
+def test_no_provider_or_noop_provider_never_persists_false_non_english_translation():
+    span = _span(language="pt", text="País de colheita declarado no Brasil")
+
+    no_provider_metrics = SnapshotMetrics()
+    no_provider_session = _CapturingSession()
+    _translate_span_if_eligible(
+        span=span,
+        provider=None,
+        metrics=no_provider_metrics,
+        session=no_provider_session,  # type: ignore[arg-type]
+    )
+    assert no_provider_metrics.translations_omitted == 1
+    assert no_provider_session.added == []
+
+    noop_metrics = SnapshotMetrics()
+    noop_session = _CapturingSession()
+    _translate_span_if_eligible(
+        span=span,
+        provider=NoOpEnglishProvider(),
+        metrics=noop_metrics,
+        session=noop_session,  # type: ignore[arg-type]
+    )
+    assert noop_metrics.translations_omitted == 1
+    assert noop_session.added == []
+
+
+def test_english_and_undefined_spans_do_not_create_translation_rows():
+    for language, text in (
+        ("en", "Country of harvest declared in Brazil"),
+        ("und", "4419199010"),
+    ):
+        metrics = SnapshotMetrics()
+        session = _CapturingSession()
+        _translate_span_if_eligible(
+            span=_span(language=language, text=text),
+            provider=_FakeTranslationProvider(),
+            metrics=metrics,
+            session=session,  # type: ignore[arg-type]
+        )
+        assert metrics.translations_created == 0
+        assert metrics.translations_omitted == 0
+        assert session.added == []

--- a/tests/test_us_lacey_multilingual_snapshot_schema.py
+++ b/tests/test_us_lacey_multilingual_snapshot_schema.py
@@ -297,3 +297,26 @@ def test_new_tables_persist_relationships_and_enforce_tenant_fks_and_uniqueness(
         session.commit()
     session.rollback()
     session.close()
+
+
+def test_phase_b_shadow_lifecycle_runs_inside_postgres_gate(
+    monkeypatch,
+    engine2_postgres_engine,
+    engine2_postgres_session_factory,
+):
+    """The gate already executes this file explicitly; keep Phase B acceptance non-skippable."""
+    from tests import test_us_lacey_multilingual_shadow_postgres as phase_b
+
+    acceptance_tests = (
+        phase_b.test_shadow_snapshot_is_operation_wide_idempotent_and_supersedes_atomically,
+        phase_b.test_shadow_snapshot_refuses_partial_snapshot_when_any_current_source_is_unavailable,
+        phase_b.test_shadow_snapshot_rejects_cross_tenant_operation_scope,
+        phase_b.test_shadow_snapshot_rolls_back_new_generation_if_build_fails,
+    )
+    for acceptance in acceptance_tests:
+        with monkeypatch.context() as scoped:
+            acceptance(
+                scoped,
+                engine2_postgres_engine,
+                engine2_postgres_session_factory,
+            )


### PR DESCRIPTION
## Phase B — Shadow Extraction & Dual-Write

- operation-wide evidence snapshots behind `LT_LACEY_MULTILINGUAL_SHADOW`
- deterministic source-set fingerprint and idempotent CURRENT snapshot reuse
- atomic BUILDING -> CURRENT / previous -> SUPERSEDED / operation pointer transition
- legacy `ExtractedDocumentField` adapter with strict source-page provenance
- EN/ES/PT/ZH detection via `lingua-language-detector`; codes/short fragments remain `und`
- optional translation provenance; non-English text is never passed through `NoOpEnglishProvider`
- semantic nodes remain rooted in original `DocumentTextSpan`
- worker integration is best-effort and cannot fail the legacy job
- metrics for documents, spans, languages, translations and semantic nodes
- unit, PostgreSQL lifecycle/isolation, rollback and legacy ON/OFF regression tests

### Safety boundary
The UI, Review, Advanced Evidence, PPQ projection and operation status continue to consume the legacy path exclusively. Shadow errors are caught and logged; legacy completion remains authoritative.
