### PR TITLE
chore(render): enable multilingual evidence shadow

### DIFF
--- a/deploy/render-us-lacey-pilot-free.yaml
+++ b/deploy/render-us-lacey-pilot-free.yaml
@@ -58,6 +58,8 @@ services:
         value: "60"
       - key: US_LACEY_WORKER_STALE_AFTER_SECONDS
         value: "600"
+      - key: LT_LACEY_MULTILINGUAL_SHADOW
+        value: "1"
 
       # The web IAM identity already has private read/write access to the same
       # isolated prefix used by document ingestion and processing.

--- a/deploy/render-us-lacey-pilot.yaml
+++ b/deploy/render-us-lacey-pilot.yaml
@@ -123,3 +123,5 @@ services:
         value: "60"
       - key: US_LACEY_WORKER_STALE_AFTER_SECONDS
         value: "600"
+      - key: LT_LACEY_MULTILINGUAL_SHADOW
+        value: "1"


### PR DESCRIPTION
## Summary
- enable `LT_LACEY_MULTILINGUAL_SHADOW=1` on the current free-tier web service, where the extraction worker runs embedded
- enable the same flag on the dedicated Render worker definition for the future paid topology
- leave `LT_LACEY_TRANSLATION_PROVIDER` undefined so translation remains fail-closed with no AWS translation calls

## Scope
Infrastructure-only change. No extraction, reconciliation, review-state, or translation-provider logic is modified.

## Expected deployment behavior
After merge into `feature/us-lacey-pilot-platform`, Render should autodeploy the current `litoral-trace-us-lacey-pilot-free` service once required checks pass.