### PR TITLE
fix(us-lacey): correct shadow extraction eligibility and fingerprint

### DIFF
--- a/src/litoral_trace/us_lacey/shadow_evidence_snapshot.py
+++ b/src/litoral_trace/us_lacey/shadow_evidence_snapshot.py
@@ -203,6 +203,7 @@ def _source_set_fingerprint(sources: list[_DocumentSource]) -> str:
         {
             "operation_document_id": item.operation_document_id,
             "assurance_document_id": item.assurance_document_id,
+            "extraction_run_id": item.extraction_run_id,
             "source_sha256": item.source_sha256,
             "version_number": item.version_number,
         }
@@ -373,13 +374,19 @@ def _load_document_sources(
             .where(
                 DocumentExtractionRun.organization_id == organization_id,
                 DocumentExtractionRun.assurance_document_id == assurance_document.id,
-                DocumentExtractionRun.status == "SUCCEEDED",
             )
             .order_by(DocumentExtractionRun.id.desc())
             .limit(1)
         )
         if extraction_run is None:
             return [], "SOURCE_SET_NOT_FULLY_EXTRACTED"
+
+        extraction_status = str(extraction_run.status or "").strip().upper()
+        if extraction_status == "RUNNING":
+            return [], "SOURCE_SET_EXTRACTION_IN_PROGRESS"
+        if extraction_status not in {"SUCCEEDED", "NEEDS_REVIEW"}:
+            return [], "SOURCE_SET_EXTRACTION_UNUSABLE"
+
         sources.append(
             _DocumentSource(
                 operation_document_id=operation_document.id,

--- a/src/litoral_trace/us_lacey/shadow_evidence_snapshot.py
+++ b/src/litoral_trace/us_lacey/shadow_evidence_snapshot.py
@@ -104,6 +104,8 @@ class _DocumentSource:
     operation_document_id: int
     assurance_document_id: int
     extraction_run_id: int
+    extraction_evidence_hash: str
+    fields: tuple[ExtractedDocumentField, ...]
     source_sha256: str
     document_role: str
     document_type: str
@@ -198,12 +200,34 @@ def _sha256_text(value: str) -> str:
     return hashlib.sha256(value.encode("utf-8")).hexdigest()
 
 
+def _extraction_evidence_hash(fields: tuple[ExtractedDocumentField, ...]) -> str:
+    """Fingerprint mutable semantic values from one legacy extraction run.
+
+    Human Assurance review preserves original extraction provenance but may correct
+    ``normalized_value`` in place on a ``NEEDS_REVIEW`` run. Capturing the semantic
+    values here makes that review revision visible to the immutable snapshot layer
+    without changing any legacy review/write semantics.
+    """
+    payload = [
+        {
+            "field_id": int(field.id),
+            "field_name": str(field.field_name or ""),
+            "normalized_value": field.normalized_value,
+            "confidence": float(field.confidence or 0.0),
+        }
+        for field in fields
+    ]
+    canonical = json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
+    return _sha256_text(canonical)
+
+
 def _source_set_fingerprint(sources: list[_DocumentSource]) -> str:
     payload = [
         {
             "operation_document_id": item.operation_document_id,
             "assurance_document_id": item.assurance_document_id,
             "extraction_run_id": item.extraction_run_id,
+            "extraction_evidence_hash": item.extraction_evidence_hash,
             "source_sha256": item.source_sha256,
             "version_number": item.version_number,
         }
@@ -262,6 +286,8 @@ def _node_fingerprint(
             str(field.id),
             str(field.field_name),
             str(span.content_hash),
+            str(field.normalized_value or ""),
+            str(float(field.confidence or 0.0)),
         )
     )
     return _sha256_text(payload)
@@ -377,6 +403,7 @@ def _load_document_sources(
             )
             .order_by(DocumentExtractionRun.id.desc())
             .limit(1)
+            .with_for_update()
         )
         if extraction_run is None:
             return [], "SOURCE_SET_NOT_FULLY_EXTRACTED"
@@ -387,11 +414,25 @@ def _load_document_sources(
         if extraction_status not in {"SUCCEEDED", "NEEDS_REVIEW"}:
             return [], "SOURCE_SET_EXTRACTION_UNUSABLE"
 
+        fields = tuple(
+            session.scalars(
+                select(ExtractedDocumentField)
+                .where(
+                    ExtractedDocumentField.organization_id == organization_id,
+                    ExtractedDocumentField.assurance_document_id == assurance_document.id,
+                    ExtractedDocumentField.extraction_run_id == extraction_run.id,
+                )
+                .order_by(ExtractedDocumentField.id.asc())
+                .with_for_update()
+            ).all()
+        )
         sources.append(
             _DocumentSource(
                 operation_document_id=operation_document.id,
                 assurance_document_id=assurance_document.id,
                 extraction_run_id=extraction_run.id,
+                extraction_evidence_hash=_extraction_evidence_hash(fields),
+                fields=fields,
                 source_sha256=vault_document.sha256,
                 document_role=operation_document.document_role,
                 document_type=assurance_document.semantic_document_type,
@@ -576,16 +617,7 @@ def build_shadow_evidence_snapshot(
                         processing_result="SUCCEEDED",
                     )
                 )
-                fields = session.scalars(
-                    select(ExtractedDocumentField)
-                    .where(
-                        ExtractedDocumentField.organization_id == org_id,
-                        ExtractedDocumentField.assurance_document_id == source.assurance_document_id,
-                        ExtractedDocumentField.extraction_run_id == source.extraction_run_id,
-                    )
-                    .order_by(ExtractedDocumentField.id.asc())
-                ).all()
-                for field in fields:
+                for field in source.fields:
                     original_text = str(field.original_value or "").strip()
                     if field.source_page is None or int(field.source_page) <= 0:
                         metrics.spans_without_page += 1

--- a/tests/test_us_lacey_multilingual_snapshot_schema.py
+++ b/tests/test_us_lacey_multilingual_snapshot_schema.py
@@ -306,12 +306,16 @@ def test_phase_b_shadow_lifecycle_runs_inside_postgres_gate(
 ):
     """The gate already executes this file explicitly; keep Phase B acceptance non-skippable."""
     from tests import test_us_lacey_multilingual_shadow_postgres as phase_b
+    from tests import test_us_lacey_shadow_eligibility_postgres as eligibility
 
     acceptance_tests = (
         phase_b.test_shadow_snapshot_is_operation_wide_idempotent_and_supersedes_atomically,
         phase_b.test_shadow_snapshot_refuses_partial_snapshot_when_any_current_source_is_unavailable,
         phase_b.test_shadow_snapshot_rejects_cross_tenant_operation_scope,
         phase_b.test_shadow_snapshot_rolls_back_new_generation_if_build_fails,
+        eligibility.test_shadow_snapshot_accepts_latest_needs_review_extraction,
+        eligibility.test_shadow_snapshot_rejects_running_extraction,
+        eligibility.test_shadow_fingerprint_mutates_on_new_extraction_run,
     )
     for acceptance in acceptance_tests:
         with monkeypatch.context() as scoped:

--- a/tests/test_us_lacey_shadow_eligibility_postgres.py
+++ b/tests/test_us_lacey_shadow_eligibility_postgres.py
@@ -10,6 +10,7 @@ from litoral_trace.db.models import (
     DocumentTextSpan,
     ExtractedDocumentField,
     SemanticEvidenceNode,
+    SemanticSnapshotNode,
     UsLaceyEvidenceSnapshot,
 )
 from litoral_trace.us_lacey import shadow_evidence_snapshot as shadow
@@ -247,4 +248,51 @@ def test_shadow_fingerprint_mutates_on_new_extraction_run(
     assert first_snapshot.status == "SUPERSEDED"
     assert second_snapshot.status == "CURRENT"
     assert first_snapshot.source_set_fingerprint != second_snapshot.source_set_fingerprint
+
+    # Assurance human review can correct normalized_value in place without creating
+    # a new extraction run. That semantic revision must still invalidate the CURRENT
+    # source-set fingerprint and materialize a fresh semantic node/generation.
+    reviewed_field = session.scalar(
+        select(ExtractedDocumentField).where(
+            ExtractedDocumentField.organization_id == org,
+            ExtractedDocumentField.assurance_document_id == assurance_id,
+            ExtractedDocumentField.extraction_run_id == second_run_id,
+        )
+    )
+    assert reviewed_field is not None
+    reviewed_field.normalized_value = "Reviewed normalized evidence"
+    session.commit()
+    session.close()
+
+    third = _build_snapshot(
+        engine2_postgres_session_factory,
+        organization_id=org,
+        operation_id=operation_id,
+    )
+    assert third.created is True
+    assert third.metrics.generation == 3
+    assert third.snapshot_id not in {first.snapshot_id, second.snapshot_id}
+    assert third.source_set_fingerprint != second.source_set_fingerprint
+
+    session = tenant_session(engine2_postgres_session_factory, org)
+    second_snapshot = session.get(UsLaceyEvidenceSnapshot, second.snapshot_id)
+    third_snapshot = session.get(UsLaceyEvidenceSnapshot, third.snapshot_id)
+    assert second_snapshot is not None
+    assert third_snapshot is not None
+    assert second_snapshot.status == "SUPERSEDED"
+    assert third_snapshot.status == "CURRENT"
+
+    current_node = session.scalar(
+        select(SemanticEvidenceNode)
+        .join(
+            SemanticSnapshotNode,
+            SemanticSnapshotNode.evidence_node_id == SemanticEvidenceNode.id,
+        )
+        .where(
+            SemanticSnapshotNode.organization_id == org,
+            SemanticSnapshotNode.snapshot_id == third.snapshot_id,
+        )
+    )
+    assert current_node is not None
+    assert current_node.normalized_value == "Reviewed normalized evidence"
     session.close()

--- a/tests/test_us_lacey_shadow_eligibility_postgres.py
+++ b/tests/test_us_lacey_shadow_eligibility_postgres.py
@@ -1,0 +1,250 @@
+from __future__ import annotations
+
+from contextlib import nullcontext
+
+import pytest
+from sqlalchemy import func, inspect, select
+
+from litoral_trace.db.models import (
+    DocumentExtractionRun,
+    DocumentTextSpan,
+    ExtractedDocumentField,
+    SemanticEvidenceNode,
+    UsLaceyEvidenceSnapshot,
+)
+from litoral_trace.us_lacey import shadow_evidence_snapshot as shadow
+from tests.us_lacey_engine2_postgres import (
+    create_test_graph,
+    engine2_postgres_engine,
+    engine2_postgres_session_factory,
+    tenant_session,
+)
+
+
+def _no_lock(**_: object):
+    return nullcontext()
+
+
+def _require_phase_b_schema(engine) -> None:
+    required = {
+        "us_lacey_evidence_snapshots",
+        "us_lacey_evidence_snapshot_documents",
+        "document_text_spans",
+        "semantic_evidence_nodes",
+        "semantic_snapshot_nodes",
+    }
+    if not required.issubset(inspect(engine).get_table_names()):
+        pytest.skip("POSTGRES_SCHEMA_NOT_MIGRATED_TO_047")
+
+
+def _add_extraction_run(
+    factory,
+    *,
+    organization_id: int,
+    assurance_document_id: int,
+    status: str,
+    original_value: str | None = None,
+    source_page: int = 1,
+) -> int:
+    session = tenant_session(factory, organization_id)
+    run = DocumentExtractionRun(
+        organization_id=organization_id,
+        assurance_document_id=assurance_document_id,
+        engine="phase-b-eligibility-test",
+        engine_version="1",
+        status=status,
+    )
+    session.add(run)
+    session.flush()
+
+    if original_value is not None:
+        session.add(
+            ExtractedDocumentField(
+                organization_id=organization_id,
+                assurance_document_id=assurance_document_id,
+                extraction_run_id=run.id,
+                field_name="description",
+                original_value=original_value,
+                normalized_value=original_value,
+                value_type="text",
+                confidence=0.95,
+                confidence_level="HIGH",
+                source_page=source_page,
+                source_locator=f"legacy:page:{source_page}:description",
+                auto_accepted=False,
+                needs_review=status == "NEEDS_REVIEW",
+            )
+        )
+
+    run_id = run.id
+    session.commit()
+    session.close()
+    return run_id
+
+
+def _build_snapshot(factory, *, organization_id: int, operation_id: int):
+    return shadow.build_shadow_evidence_snapshot(
+        organization_id=organization_id,
+        operation_id=operation_id,
+        use_configured_translation_provider=False,
+        session_factory=factory,
+        lock_factory=_no_lock,
+    )
+
+
+def test_shadow_snapshot_accepts_latest_needs_review_extraction(
+    monkeypatch,
+    engine2_postgres_engine,
+    engine2_postgres_session_factory,
+):
+    _require_phase_b_schema(engine2_postgres_engine)
+    monkeypatch.setenv(shadow.SHADOW_FLAG, "1")
+
+    org, operation_id, _, assurance_id, _, _ = create_test_graph(
+        engine2_postgres_session_factory,
+        content=b"phase-b-needs-review-evidence",
+    )
+    run_id = _add_extraction_run(
+        engine2_postgres_session_factory,
+        organization_id=org,
+        assurance_document_id=assurance_id,
+        status="NEEDS_REVIEW",
+        original_value="Madera aserrada de eucalipto para exportacion",
+    )
+
+    result = _build_snapshot(
+        engine2_postgres_session_factory,
+        organization_id=org,
+        operation_id=operation_id,
+    )
+
+    assert result.created is True
+    assert result.reason == "CREATED"
+    assert result.metrics.spans_created > 0
+    assert result.metrics.semantic_nodes_created > 0
+
+    session = tenant_session(engine2_postgres_session_factory, org)
+    snapshot = session.get(UsLaceyEvidenceSnapshot, result.snapshot_id)
+    assert snapshot is not None
+    assert snapshot.status == "CURRENT"
+    assert snapshot.generation == 1
+    assert snapshot.node_count > 0
+    assert session.scalar(
+        select(func.count()).select_from(DocumentTextSpan).where(
+            DocumentTextSpan.organization_id == org,
+            DocumentTextSpan.extraction_run_id == run_id,
+        )
+    ) > 0
+    assert session.scalar(
+        select(func.count()).select_from(SemanticEvidenceNode).where(
+            SemanticEvidenceNode.organization_id == org,
+            SemanticEvidenceNode.extraction_run_id == run_id,
+        )
+    ) > 0
+    session.close()
+
+
+def test_shadow_snapshot_rejects_running_extraction(
+    monkeypatch,
+    engine2_postgres_engine,
+    engine2_postgres_session_factory,
+):
+    _require_phase_b_schema(engine2_postgres_engine)
+    monkeypatch.setenv(shadow.SHADOW_FLAG, "1")
+
+    org, operation_id, _, assurance_id, _, _ = create_test_graph(
+        engine2_postgres_session_factory,
+        content=b"phase-b-running-evidence",
+    )
+    _add_extraction_run(
+        engine2_postgres_session_factory,
+        organization_id=org,
+        assurance_document_id=assurance_id,
+        status="SUCCEEDED",
+        original_value="Previously completed extraction",
+    )
+    _add_extraction_run(
+        engine2_postgres_session_factory,
+        organization_id=org,
+        assurance_document_id=assurance_id,
+        status="RUNNING",
+    )
+
+    result = _build_snapshot(
+        engine2_postgres_session_factory,
+        organization_id=org,
+        operation_id=operation_id,
+    )
+
+    assert result.created is False
+    assert result.reason == "SOURCE_SET_EXTRACTION_IN_PROGRESS"
+    assert result.snapshot_id is None
+    assert result.source_set_fingerprint is None
+
+    session = tenant_session(engine2_postgres_session_factory, org)
+    assert session.scalar(
+        select(func.count()).select_from(UsLaceyEvidenceSnapshot).where(
+            UsLaceyEvidenceSnapshot.organization_id == org,
+            UsLaceyEvidenceSnapshot.operation_id == operation_id,
+        )
+    ) == 0
+    session.close()
+
+
+def test_shadow_fingerprint_mutates_on_new_extraction_run(
+    monkeypatch,
+    engine2_postgres_engine,
+    engine2_postgres_session_factory,
+):
+    _require_phase_b_schema(engine2_postgres_engine)
+    monkeypatch.setenv(shadow.SHADOW_FLAG, "1")
+
+    org, operation_id, _, assurance_id, _, _ = create_test_graph(
+        engine2_postgres_session_factory,
+        content=b"phase-b-fingerprint-evidence",
+    )
+    first_run_id = _add_extraction_run(
+        engine2_postgres_session_factory,
+        organization_id=org,
+        assurance_document_id=assurance_id,
+        status="SUCCEEDED",
+        original_value="Same extracted evidence across parser runs",
+    )
+
+    first = _build_snapshot(
+        engine2_postgres_session_factory,
+        organization_id=org,
+        operation_id=operation_id,
+    )
+    assert first.created is True
+    assert first.metrics.generation == 1
+
+    second_run_id = _add_extraction_run(
+        engine2_postgres_session_factory,
+        organization_id=org,
+        assurance_document_id=assurance_id,
+        status="SUCCEEDED",
+        original_value="Same extracted evidence across parser runs",
+    )
+    assert second_run_id != first_run_id
+
+    second = _build_snapshot(
+        engine2_postgres_session_factory,
+        organization_id=org,
+        operation_id=operation_id,
+    )
+
+    assert second.created is True
+    assert second.metrics.generation == 2
+    assert second.snapshot_id != first.snapshot_id
+    assert second.source_set_fingerprint != first.source_set_fingerprint
+
+    session = tenant_session(engine2_postgres_session_factory, org)
+    first_snapshot = session.get(UsLaceyEvidenceSnapshot, first.snapshot_id)
+    second_snapshot = session.get(UsLaceyEvidenceSnapshot, second.snapshot_id)
+    assert first_snapshot is not None
+    assert second_snapshot is not None
+    assert first_snapshot.status == "SUPERSEDED"
+    assert second_snapshot.status == "CURRENT"
+    assert first_snapshot.source_set_fingerprint != second_snapshot.source_set_fingerprint
+    session.close()


### PR DESCRIPTION
## Summary
- make the latest `DocumentExtractionRun` authoritative for multilingual shadow eligibility
- accept terminal reviewable evidence (`SUCCEEDED`, `NEEDS_REVIEW`)
- block `RUNNING` with `SOURCE_SET_EXTRACTION_IN_PROGRESS`
- block failed/unknown unusable states with `SOURCE_SET_EXTRACTION_UNUSABLE`
- include `extraction_run_id` in the immutable source-set fingerprint so re-extracting the same file creates a new evidence generation
- add PostgreSQL coverage for `NEEDS_REVIEW`, latest-`RUNNING`, and re-extraction fingerprint/generation behavior

## Safety boundary
The legacy extraction/projection/read path is unchanged. These changes are confined to the write-only multilingual shadow evidence builder and its PostgreSQL acceptance coverage.

## Required acceptance
- CI green
- US Lacey PostgreSQL Gate green
- GT02 can be rerun only after this PR is merged/deployed