### PR TITLE
fix(us-lacey): expose and persist multilingual shadow observability

### DIFF
--- a/.github/workflows/us-lacey-render-live-gate.yml
+++ b/.github/workflows/us-lacey-render-live-gate.yml
@@ -209,9 +209,11 @@ jobs:
               'status': 'ready',
               'inline_worker': 'ready',
               'storage_roundtrip': 'ready',
+              'multilingual_shadow': 'enabled',
           }, body
           print('render_inline_worker=PASS')
           print('render_storage_roundtrip=PASS')
+          print('render_multilingual_shadow=PASS')
           PY
 
       - name: Verify readiness contract

--- a/src/litoral_trace/us_lacey/live_readiness.py
+++ b/src/litoral_trace/us_lacey/live_readiness.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import logging
 from uuid import uuid4
 
+from litoral_trace.us_lacey.shadow_evidence_snapshot import multilingual_shadow_enabled
 from litoral_trace.us_lacey.storage import (
     build_us_lacey_storage_settings,
     get_us_lacey_storage_client,
@@ -78,4 +79,5 @@ def live_runtime_status(*, worker_ready: bool, storage_roundtrip: str) -> dict[s
         "status": overall,
         "inline_worker": inline_worker,
         "storage_roundtrip": storage,
+        "multilingual_shadow": "enabled" if multilingual_shadow_enabled() else "disabled",
     }

--- a/src/litoral_trace/us_lacey/shadow_evidence_snapshot.py
+++ b/src/litoral_trace/us_lacey/shadow_evidence_snapshot.py
@@ -448,6 +448,7 @@ def build_shadow_evidence_snapshot(
     org_id = int(organization_id)
     op_id = int(operation_id)
     metrics = SnapshotMetrics()
+    fingerprint: str | None = None
     if not multilingual_shadow_enabled():
         result = SnapshotBuildResult(False, None, None, "DISABLED", metrics)
         _log_metrics(
@@ -690,7 +691,8 @@ def build_shadow_evidence_snapshot(
             operation.current_evidence_snapshot_id = snapshot.id
             session.commit()
 
-            result = SnapshotBuildResult(True, snapshot.id, fingerprint, "CREATED", metrics)
+            reason = "CREATED_EMPTY_EVIDENCE" if metrics.spans_created == 0 else "CREATED"
+            result = SnapshotBuildResult(True, snapshot.id, fingerprint, reason, metrics)
             _log_metrics(
                 organization_id=org_id,
                 operation_id=op_id,
@@ -701,6 +703,13 @@ def build_shadow_evidence_snapshot(
             return result
         except Exception:
             session.rollback()
+            _log_metrics(
+                organization_id=org_id,
+                operation_id=op_id,
+                fingerprint=fingerprint,
+                reason="FAILED",
+                metrics=metrics,
+            )
             raise
         finally:
             session.close()

--- a/src/litoral_trace/us_lacey/worker.py
+++ b/src/litoral_trace/us_lacey/worker.py
@@ -35,10 +35,7 @@ from litoral_trace.us_lacey.projection import (
     refresh_us_lacey_operation_status,
 )
 from litoral_trace.us_lacey.lacey_engine_service import ENGINE2_SHADOW, UsLaceyEngine2Service, engine2_mode
-from litoral_trace.us_lacey.shadow_evidence_snapshot import (
-    build_shadow_evidence_snapshot,
-    multilingual_shadow_enabled,
-)
+from litoral_trace.us_lacey.shadow_evidence_snapshot import build_shadow_evidence_snapshot
 from litoral_trace.us_lacey.storage import (
     build_us_lacey_storage_settings,
     get_us_lacey_storage_client,
@@ -163,8 +160,6 @@ def _run_ai_review_recommendations(*, organization_id: int, operation_id: int) -
 
 def _shadow_multilingual_evidence_snapshot(*, organization_id: int, operation_id: int) -> None:
     """Best-effort Phase B dual-write; legacy completion is authoritative."""
-    if not multilingual_shadow_enabled():
-        return
     try:
         build_shadow_evidence_snapshot(
             organization_id=organization_id,

--- a/tests/test_us_lacey_live_readiness.py
+++ b/tests/test_us_lacey_live_readiness.py
@@ -77,26 +77,32 @@ def test_storage_roundtrip_fails_closed_when_cleanup_fails(monkeypatch):
     assert storage.delete_key == storage.put_key
 
 
-def test_live_runtime_status_requires_successful_worker_heartbeat_and_storage():
-    assert live_readiness.live_runtime_status(
+def test_live_runtime_status_requires_successful_worker_heartbeat_and_storage(monkeypatch):
+    monkeypatch.delenv("LT_LACEY_MULTILINGUAL_SHADOW", raising=False)
+    payload = live_readiness.live_runtime_status(
         worker_ready=True,
         storage_roundtrip="ready",
-    ) == {
-        "status": "ready",
-        "inline_worker": "ready",
-        "storage_roundtrip": "ready",
-    }
+    )
+
+    assert payload["status"] == "ready"
+    assert payload["inline_worker"] == "ready"
+    assert payload["storage_roundtrip"] == "ready"
+    assert "multilingual_shadow" in payload
+    assert payload["multilingual_shadow"] == "disabled"
 
 
-def test_live_runtime_status_fails_closed_without_worker_heartbeat():
-    assert live_readiness.live_runtime_status(
+def test_live_runtime_status_fails_closed_without_worker_heartbeat(monkeypatch):
+    monkeypatch.delenv("LT_LACEY_MULTILINGUAL_SHADOW", raising=False)
+    payload = live_readiness.live_runtime_status(
         worker_ready=False,
         storage_roundtrip="ready",
-    ) == {
-        "status": "not_ready",
-        "inline_worker": "not_ready",
-        "storage_roundtrip": "ready",
-    }
+    )
+
+    assert payload["status"] == "not_ready"
+    assert payload["inline_worker"] == "not_ready"
+    assert payload["storage_roundtrip"] == "ready"
+    assert "multilingual_shadow" in payload
+    assert payload["multilingual_shadow"] == "disabled"
 
 
 def test_free_tier_worker_readiness_requires_fresh_successful_db_heartbeat(monkeypatch):

--- a/tests/test_us_lacey_multilingual_shadow_legacy_regression.py
+++ b/tests/test_us_lacey_multilingual_shadow_legacy_regression.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
 from contextlib import nullcontext
+import logging
 from types import SimpleNamespace
 from uuid import UUID
 
+from litoral_trace.us_lacey import shadow_evidence_snapshot as shadow
 from litoral_trace.us_lacey import worker
 
 
@@ -103,5 +105,29 @@ def test_legacy_projection_and_operation_result_are_identical_with_shadow_off_an
         "complete",
         "refresh",
     ]
-    assert off_shadow_calls == []
+    # The wrapper now always invokes the builder so DISABLED is observable there;
+    # a builder failure remains isolated from the authoritative legacy result.
+    assert off_shadow_calls == ["shadow_attempt"]
     assert on_shadow_calls == ["shadow_attempt"]
+
+
+def test_worker_calls_builder_even_when_shadow_disabled_for_observability(monkeypatch, caplog):
+    monkeypatch.setenv(shadow.SHADOW_FLAG, "0")
+    calls: list[dict[str, int]] = []
+    real_builder = shadow.build_shadow_evidence_snapshot
+
+    def observable_builder(**kwargs: int):
+        calls.append(dict(kwargs))
+        return real_builder(**kwargs)
+
+    monkeypatch.setattr(worker, "build_shadow_evidence_snapshot", observable_builder)
+
+    with caplog.at_level(logging.INFO, logger=shadow.LOGGER.name):
+        worker._shadow_multilingual_evidence_snapshot(
+            organization_id=17,
+            operation_id=23,
+        )
+
+    assert calls == [{"organization_id": 17, "operation_id": 23}]
+    assert "Lacey multilingual shadow metrics" in caplog.text
+    assert "reason=DISABLED" in caplog.text

--- a/tests/test_us_lacey_shadow_observability_postgres.py
+++ b/tests/test_us_lacey_shadow_observability_postgres.py
@@ -1,0 +1,141 @@
+from __future__ import annotations
+
+from contextlib import nullcontext
+
+import pytest
+from sqlalchemy import func, inspect, select
+
+from litoral_trace.db.models import (
+    DocumentExtractionRun,
+    DocumentTextSpan,
+    ExtractedDocumentField,
+    SemanticEvidenceNode,
+    UsLaceyEvidenceSnapshot,
+    UsLaceyOperation,
+)
+from litoral_trace.us_lacey import shadow_evidence_snapshot as shadow
+from tests.us_lacey_engine2_postgres import (
+    create_test_graph,
+    engine2_postgres_engine,
+    engine2_postgres_session_factory,
+    tenant_session,
+)
+
+
+def _no_lock(**_: object):
+    return nullcontext()
+
+
+def _require_phase_b_schema(engine) -> None:
+    required = {
+        "us_lacey_evidence_snapshots",
+        "us_lacey_evidence_snapshot_documents",
+        "document_text_spans",
+        "semantic_evidence_nodes",
+        "semantic_snapshot_nodes",
+    }
+    if not required.issubset(inspect(engine).get_table_names()):
+        pytest.skip("POSTGRES_SCHEMA_NOT_MIGRATED_TO_047")
+
+
+def _add_page_less_extraction(
+    factory,
+    *,
+    organization_id: int,
+    assurance_document_id: int,
+) -> None:
+    session = tenant_session(factory, organization_id)
+    run = DocumentExtractionRun(
+        organization_id=organization_id,
+        assurance_document_id=assurance_document_id,
+        engine="phase-b-observability-test",
+        engine_version="1",
+        status="SUCCEEDED",
+    )
+    session.add(run)
+    session.flush()
+
+    values = [
+        ("description", "Wooden furniture component"),
+        ("entered_value", "12600"),
+        ("genus", "Eucalyptus"),
+        ("species", "grandis"),
+    ]
+    for index, (field_name, original_value) in enumerate(values, start=1):
+        session.add(
+            ExtractedDocumentField(
+                organization_id=organization_id,
+                assurance_document_id=assurance_document_id,
+                extraction_run_id=run.id,
+                field_name=field_name,
+                original_value=original_value,
+                normalized_value=original_value,
+                value_type="text",
+                confidence=0.95,
+                confidence_level="HIGH",
+                source_page=None,
+                source_locator=f"legacy:unknown-page:{index}",
+                auto_accepted=False,
+                needs_review=True,
+            )
+        )
+    session.commit()
+    session.close()
+
+
+def test_shadow_snapshot_persists_when_all_legacy_fields_lack_source_page(
+    monkeypatch,
+    engine2_postgres_engine,
+    engine2_postgres_session_factory,
+):
+    _require_phase_b_schema(engine2_postgres_engine)
+    monkeypatch.setenv(shadow.SHADOW_FLAG, "1")
+
+    org, operation_id, _, assurance_id, _, _ = create_test_graph(
+        engine2_postgres_session_factory,
+        content=b"phase-b-empty-evidence",
+    )
+    _add_page_less_extraction(
+        engine2_postgres_session_factory,
+        organization_id=org,
+        assurance_document_id=assurance_id,
+    )
+
+    result = shadow.build_shadow_evidence_snapshot(
+        organization_id=org,
+        operation_id=operation_id,
+        use_configured_translation_provider=False,
+        session_factory=engine2_postgres_session_factory,
+        lock_factory=_no_lock,
+    )
+
+    assert result.created is True
+    assert result.reason == "CREATED_EMPTY_EVIDENCE"
+    assert result.metrics.spans_created == 0
+    assert result.metrics.spans_without_page == 4
+    assert result.metrics.semantic_nodes_created == 0
+
+    session = tenant_session(engine2_postgres_session_factory, org)
+    snapshot = session.get(UsLaceyEvidenceSnapshot, result.snapshot_id)
+    assert snapshot is not None
+    assert snapshot.status == "CURRENT"
+    assert snapshot.document_count == 1
+    assert snapshot.node_count == 0
+
+    operation = session.get(UsLaceyOperation, operation_id)
+    assert operation is not None
+    assert operation.current_evidence_snapshot_id == snapshot.id
+
+    assert session.scalar(
+        select(func.count()).select_from(DocumentTextSpan).where(
+            DocumentTextSpan.organization_id == org,
+            DocumentTextSpan.assurance_document_id == assurance_id,
+        )
+    ) == 0
+    assert session.scalar(
+        select(func.count()).select_from(SemanticEvidenceNode).where(
+            SemanticEvidenceNode.organization_id == org,
+            SemanticEvidenceNode.assurance_document_id == assurance_id,
+        )
+    ) == 0
+    session.close()


### PR DESCRIPTION
## Summary
- expose the multilingual shadow configuration state in `/live-readiness`
- keep readiness test assertions resilient by checking required keys instead of exact whole-response equality
- persist shadow snapshots even when all legacy extracted fields lack `source_page`
- ensure the PostgreSQL gate runs the new persistence regression

## Safety boundary
No legacy extraction or authoritative projection semantics are changed. This PR adds shadow observability and persistence coverage only.