### PR TITLE
fix(ci): break Render checks-pass predeploy deadlock

### DIFF
--- a/.github/workflows/us-lacey-render-live-gate.yml
+++ b/.github/workflows/us-lacey-render-live-gate.yml
@@ -205,15 +205,26 @@ jobs:
           import json
           from pathlib import Path
           body = json.loads(Path('/tmp/live.json').read_text())
-          assert body == {
+          required = {
               'status': 'ready',
               'inline_worker': 'ready',
               'storage_roundtrip': 'ready',
-              'multilingual_shadow': 'enabled',
-          }, body
+          }
+          for key, expected in required.items():
+              assert body.get(key) == expected, body
+
+          # Render is configured with autoDeployTrigger=checksPass, so this workflow
+          # executes against the previously deployed revision before the candidate
+          # can be released. Allow the legacy response to omit the newly introduced
+          # observability key, but fail closed if an exposed key is not enabled.
+          shadow = body.get('multilingual_shadow')
+          assert shadow in (None, 'enabled'), body
           print('render_inline_worker=PASS')
           print('render_storage_roundtrip=PASS')
-          print('render_multilingual_shadow=PASS')
+          print(
+              'render_multilingual_shadow=' +
+              ('PASS' if shadow == 'enabled' else 'PREDEPLOY_NOT_EXPOSED')
+          )
           PY
 
       - name: Verify readiness contract


### PR DESCRIPTION
## Why
PR #197 correctly adds `multilingual_shadow` to `/live-readiness`, but Render is configured with `autoDeployTrigger=checksPass`. The push-time Render live gate therefore runs against the *previous* production revision. Requiring the new key before Render is allowed to deploy creates a circular dependency and blocks the autodeploy.

## Change
- keep strict checks for the existing live runtime invariants (`status`, `inline_worker`, `storage_roundtrip`)
- if `multilingual_shadow` is already exposed, require it to be `enabled`
- allow the previous production revision to omit the new key during this predeploy gate
- retain the final post-deploy production validation of `multilingual_shadow=enabled` outside the predeploy gate

No application extraction/projection behavior changes.