### PR TITLE
fix(us-lacey): set AWS Translate region

### DIFF
--- a/deploy/render-us-lacey-pilot-free.yaml
+++ b/deploy/render-us-lacey-pilot-free.yaml
@@ -62,6 +62,11 @@ services:
         value: "1"
       - key: LT_LACEY_TRANSLATION_PROVIDER
         value: "aws"
+      - key: AWS_REGION
+        value: "us-east-1"
+      # The shadow builder consumes this application-specific region explicitly.
+      - key: LT_LACEY_TRANSLATION_AWS_REGION
+        value: "us-east-1"
 
       # The web IAM identity already has private read/write access to the same
       # isolated prefix used by document ingestion and processing.

--- a/deploy/render-us-lacey-pilot.yaml
+++ b/deploy/render-us-lacey-pilot.yaml
@@ -127,3 +127,8 @@ services:
         value: "1"
       - key: LT_LACEY_TRANSLATION_PROVIDER
         value: "aws"
+      - key: AWS_REGION
+        value: "us-east-1"
+      # The shadow builder consumes this application-specific region explicitly.
+      - key: LT_LACEY_TRANSLATION_AWS_REGION
+        value: "us-east-1"


### PR DESCRIPTION
## Summary
- set `AWS_REGION=us-east-1` on the free U.S. Lacey pilot service and the dedicated worker topology
- also set `LT_LACEY_TRANSLATION_AWS_REGION=us-east-1` because the current shadow builder reads that application-specific variable and passes it explicitly to `AwsTranslateProvider`
- leave AWS credentials out of source control

## Credential note
The Render blueprints currently define only `US_LACEY_STORAGE_ACCESS_KEY_ID` / `US_LACEY_STORAGE_SECRET_ACCESS_KEY` as `sync: false`; there is no committed `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, or `envVarGroup` for the translation client. AWS Translate uses the standard boto3 credential chain, so the production Render service must have `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` supplied securely in Render (or an equivalent credential source) before translations can succeed.

## Acceptance
- CI green
- US Lacey PostgreSQL Gate green
- merge to `feature/us-lacey-pilot-platform`
- Render autodeploy reaches Live