### PR TITLE
feat(us-lacey): Phase D semantic read path and bounded translation backfill

### DIFF
--- a/src/litoral_trace/us_lacey/semantic_evidence_read.py
+++ b/src/litoral_trace/us_lacey/semantic_evidence_read.py
@@ -1,0 +1,170 @@
+"""Read-only Phase D projection for multilingual semantic evidence.
+
+The immutable source span remains authoritative. English translations are optional
+interpretations attached to that span and are selected only for presentation.
+"""
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+from uuid import UUID
+
+from sqlalchemy import and_, case, select
+from sqlalchemy.orm import Session
+
+from litoral_trace.db.models import (
+    DocumentTextSpan,
+    DocumentTextTranslation,
+    SemanticEvidenceNode,
+    SemanticSnapshotNode,
+    UsLaceyOperation,
+)
+from litoral_trace.db.tenant import set_tenant_db_context
+from litoral_trace.us_lacey.db import get_us_lacey_db_session
+
+
+SessionFactory = Callable[[], Session]
+_LANGUAGE_LABELS = {
+    "es": "Spanish",
+    "pt": "Portuguese",
+    "zh": "Chinese",
+    "en": "English",
+}
+
+
+@dataclass(frozen=True, slots=True)
+class EvidenceTextView:
+    """Customer-safe text projection preserving the original source evidence."""
+
+    source_span_id: int
+    target_field: str
+    original_text: str
+    original_language: str
+    translated_text: str | None
+    display_text: str
+    is_translated: bool
+    original_language_label: str
+    source_assurance_document_id: int
+    source_page: int
+    source_locator: str | None
+
+
+def evidence_text_view(
+    *,
+    span: DocumentTextSpan,
+    target_field: str,
+    translation: DocumentTextTranslation | None,
+) -> EvidenceTextView:
+    """Build the immutable-source/fallback contract independently of SQL."""
+    original_text = str(span.original_text or "")
+    original_language = str(span.original_language or "und").strip().lower() or "und"
+    translated = ""
+    if translation is not None:
+        translated = str(translation.translated_text or "").strip()
+    return EvidenceTextView(
+        source_span_id=int(span.id),
+        target_field=str(target_field or ""),
+        original_text=original_text,
+        original_language=original_language,
+        translated_text=translated or None,
+        display_text=translated or original_text,
+        is_translated=bool(translated),
+        original_language_label=_LANGUAGE_LABELS.get(
+            original_language, original_language.upper() if original_language != "und" else "Unknown"
+        ),
+        source_assurance_document_id=int(span.assurance_document_id),
+        source_page=int(span.page),
+        source_locator=span.source_locator,
+    )
+
+
+class SemanticEvidenceReadService:
+    """Read the CURRENT immutable snapshot plus its optional English translations."""
+
+    def __init__(self, *, session_factory: SessionFactory | None = None) -> None:
+        self._session_factory = session_factory or get_us_lacey_db_session
+
+    def get_operation_evidence(
+        self,
+        *,
+        organization_id: int,
+        operation_public_id: UUID | str,
+    ) -> dict[str, tuple[EvidenceTextView, ...]]:
+        org_id = int(organization_id)
+        session = self._session_factory()
+        try:
+            set_tenant_db_context(session, org_id)
+            operation = session.scalar(
+                select(UsLaceyOperation).where(
+                    UsLaceyOperation.organization_id == org_id,
+                    UsLaceyOperation.public_id == UUID(str(operation_public_id)),
+                )
+            )
+            if operation is None or operation.current_evidence_snapshot_id is None:
+                return {}
+
+            provider_preference = case(
+                (DocumentTextTranslation.provider == "OPEN_SOURCE_GOOGLE", 0),
+                else_=1,
+            )
+            translation_presence = case(
+                (DocumentTextTranslation.id.is_(None), 1),
+                else_=0,
+            )
+            rows = session.execute(
+                select(SemanticEvidenceNode, DocumentTextSpan, DocumentTextTranslation)
+                .join(
+                    SemanticSnapshotNode,
+                    and_(
+                        SemanticSnapshotNode.organization_id == SemanticEvidenceNode.organization_id,
+                        SemanticSnapshotNode.evidence_node_id == SemanticEvidenceNode.id,
+                    ),
+                )
+                .join(
+                    DocumentTextSpan,
+                    and_(
+                        DocumentTextSpan.organization_id == SemanticEvidenceNode.organization_id,
+                        DocumentTextSpan.id == SemanticEvidenceNode.source_span_id,
+                    ),
+                )
+                .outerjoin(
+                    DocumentTextTranslation,
+                    and_(
+                        DocumentTextTranslation.organization_id == DocumentTextSpan.organization_id,
+                        DocumentTextTranslation.source_span_id == DocumentTextSpan.id,
+                        DocumentTextTranslation.target_language == "en",
+                    ),
+                )
+                .where(
+                    SemanticSnapshotNode.organization_id == org_id,
+                    SemanticSnapshotNode.snapshot_id == operation.current_evidence_snapshot_id,
+                    SemanticEvidenceNode.organization_id == org_id,
+                )
+                .order_by(
+                    SemanticEvidenceNode.target_field.asc(),
+                    DocumentTextSpan.id.asc(),
+                    translation_presence.asc(),
+                    provider_preference.asc(),
+                    DocumentTextTranslation.id.desc(),
+                )
+            ).all()
+
+            by_field: dict[str, list[EvidenceTextView]] = {}
+            seen: set[tuple[str, int]] = set()
+            for node, span, translation in rows:
+                key = (str(node.target_field), int(span.id))
+                # The ORDER BY puts the preferred English interpretation first.
+                # Keep exactly one presentation row per immutable source span.
+                if key in seen:
+                    continue
+                seen.add(key)
+                by_field.setdefault(str(node.target_field), []).append(
+                    evidence_text_view(
+                        span=span,
+                        target_field=node.target_field,
+                        translation=translation,
+                    )
+                )
+            return {key: tuple(values) for key, values in by_field.items()}
+        finally:
+            session.close()

--- a/src/litoral_trace/us_lacey/translation_backfill.py
+++ b/src/litoral_trace/us_lacey/translation_backfill.py
@@ -1,0 +1,257 @@
+"""Bounded, best-effort backfill for historical multilingual source spans.
+
+The live U.S. Lacey read/write workflow never waits for this module. One startup
+attempt processes at most 50 immutable spans and then exits; any remainder is
+left for a later process restart.
+"""
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Awaitable, Callable, Sequence
+from dataclasses import dataclass
+import hashlib
+import logging
+
+from sqlalchemy import and_, select
+
+from litoral_trace.db.models import DocumentTextSpan, DocumentTextTranslation
+from litoral_trace.db.models.organization import Organization
+from litoral_trace.db.tenant import set_tenant_db_context
+from litoral_trace.services.translation import (
+    OpenSourceTranslationProvider,
+    TranslationProvider,
+    TranslationResult,
+)
+from litoral_trace.us_lacey.db import get_us_lacey_db_session
+from litoral_trace.us_lacey.shadow_evidence_snapshot import configured_translation_provider
+
+
+LOGGER = logging.getLogger(__name__)
+BACKFILL_LIMIT = 50
+BACKFILL_DELAY_SECONDS = 0.5
+TRANSLATABLE_LANGUAGES = ("es", "pt", "zh")
+TARGET_LANGUAGE = "en"
+
+
+@dataclass(frozen=True, slots=True)
+class TranslationBackfillCandidate:
+    organization_id: int
+    source_span_id: int
+    original_text: str
+    original_language: str
+
+
+@dataclass(frozen=True, slots=True)
+class TranslationBackfillWrite:
+    candidate: TranslationBackfillCandidate
+    result: TranslationResult
+
+
+LoadCandidates = Callable[[int], Sequence[TranslationBackfillCandidate]]
+PersistWrites = Callable[[Sequence[TranslationBackfillWrite]], int]
+Sleeper = Callable[[float], Awaitable[None]]
+
+
+def _sha256_text(value: str) -> str:
+    return hashlib.sha256(value.encode("utf-8")).hexdigest()
+
+
+def _organization_ids() -> tuple[int, ...]:
+    session = get_us_lacey_db_session()
+    try:
+        return tuple(
+            int(value)
+            for value in session.scalars(
+                select(Organization.id).order_by(Organization.id.asc())
+            ).all()
+        )
+    finally:
+        session.close()
+
+
+def _load_missing_candidates(limit: int) -> tuple[TranslationBackfillCandidate, ...]:
+    """Load at most the hard process budget while respecting tenant RLS."""
+    hard_limit = min(max(int(limit), 0), BACKFILL_LIMIT)
+    if hard_limit == 0:
+        return ()
+
+    candidates: list[TranslationBackfillCandidate] = []
+    for organization_id in _organization_ids():
+        remaining = hard_limit - len(candidates)
+        if remaining <= 0:
+            break
+        session = get_us_lacey_db_session()
+        try:
+            set_tenant_db_context(session, organization_id)
+            spans = session.scalars(
+                select(DocumentTextSpan)
+                .outerjoin(
+                    DocumentTextTranslation,
+                    and_(
+                        DocumentTextTranslation.organization_id
+                        == DocumentTextSpan.organization_id,
+                        DocumentTextTranslation.source_span_id == DocumentTextSpan.id,
+                        DocumentTextTranslation.target_language == TARGET_LANGUAGE,
+                    ),
+                )
+                .where(
+                    DocumentTextSpan.organization_id == organization_id,
+                    DocumentTextSpan.original_language.in_(TRANSLATABLE_LANGUAGES),
+                    DocumentTextTranslation.id.is_(None),
+                )
+                .order_by(DocumentTextSpan.id.asc())
+                .limit(remaining)
+            ).all()
+            candidates.extend(
+                TranslationBackfillCandidate(
+                    organization_id=organization_id,
+                    source_span_id=int(span.id),
+                    original_text=str(span.original_text or ""),
+                    original_language=str(span.original_language or "und"),
+                )
+                for span in spans
+            )
+        finally:
+            session.close()
+    # Defense in depth: no loader refactor may raise the per-startup budget.
+    return tuple(candidates[:BACKFILL_LIMIT])
+
+
+def _persist_writes(writes: Sequence[TranslationBackfillWrite]) -> int:
+    """Commit one small transaction per tenant; source spans are never mutated."""
+    by_organization: dict[int, list[TranslationBackfillWrite]] = {}
+    for write in writes[:BACKFILL_LIMIT]:
+        by_organization.setdefault(write.candidate.organization_id, []).append(write)
+
+    created = 0
+    for organization_id, organization_writes in by_organization.items():
+        session = get_us_lacey_db_session()
+        try:
+            set_tenant_db_context(session, organization_id)
+            for write in organization_writes:
+                candidate = write.candidate
+                result = write.result
+                # Recheck after the network call so concurrent startup attempts are
+                # harmless even when two instances briefly overlap during a deploy.
+                existing = session.scalar(
+                    select(DocumentTextTranslation.id)
+                    .where(
+                        DocumentTextTranslation.organization_id == organization_id,
+                        DocumentTextTranslation.source_span_id == candidate.source_span_id,
+                        DocumentTextTranslation.target_language == TARGET_LANGUAGE,
+                    )
+                    .limit(1)
+                )
+                if existing is not None:
+                    continue
+                translated_text = str(result.translated_text or "").strip()
+                if not translated_text:
+                    continue
+                quality = result.metadata.get("quality_score") if result.metadata else None
+                session.add(
+                    DocumentTextTranslation(
+                        organization_id=organization_id,
+                        source_span_id=candidate.source_span_id,
+                        source_language=candidate.original_language,
+                        target_language=TARGET_LANGUAGE,
+                        translated_text=translated_text,
+                        provider=result.provider,
+                        model_name=result.model_name,
+                        model_version=result.model_version,
+                        quality_score=(
+                            float(quality) if isinstance(quality, (int, float)) else None
+                        ),
+                        input_hash=_sha256_text(candidate.original_text),
+                        output_hash=_sha256_text(translated_text),
+                    )
+                )
+                created += 1
+            session.commit()
+        except Exception:
+            session.rollback()
+            raise
+        finally:
+            session.close()
+    return created
+
+
+async def _run_translation_backfill_batch(
+    *,
+    provider: TranslationProvider,
+    load_candidates: LoadCandidates = _load_missing_candidates,
+    persist_writes: PersistWrites = _persist_writes,
+    sleeper: Sleeper = asyncio.sleep,
+) -> int:
+    candidates = tuple(
+        (await asyncio.to_thread(load_candidates, BACKFILL_LIMIT))[:BACKFILL_LIMIT]
+    )
+    if not candidates:
+        return 0
+
+    writes: list[TranslationBackfillWrite] = []
+    for index, candidate in enumerate(candidates):
+        try:
+            result = await asyncio.to_thread(
+                provider.translate,
+                candidate.original_text,
+                candidate.original_language,
+                TARGET_LANGUAGE,
+            )
+            if str(result.translated_text or "").strip():
+                writes.append(TranslationBackfillWrite(candidate=candidate, result=result))
+        except Exception:
+            # A public provider can be temporarily unavailable. Keep immutable source
+            # evidence untouched and leave this span eligible for the next restart.
+            LOGGER.warning(
+                "us_lacey_translation_backfill_span_failed source_span_id=%s language=%s",
+                candidate.source_span_id,
+                candidate.original_language,
+                exc_info=True,
+            )
+        if index + 1 < len(candidates):
+            await sleeper(BACKFILL_DELAY_SECONDS)
+
+    if not writes:
+        return 0
+    created = await asyncio.to_thread(persist_writes, tuple(writes))
+    LOGGER.info(
+        "us_lacey_translation_backfill_complete selected=%s translated=%s persisted=%s limit=%s",
+        len(candidates),
+        len(writes),
+        created,
+        BACKFILL_LIMIT,
+    )
+    return int(created)
+
+
+async def run_translation_backfill(
+    *,
+    provider: TranslationProvider | None = None,
+    load_candidates: LoadCandidates = _load_missing_candidates,
+    persist_writes: PersistWrites = _persist_writes,
+    sleeper: Sleeper = asyncio.sleep,
+) -> int:
+    """Best-effort public entrypoint designed for a detached FastAPI startup task."""
+    try:
+        selected_provider = provider
+        if selected_provider is None:
+            selected_provider = configured_translation_provider()
+            # Never make the automatic repair path silently fall back to a paid API.
+            if not isinstance(selected_provider, OpenSourceTranslationProvider):
+                return 0
+        if selected_provider is None:
+            return 0
+        return await _run_translation_backfill_batch(
+            provider=selected_provider,
+            load_candidates=load_candidates,
+            persist_writes=persist_writes,
+            sleeper=sleeper,
+        )
+    except asyncio.CancelledError:
+        raise
+    except Exception:
+        LOGGER.warning(
+            "us_lacey_translation_backfill_failed retry=next_startup",
+            exc_info=True,
+        )
+        return 0

--- a/src/litoral_trace/web/us_lacey_operational_views.py
+++ b/src/litoral_trace/web/us_lacey_operational_views.py
@@ -3,10 +3,20 @@ from __future__ import annotations
 
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass, replace
+import logging
+
+from markupsafe import Markup, escape
 
 from litoral_trace.us_lacey.candidate_normalization import group_candidate_evidence
 from litoral_trace.us_lacey.ppq505 import PPQ505_FIELDS_BY_KEY
+from litoral_trace.us_lacey.semantic_evidence_read import (
+    EvidenceTextView,
+    SemanticEvidenceReadService,
+)
 from litoral_trace.web.templates import templates
+
+
+LOGGER = logging.getLogger(__name__)
 
 
 def _render(request, name: str, **context: object) -> str:
@@ -150,6 +160,102 @@ def _review_field_sets(detail):
     return exception_fields, settled_fields
 
 
+def _semantic_evidence_for_detail(identity, detail) -> dict[str, tuple[EvidenceTextView, ...]]:
+    """Read optional Phase D evidence without making the legacy UI depend on it."""
+    organization_id = getattr(identity, "organization_id", None)
+    operation_public_id = getattr(detail, "public_id", None)
+    if not organization_id or operation_public_id is None:
+        return {}
+    try:
+        return SemanticEvidenceReadService().get_operation_evidence(
+            organization_id=int(organization_id),
+            operation_public_id=operation_public_id,
+        )
+    except Exception:
+        # The semantic layer remains additive during Phase D. A read-side problem must
+        # never hide the authoritative human-review workflow.
+        LOGGER.exception(
+            "us_lacey_semantic_evidence_read_failed",
+            extra={"organization_id": int(organization_id)},
+        )
+        return {}
+
+
+def _evidence_for_field(field, evidence_by_field: Mapping[str, tuple[EvidenceTextView, ...]]):
+    items = tuple(evidence_by_field.get(str(getattr(field, "field_name", "")), ()))
+    if not items:
+        return ()
+    source_document_id = getattr(field, "source_assurance_document_id", None)
+    source_page = getattr(field, "source_page", None)
+    preferred = tuple(
+        item
+        for item in items
+        if (source_document_id is None or item.source_assurance_document_id == source_document_id)
+        and (source_page is None or str(item.source_page) == str(source_page))
+    )
+    return preferred or items
+
+
+def _semantic_evidence_markup(evidence: EvidenceTextView) -> Markup:
+    """Inline-safe evidence UI for the existing Jinja review card.
+
+    The translated interpretation is visible by default. The badge's native tooltip
+    always exposes the immutable original source text, including on a no-JS page.
+    """
+    display = escape(evidence.display_text)
+    source_meta = Markup(
+        '<span class="text-xs text-slate-500">Document evidence · page {}</span>'
+    ).format(escape(str(evidence.source_page)))
+    if evidence.is_translated:
+        badge = Markup(
+            '<span class="ml-2 inline-flex rounded-full bg-sky-50 px-2 py-0.5 text-xs font-semibold text-sky-800" '
+            'data-translation-badge data-original-language="{}" title="Original evidence: {}">Translated from {}</span>'
+        ).format(
+            escape(evidence.original_language),
+            escape(evidence.original_text),
+            escape(evidence.original_language_label),
+        )
+    else:
+        badge = Markup("")
+    return Markup(
+        '<br><span class="mt-2 inline-block text-sm text-slate-700" data-semantic-evidence '
+        'data-source-span-id="{}"><span class="font-semibold">Evidence:</span> {}</span> {} {}'
+    ).format(
+        escape(str(evidence.source_span_id)),
+        display,
+        badge,
+        source_meta,
+    )
+
+
+def _decorate_review_fields(fields, evidence_by_field: Mapping[str, tuple[EvidenceTextView, ...]]):
+    """Attach display_text to review cards without mutating evidence or form values."""
+    decorated = []
+    for field in fields:
+        proposed_value = getattr(field, "proposed_value", None)
+        if not proposed_value:
+            decorated.append(field)
+            continue
+        evidence_items = _evidence_for_field(field, evidence_by_field)
+        if not evidence_items:
+            decorated.append(field)
+            continue
+        presentation = Markup("{}").format(escape(str(proposed_value)))
+        for evidence in evidence_items:
+            presentation += _semantic_evidence_markup(evidence)
+        decorated.append(replace(field, proposed_value=presentation))
+    return decorated
+
+
+def _review_field_sets_with_semantic_evidence(identity, detail):
+    exception_fields, settled_fields = _review_field_sets(detail)
+    evidence_by_field = _semantic_evidence_for_detail(identity, detail)
+    return (
+        _decorate_review_fields(exception_fields, evidence_by_field),
+        _decorate_review_fields(settled_fields, evidence_by_field),
+    )
+
+
 def render_operations(*, request, identity, operations: Sequence, entitlement) -> str:
     return _render(request, "operations", identity=identity, operations=operations, entitlement=entitlement)
 
@@ -159,7 +265,7 @@ def render_new_operation(*, request, identity, entitlement, csrf_token: str, err
 
 
 def render_operation_detail(*, request, identity, detail, engine2_dossier, upload_csrf: str, complete_csrf: str, review_csrf: Mapping[int, str], error: str | None = None, notice: str | None = None) -> str:
-    exception_fields, settled_fields = _review_field_sets(detail)
+    exception_fields, settled_fields = _review_field_sets_with_semantic_evidence(identity, detail)
     progress = processing_view(detail)
     return _render(request, "operation_detail", identity=identity, detail=detail, engine2_dossier=engine2_dossier, upload_csrf=upload_csrf, complete_csrf=complete_csrf, review_csrf=review_csrf, exception_fields=exception_fields, settled_fields=settled_fields, processing=progress, error=error, notice=notice)
 
@@ -169,7 +275,7 @@ def render_processing_fragment(*, request, detail) -> str:
 
 
 def render_operation_workspace(*, request, identity, detail, engine2_dossier, complete_csrf: str, review_csrf: Mapping[int, str], error: str | None = None, is_oob_update: bool | None = None) -> str:
-    exception_fields, settled_fields = _review_field_sets(detail)
+    exception_fields, settled_fields = _review_field_sets_with_semantic_evidence(identity, detail)
     # Initial workspace hydration is a GET and must render its own summary/banner/final
     # confirmation normally. Review mutations are POSTs and update those regions OOB.
     if is_oob_update is None:

--- a/src/litoral_trace/web/us_lacey_unified_app.py
+++ b/src/litoral_trace/web/us_lacey_unified_app.py
@@ -10,6 +10,8 @@ plus /admin for an authenticated persisted platform superadmin.
 """
 from __future__ import annotations
 
+import asyncio
+from contextlib import asynccontextmanager, suppress
 import re
 
 from fastapi import Request, Response
@@ -24,11 +26,40 @@ from litoral_trace.us_lacey.portal_auth import (
     UsLaceyPortalAuthError,
     resolve_us_lacey_session,
 )
+from litoral_trace.us_lacey.translation_backfill import run_translation_backfill
 from litoral_trace.web.lacey_gtm import render_lacey_landing, router as lacey_router
 from litoral_trace.web.us_lacey_free_app import app
 from litoral_trace.web.us_lacey_intelligent_workflow import router as intelligent_workflow_router
 from litoral_trace.web.us_lacey_lemon_billing import router as lemon_billing_router
 from litoral_trace.web.us_lacey_platform_admin import router as platform_admin_router
+
+
+# Preserve the already-certified free-tier lifespan (inline worker, storage probe)
+# and add the historical translation repair as a detached one-shot task. Scheduling
+# with create_task means HTTP startup never waits for PostgreSQL or the public
+# translation backend. All synchronous DB/network work inside the task uses
+# asyncio.to_thread() and the task is capped at 50 spans per process start.
+_free_tier_lifespan_context = app.router.lifespan_context
+
+
+@asynccontextmanager
+async def _phase_d_lifespan(application):
+    async with _free_tier_lifespan_context(application) as state:
+        backfill_task = asyncio.create_task(
+            run_translation_backfill(),
+            name="us-lacey-translation-backfill",
+        )
+        application.state.us_lacey_translation_backfill_task = backfill_task
+        try:
+            yield state
+        finally:
+            if not backfill_task.done():
+                backfill_task.cancel()
+            with suppress(asyncio.CancelledError):
+                await backfill_task
+
+
+app.router.lifespan_context = _phase_d_lifespan
 
 
 # Public marketing/sample, payment-provider, upload-first workflow and superadmin

--- a/tests/test_us_lacey_phase_d_translation.py
+++ b/tests/test_us_lacey_phase_d_translation.py
@@ -1,0 +1,163 @@
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass
+from types import SimpleNamespace
+
+from litoral_trace.services.translation import TranslationResult
+from litoral_trace.us_lacey.semantic_evidence_read import EvidenceTextView, evidence_text_view
+from litoral_trace.us_lacey.translation_backfill import (
+    BACKFILL_DELAY_SECONDS,
+    BACKFILL_LIMIT,
+    TranslationBackfillCandidate,
+    run_translation_backfill,
+)
+from litoral_trace.web.us_lacey_operational_views import _decorate_review_fields
+
+
+def test_read_projection_falls_back_to_original_text_without_translation():
+    span = SimpleNamespace(
+        id=42,
+        assurance_document_id=7,
+        page=3,
+        source_locator="page:3:block:2",
+        original_text="Factura comercial de productos de madera",
+        original_language="es",
+    )
+
+    view = evidence_text_view(
+        span=span,
+        target_field="merchandise_description",
+        translation=None,
+    )
+
+    assert view.original_text == "Factura comercial de productos de madera"
+    assert view.original_language == "es"
+    assert view.translated_text is None
+    assert view.display_text == view.original_text
+    assert view.is_translated is False
+
+
+def test_read_projection_prefers_translation_but_preserves_original():
+    span = SimpleNamespace(
+        id=43,
+        assurance_document_id=7,
+        page=4,
+        source_locator="page:4:block:1",
+        original_text="Madeira serrada de pinus",
+        original_language="pt",
+    )
+    translation = SimpleNamespace(translated_text="Sawn pine wood")
+
+    view = evidence_text_view(
+        span=span,
+        target_field="merchandise_description",
+        translation=translation,
+    )
+
+    assert view.translated_text == "Sawn pine wood"
+    assert view.display_text == "Sawn pine wood"
+    assert view.is_translated is True
+    assert view.original_text == "Madeira serrada de pinus"
+    assert view.original_language_label == "Portuguese"
+
+
+class _FakeProvider:
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, str, str]] = []
+
+    def translate(self, text: str, source: str, target: str = "en") -> TranslationResult:
+        self.calls.append((text, source, target))
+        return TranslationResult(
+            translated_text=f"EN:{text}",
+            source_language=source,
+            target_language=target,
+            provider="OPEN_SOURCE_GOOGLE",
+            model_name="test-provider",
+            model_version="1",
+            metadata={},
+        )
+
+
+def test_backfill_hard_caps_at_50_and_yields_between_translations():
+    provider = _FakeProvider()
+    persisted = []
+    sleeps = []
+
+    def load_candidates(limit: int):
+        assert limit == BACKFILL_LIMIT
+        # Deliberately violate the loader contract to prove the async layer still
+        # enforces the innegotiable startup budget.
+        return tuple(
+            TranslationBackfillCandidate(
+                organization_id=1,
+                source_span_id=index + 1,
+                original_text=f"texto {index + 1}",
+                original_language="es",
+            )
+            for index in range(BACKFILL_LIMIT + 10)
+        )
+
+    def persist_writes(writes):
+        persisted.extend(writes)
+        return len(writes)
+
+    async def fake_sleep(delay: float):
+        sleeps.append(delay)
+
+    created = asyncio.run(
+        run_translation_backfill(
+            provider=provider,
+            load_candidates=load_candidates,
+            persist_writes=persist_writes,
+            sleeper=fake_sleep,
+        )
+    )
+
+    assert created == BACKFILL_LIMIT
+    assert len(provider.calls) == BACKFILL_LIMIT
+    assert len(persisted) == BACKFILL_LIMIT
+    assert sleeps == [BACKFILL_DELAY_SECONDS] * (BACKFILL_LIMIT - 1)
+
+
+@dataclass(frozen=True)
+class _ReviewField:
+    field_name: str
+    proposed_value: str
+    source_assurance_document_id: int | None
+    source_page: int | None
+
+
+def test_review_card_uses_display_text_and_keeps_original_in_tooltip():
+    field = _ReviewField(
+        field_name="merchandise_description",
+        proposed_value="Normalized merchandise description",
+        source_assurance_document_id=7,
+        source_page=3,
+    )
+    evidence = EvidenceTextView(
+        source_span_id=42,
+        target_field="merchandise_description",
+        original_text="Descripción de mercancía",
+        original_language="es",
+        translated_text="Merchandise description",
+        display_text="Merchandise description",
+        is_translated=True,
+        original_language_label="Spanish",
+        source_assurance_document_id=7,
+        source_page=3,
+        source_locator="page:3:block:2",
+    )
+
+    decorated = _decorate_review_fields(
+        [field],
+        {"merchandise_description": (evidence,)},
+    )[0]
+    rendered = str(decorated.proposed_value)
+
+    assert "Evidence:</span> Merchandise description" in rendered
+    assert "Translated from Spanish" in rendered
+    assert 'title="Original evidence: Descripción de mercancía"' in rendered
+    # Form/edit value remains separate; only the customer-facing proposed-value
+    # presentation is enriched with semantic evidence.
+    assert rendered.startswith("Normalized merchandise description")


### PR DESCRIPTION
## Summary
- add a tenant-safe Phase D semantic evidence read projection over the CURRENT evidence snapshot
- LEFT JOIN immutable source spans to English translation interpretations and expose `original_text`, `original_language`, `translated_text`, `display_text`, and `is_translated`
- enrich existing review cards with `display_text`; translated evidence gets a discrete `Translated from <language>` badge whose tooltip exposes the immutable original source text
- add a detached FastAPI startup backfill for historical `es`/`pt`/`zh` spans
- hard-cap every startup run at 50 spans and yield 0.5s between public-provider calls
- move synchronous translation/DB work to `asyncio.to_thread()` so API startup/event-loop traffic is not blocked
- preserve tenant RLS and source immutability; commits remain small and tenant-scoped
- never let the automatic repair path fall back to a paid translation provider

## Resource constraints
- no new dependency
- no new service, queue, cron, or worker infrastructure
- zero work after the fast missing-span query returns no candidates
- remainder beyond 50 is intentionally deferred to a later process restart

## Tests
- fallback to `original_text` when no translation exists
- translated read projection preserves original source text
- hard cap of 50 even if a loader returns more rows
- exactly 0.5s cooperative delay between translation attempts
- review-card presentation uses `display_text`, shows the translated-language badge, and keeps the original source text inspectable via tooltip

## Acceptance target
- full CI green
- U.S. Lacey PostgreSQL gate green
- no merge until the gates are reviewed