### PR TITLE
fix(us-lacey): trigger translation backfill just in time per tenant

### DIFF
--- a/src/litoral_trace/us_lacey/translation_backfill.py
+++ b/src/litoral_trace/us_lacey/translation_backfill.py
@@ -1,8 +1,8 @@
 """Bounded, best-effort backfill for historical multilingual source spans.
 
-The live U.S. Lacey read/write workflow never waits for this module. One startup
-attempt processes at most 50 immutable spans and then exits; any remainder is
-left for a later process restart.
+The live U.S. Lacey read/write workflow never waits for this module. Each
+request-triggered attempt is scoped to one authenticated tenant, processes at
+most 50 immutable spans, and then exits.
 """
 from __future__ import annotations
 
@@ -15,7 +15,6 @@ import logging
 from sqlalchemy import and_, select
 
 from litoral_trace.db.models import DocumentTextSpan, DocumentTextTranslation
-from litoral_trace.db.models.organization import Organization
 from litoral_trace.db.tenant import set_tenant_db_context
 from litoral_trace.services.translation import (
     OpenSourceTranslationProvider,
@@ -47,8 +46,8 @@ class TranslationBackfillWrite:
     result: TranslationResult
 
 
-LoadCandidates = Callable[[int], Sequence[TranslationBackfillCandidate]]
-PersistWrites = Callable[[Sequence[TranslationBackfillWrite]], int]
+LoadCandidates = Callable[[int, int], Sequence[TranslationBackfillCandidate]]
+PersistWrites = Callable[[int, Sequence[TranslationBackfillWrite]], int]
 Sleeper = Callable[[float], Awaitable[None]]
 
 
@@ -56,135 +55,148 @@ def _sha256_text(value: str) -> str:
     return hashlib.sha256(value.encode("utf-8")).hexdigest()
 
 
-def _organization_ids() -> tuple[int, ...]:
+def _missing_candidates_statement(organization_id: int, limit: int):
+    """Build the tenant-scoped missing-translation query.
+
+    The caller must also install the same organization in PostgreSQL's RLS GUC
+    before executing the statement. Keeping the explicit predicate as well as
+    RLS gives defense in depth and makes accidental cross-tenant reads fail
+    closed.
+    """
+    tenant_id = int(organization_id)
+    hard_limit = min(max(int(limit), 0), BACKFILL_LIMIT)
+    return (
+        select(DocumentTextSpan)
+        .outerjoin(
+            DocumentTextTranslation,
+            and_(
+                DocumentTextTranslation.organization_id
+                == DocumentTextSpan.organization_id,
+                DocumentTextTranslation.source_span_id == DocumentTextSpan.id,
+                DocumentTextTranslation.target_language == TARGET_LANGUAGE,
+            ),
+        )
+        .where(
+            DocumentTextSpan.organization_id == tenant_id,
+            DocumentTextSpan.original_language.in_(TRANSLATABLE_LANGUAGES),
+            DocumentTextTranslation.id.is_(None),
+        )
+        .order_by(DocumentTextSpan.id.asc())
+        .limit(hard_limit)
+    )
+
+
+def _load_missing_candidates(
+    organization_id: int,
+    limit: int,
+) -> tuple[TranslationBackfillCandidate, ...]:
+    """Load only the authenticated tenant's candidates under FORCE RLS."""
+    hard_limit = min(max(int(limit), 0), BACKFILL_LIMIT)
+    if hard_limit == 0:
+        return ()
+
     session = get_us_lacey_db_session()
     try:
+        tenant_id = set_tenant_db_context(session, organization_id)
+        spans = session.scalars(
+            _missing_candidates_statement(tenant_id, hard_limit)
+        ).all()
         return tuple(
-            int(value)
-            for value in session.scalars(
-                select(Organization.id).order_by(Organization.id.asc())
-            ).all()
+            TranslationBackfillCandidate(
+                organization_id=tenant_id,
+                source_span_id=int(span.id),
+                original_text=str(span.original_text or ""),
+                original_language=str(span.original_language or "und"),
+            )
+            for span in spans[:BACKFILL_LIMIT]
         )
     finally:
         session.close()
 
 
-def _load_missing_candidates(limit: int) -> tuple[TranslationBackfillCandidate, ...]:
-    """Load at most the hard process budget while respecting tenant RLS."""
-    hard_limit = min(max(int(limit), 0), BACKFILL_LIMIT)
-    if hard_limit == 0:
-        return ()
-
-    candidates: list[TranslationBackfillCandidate] = []
-    for organization_id in _organization_ids():
-        remaining = hard_limit - len(candidates)
-        if remaining <= 0:
-            break
-        session = get_us_lacey_db_session()
-        try:
-            set_tenant_db_context(session, organization_id)
-            spans = session.scalars(
-                select(DocumentTextSpan)
-                .outerjoin(
-                    DocumentTextTranslation,
-                    and_(
-                        DocumentTextTranslation.organization_id
-                        == DocumentTextSpan.organization_id,
-                        DocumentTextTranslation.source_span_id == DocumentTextSpan.id,
-                        DocumentTextTranslation.target_language == TARGET_LANGUAGE,
-                    ),
-                )
-                .where(
-                    DocumentTextSpan.organization_id == organization_id,
-                    DocumentTextSpan.original_language.in_(TRANSLATABLE_LANGUAGES),
-                    DocumentTextTranslation.id.is_(None),
-                )
-                .order_by(DocumentTextSpan.id.asc())
-                .limit(remaining)
-            ).all()
-            candidates.extend(
-                TranslationBackfillCandidate(
-                    organization_id=organization_id,
-                    source_span_id=int(span.id),
-                    original_text=str(span.original_text or ""),
-                    original_language=str(span.original_language or "und"),
-                )
-                for span in spans
-            )
-        finally:
-            session.close()
-    # Defense in depth: no loader refactor may raise the per-startup budget.
-    return tuple(candidates[:BACKFILL_LIMIT])
-
-
-def _persist_writes(writes: Sequence[TranslationBackfillWrite]) -> int:
-    """Commit one small transaction per tenant; source spans are never mutated."""
-    by_organization: dict[int, list[TranslationBackfillWrite]] = {}
-    for write in writes[:BACKFILL_LIMIT]:
-        by_organization.setdefault(write.candidate.organization_id, []).append(write)
+def _persist_writes(
+    organization_id: int,
+    writes: Sequence[TranslationBackfillWrite],
+) -> int:
+    """Persist one tenant-only transaction; source spans are never mutated."""
+    tenant_id = int(organization_id)
+    tenant_writes = tuple(writes[:BACKFILL_LIMIT])
+    if any(write.candidate.organization_id != tenant_id for write in tenant_writes):
+        raise ValueError("translation backfill candidate tenant mismatch")
+    if not tenant_writes:
+        return 0
 
     created = 0
-    for organization_id, organization_writes in by_organization.items():
-        session = get_us_lacey_db_session()
-        try:
-            set_tenant_db_context(session, organization_id)
-            for write in organization_writes:
-                candidate = write.candidate
-                result = write.result
-                # Recheck after the network call so concurrent startup attempts are
-                # harmless even when two instances briefly overlap during a deploy.
-                existing = session.scalar(
-                    select(DocumentTextTranslation.id)
-                    .where(
-                        DocumentTextTranslation.organization_id == organization_id,
-                        DocumentTextTranslation.source_span_id == candidate.source_span_id,
-                        DocumentTextTranslation.target_language == TARGET_LANGUAGE,
-                    )
-                    .limit(1)
+    session = get_us_lacey_db_session()
+    try:
+        set_tenant_db_context(session, tenant_id)
+        for write in tenant_writes:
+            candidate = write.candidate
+            result = write.result
+            # Recheck after the network call so overlapping requests remain
+            # harmless even if two web instances briefly schedule the same tenant.
+            existing = session.scalar(
+                select(DocumentTextTranslation.id)
+                .where(
+                    DocumentTextTranslation.organization_id == tenant_id,
+                    DocumentTextTranslation.source_span_id == candidate.source_span_id,
+                    DocumentTextTranslation.target_language == TARGET_LANGUAGE,
                 )
-                if existing is not None:
-                    continue
-                translated_text = str(result.translated_text or "").strip()
-                if not translated_text:
-                    continue
-                quality = result.metadata.get("quality_score") if result.metadata else None
-                session.add(
-                    DocumentTextTranslation(
-                        organization_id=organization_id,
-                        source_span_id=candidate.source_span_id,
-                        source_language=candidate.original_language,
-                        target_language=TARGET_LANGUAGE,
-                        translated_text=translated_text,
-                        provider=result.provider,
-                        model_name=result.model_name,
-                        model_version=result.model_version,
-                        quality_score=(
-                            float(quality) if isinstance(quality, (int, float)) else None
-                        ),
-                        input_hash=_sha256_text(candidate.original_text),
-                        output_hash=_sha256_text(translated_text),
-                    )
+                .limit(1)
+            )
+            if existing is not None:
+                continue
+            translated_text = str(result.translated_text or "").strip()
+            if not translated_text:
+                continue
+            quality = result.metadata.get("quality_score") if result.metadata else None
+            session.add(
+                DocumentTextTranslation(
+                    organization_id=tenant_id,
+                    source_span_id=candidate.source_span_id,
+                    source_language=candidate.original_language,
+                    target_language=TARGET_LANGUAGE,
+                    translated_text=translated_text,
+                    provider=result.provider,
+                    model_name=result.model_name,
+                    model_version=result.model_version,
+                    quality_score=(
+                        float(quality) if isinstance(quality, (int, float)) else None
+                    ),
+                    input_hash=_sha256_text(candidate.original_text),
+                    output_hash=_sha256_text(translated_text),
                 )
-                created += 1
-            session.commit()
-        except Exception:
-            session.rollback()
-            raise
-        finally:
-            session.close()
+            )
+            created += 1
+        session.commit()
+    except Exception:
+        session.rollback()
+        raise
+    finally:
+        session.close()
     return created
 
 
 async def _run_translation_backfill_batch(
     *,
+    organization_id: int,
     provider: TranslationProvider,
     load_candidates: LoadCandidates = _load_missing_candidates,
     persist_writes: PersistWrites = _persist_writes,
     sleeper: Sleeper = asyncio.sleep,
 ) -> int:
+    tenant_id = int(organization_id)
     candidates = tuple(
-        (await asyncio.to_thread(load_candidates, BACKFILL_LIMIT))[:BACKFILL_LIMIT]
+        (
+            await asyncio.to_thread(
+                load_candidates,
+                tenant_id,
+                BACKFILL_LIMIT,
+            )
+        )[:BACKFILL_LIMIT]
     )
+    if any(candidate.organization_id != tenant_id for candidate in candidates):
+        raise ValueError("translation backfill loader returned another tenant")
     if not candidates:
         return 0
 
@@ -201,9 +213,11 @@ async def _run_translation_backfill_batch(
                 writes.append(TranslationBackfillWrite(candidate=candidate, result=result))
         except Exception:
             # A public provider can be temporarily unavailable. Keep immutable source
-            # evidence untouched and leave this span eligible for the next restart.
+            # evidence untouched and leave this span eligible for a later tenant trigger.
             LOGGER.warning(
-                "us_lacey_translation_backfill_span_failed source_span_id=%s language=%s",
+                "us_lacey_translation_backfill_span_failed organization_id=%s "
+                "source_span_id=%s language=%s",
+                tenant_id,
                 candidate.source_span_id,
                 candidate.original_language,
                 exc_info=True,
@@ -213,9 +227,15 @@ async def _run_translation_backfill_batch(
 
     if not writes:
         return 0
-    created = await asyncio.to_thread(persist_writes, tuple(writes))
+    created = await asyncio.to_thread(
+        persist_writes,
+        tenant_id,
+        tuple(writes),
+    )
     LOGGER.info(
-        "us_lacey_translation_backfill_complete selected=%s translated=%s persisted=%s limit=%s",
+        "us_lacey_translation_backfill_complete organization_id=%s selected=%s "
+        "translated=%s persisted=%s limit=%s",
+        tenant_id,
         len(candidates),
         len(writes),
         created,
@@ -225,14 +245,18 @@ async def _run_translation_backfill_batch(
 
 
 async def run_translation_backfill(
+    organization_id: int,
     *,
     provider: TranslationProvider | None = None,
     load_candidates: LoadCandidates = _load_missing_candidates,
     persist_writes: PersistWrites = _persist_writes,
     sleeper: Sleeper = asyncio.sleep,
 ) -> int:
-    """Best-effort public entrypoint designed for a detached FastAPI startup task."""
+    """Best-effort tenant-scoped entrypoint for authenticated request triggers."""
     try:
+        tenant_id = int(organization_id)
+        if tenant_id <= 0:
+            raise ValueError("organization_id must be positive")
         selected_provider = provider
         if selected_provider is None:
             selected_provider = configured_translation_provider()
@@ -242,6 +266,7 @@ async def run_translation_backfill(
         if selected_provider is None:
             return 0
         return await _run_translation_backfill_batch(
+            organization_id=tenant_id,
             provider=selected_provider,
             load_candidates=load_candidates,
             persist_writes=persist_writes,
@@ -251,7 +276,9 @@ async def run_translation_backfill(
         raise
     except Exception:
         LOGGER.warning(
-            "us_lacey_translation_backfill_failed retry=next_startup",
+            "us_lacey_translation_backfill_failed organization_id=%s "
+            "retry=eligible_on_next_trigger",
+            organization_id,
             exc_info=True,
         )
         return 0

--- a/src/litoral_trace/web/us_lacey_pilot_app.py
+++ b/src/litoral_trace/web/us_lacey_pilot_app.py
@@ -8,8 +8,9 @@ from __future__ import annotations
 from datetime import date, datetime, timezone
 import logging
 import re
+import threading
 
-from fastapi import Cookie, FastAPI, File, Form, HTTPException, Request, UploadFile, status
+from fastapi import BackgroundTasks, Cookie, FastAPI, File, Form, HTTPException, Request, UploadFile, status
 from fastapi.responses import HTMLResponse, RedirectResponse, Response
 from fastapi.staticfiles import StaticFiles
 
@@ -65,6 +66,7 @@ from litoral_trace.us_lacey.self_service import (
     register_us_lacey_company,
     verify_us_lacey_email,
 )
+from litoral_trace.us_lacey.translation_backfill import run_translation_backfill
 from litoral_trace.us_lacey.workflow import (
     UsLaceyWorkflowError,
     create_us_lacey_customer_operation,
@@ -88,6 +90,8 @@ from litoral_trace.web.us_lacey_portal_views import (
 from litoral_trace.web.templates import STATIC_DIR
 
 LOGGER = logging.getLogger(__name__)
+_TRANSLATION_BACKFILL_SCHEDULED_ORGANIZATIONS: set[int] = set()
+_TRANSLATION_BACKFILL_SCHEDULE_LOCK = threading.Lock()
 
 
 app = FastAPI(
@@ -97,6 +101,22 @@ app = FastAPI(
     openapi_url=None,
 )
 app.mount("/static", StaticFiles(directory=str(STATIC_DIR)), name="static")
+
+
+def _schedule_translation_backfill_once(
+    background_tasks: BackgroundTasks,
+    organization_id: int,
+) -> bool:
+    """Schedule one best-effort tenant repair per organization and web process."""
+    tenant_id = int(organization_id)
+    if tenant_id <= 0:
+        raise ValueError("organization_id must be positive")
+    with _TRANSLATION_BACKFILL_SCHEDULE_LOCK:
+        if tenant_id in _TRANSLATION_BACKFILL_SCHEDULED_ORGANIZATIONS:
+            return False
+        _TRANSLATION_BACKFILL_SCHEDULED_ORGANIZATIONS.add(tenant_id)
+    background_tasks.add_task(run_translation_backfill, tenant_id)
+    return True
 
 
 def _html(content: str, *, status_code: int = 200) -> HTMLResponse:
@@ -417,6 +437,7 @@ def billing_page(
 @app.get("/operations", response_class=HTMLResponse)
 def operations_page(
     request: Request,
+    background_tasks: BackgroundTasks,
     us_session: str | None = Cookie(None, alias=US_LACEY_SESSION_COOKIE),
 ):
     try:
@@ -424,6 +445,10 @@ def operations_page(
         items = UsLaceyOperationService().list_operations(
             organization_id=identity.organization_id,
             limit=100,
+        )
+        _schedule_translation_backfill_once(
+            background_tasks,
+            identity.organization_id,
         )
     except UsLaceyPortalAuthError:
         return _login_redirect(clear_cookie=bool(us_session))

--- a/src/litoral_trace/web/us_lacey_unified_app.py
+++ b/src/litoral_trace/web/us_lacey_unified_app.py
@@ -10,8 +10,6 @@ plus /admin for an authenticated persisted platform superadmin.
 """
 from __future__ import annotations
 
-import asyncio
-from contextlib import asynccontextmanager, suppress
 import re
 
 from fastapi import Request, Response
@@ -26,40 +24,11 @@ from litoral_trace.us_lacey.portal_auth import (
     UsLaceyPortalAuthError,
     resolve_us_lacey_session,
 )
-from litoral_trace.us_lacey.translation_backfill import run_translation_backfill
 from litoral_trace.web.lacey_gtm import render_lacey_landing, router as lacey_router
 from litoral_trace.web.us_lacey_free_app import app
 from litoral_trace.web.us_lacey_intelligent_workflow import router as intelligent_workflow_router
 from litoral_trace.web.us_lacey_lemon_billing import router as lemon_billing_router
 from litoral_trace.web.us_lacey_platform_admin import router as platform_admin_router
-
-
-# Preserve the already-certified free-tier lifespan (inline worker, storage probe)
-# and add the historical translation repair as a detached one-shot task. Scheduling
-# with create_task means HTTP startup never waits for PostgreSQL or the public
-# translation backend. All synchronous DB/network work inside the task uses
-# asyncio.to_thread() and the task is capped at 50 spans per process start.
-_free_tier_lifespan_context = app.router.lifespan_context
-
-
-@asynccontextmanager
-async def _phase_d_lifespan(application):
-    async with _free_tier_lifespan_context(application) as state:
-        backfill_task = asyncio.create_task(
-            run_translation_backfill(),
-            name="us-lacey-translation-backfill",
-        )
-        application.state.us_lacey_translation_backfill_task = backfill_task
-        try:
-            yield state
-        finally:
-            if not backfill_task.done():
-                backfill_task.cancel()
-            with suppress(asyncio.CancelledError):
-                await backfill_task
-
-
-app.router.lifespan_context = _phase_d_lifespan
 
 
 # Public marketing/sample, payment-provider, upload-first workflow and superadmin

--- a/tests/test_us_lacey_phase_d_translation.py
+++ b/tests/test_us_lacey_phase_d_translation.py
@@ -4,14 +4,19 @@ import asyncio
 from dataclasses import dataclass
 from types import SimpleNamespace
 
+from fastapi import BackgroundTasks
+from sqlalchemy.dialects import postgresql
+
 from litoral_trace.services.translation import TranslationResult
 from litoral_trace.us_lacey.semantic_evidence_read import EvidenceTextView, evidence_text_view
 from litoral_trace.us_lacey.translation_backfill import (
     BACKFILL_DELAY_SECONDS,
     BACKFILL_LIMIT,
     TranslationBackfillCandidate,
+    _missing_candidates_statement,
     run_translation_backfill,
 )
+from litoral_trace.web import us_lacey_pilot_app as pilot_app
 from litoral_trace.web.us_lacey_operational_views import _decorate_review_fields
 
 
@@ -62,6 +67,28 @@ def test_read_projection_prefers_translation_but_preserves_original():
     assert view.original_language_label == "Portuguese"
 
 
+def test_backfill_query_is_explicitly_tenant_scoped():
+    statement = _missing_candidates_statement(14, BACKFILL_LIMIT)
+    sql = str(
+        statement.compile(
+            dialect=postgresql.dialect(),
+            compile_kwargs={"literal_binds": True},
+        )
+    ).lower()
+
+    assert "document_text_spans" in sql
+    assert "document_text_translations" in sql
+    assert "organizations" not in sql
+    assert "document_text_spans.organization_id = 14" in sql
+    assert "document_text_translations.id is null" in sql
+    assert "original_language" in sql
+    assert "'es'" in sql
+    assert "'pt'" in sql
+    assert "'zh'" in sql
+    assert "target_language = 'en'" in sql
+    assert f"limit {BACKFILL_LIMIT}" in sql
+
+
 class _FakeProvider:
     def __init__(self) -> None:
         self.calls: list[tuple[str, str, str]] = []
@@ -84,13 +111,14 @@ def test_backfill_hard_caps_at_50_and_yields_between_translations():
     persisted = []
     sleeps = []
 
-    def load_candidates(limit: int):
+    def load_candidates(organization_id: int, limit: int):
+        assert organization_id == 7
         assert limit == BACKFILL_LIMIT
         # Deliberately violate the loader contract to prove the async layer still
-        # enforces the innegotiable startup budget.
+        # enforces the innegotiable per-trigger startup budget.
         return tuple(
             TranslationBackfillCandidate(
-                organization_id=1,
+                organization_id=7,
                 source_span_id=index + 1,
                 original_text=f"texto {index + 1}",
                 original_language="es",
@@ -98,7 +126,8 @@ def test_backfill_hard_caps_at_50_and_yields_between_translations():
             for index in range(BACKFILL_LIMIT + 10)
         )
 
-    def persist_writes(writes):
+    def persist_writes(organization_id: int, writes):
+        assert organization_id == 7
         persisted.extend(writes)
         return len(writes)
 
@@ -107,6 +136,7 @@ def test_backfill_hard_caps_at_50_and_yields_between_translations():
 
     created = asyncio.run(
         run_translation_backfill(
+            7,
             provider=provider,
             load_candidates=load_candidates,
             persist_writes=persist_writes,
@@ -118,6 +148,57 @@ def test_backfill_hard_caps_at_50_and_yields_between_translations():
     assert len(provider.calls) == BACKFILL_LIMIT
     assert len(persisted) == BACKFILL_LIMIT
     assert sleeps == [BACKFILL_DELAY_SECONDS] * (BACKFILL_LIMIT - 1)
+
+
+def test_jit_backfill_schedules_only_once_per_organization():
+    tasks = BackgroundTasks()
+    with pilot_app._TRANSLATION_BACKFILL_SCHEDULE_LOCK:
+        pilot_app._TRANSLATION_BACKFILL_SCHEDULED_ORGANIZATIONS.clear()
+    try:
+        assert pilot_app._schedule_translation_backfill_once(tasks, 14) is True
+        assert pilot_app._schedule_translation_backfill_once(tasks, 14) is False
+        assert pilot_app._schedule_translation_backfill_once(tasks, 15) is True
+        assert len(tasks.tasks) == 2
+    finally:
+        with pilot_app._TRANSLATION_BACKFILL_SCHEDULE_LOCK:
+            pilot_app._TRANSLATION_BACKFILL_SCHEDULED_ORGANIZATIONS.clear()
+
+
+def test_operations_endpoint_schedules_jit_backfill_for_authenticated_tenant(monkeypatch):
+    identity = SimpleNamespace(organization_id=14)
+    entitlement = SimpleNamespace()
+    monkeypatch.setattr(
+        pilot_app,
+        "_operational_context",
+        lambda _session: (identity, entitlement),
+    )
+    monkeypatch.setattr(
+        pilot_app,
+        "UsLaceyOperationService",
+        lambda: SimpleNamespace(
+            list_operations=lambda *, organization_id, limit: []
+        ),
+    )
+    monkeypatch.setattr(
+        pilot_app,
+        "render_operations",
+        lambda **_kwargs: "<main>ok</main>",
+    )
+    scheduled: list[int] = []
+    monkeypatch.setattr(
+        pilot_app,
+        "_schedule_translation_backfill_once",
+        lambda _tasks, organization_id: scheduled.append(organization_id) or True,
+    )
+
+    response = pilot_app.operations_page(
+        request=SimpleNamespace(),
+        background_tasks=BackgroundTasks(),
+        us_session="opaque-session",
+    )
+
+    assert response.status_code == 200
+    assert scheduled == [14]
 
 
 @dataclass(frozen=True)


### PR DESCRIPTION
## Summary
- remove the global FastAPI startup translation-backfill task
- trigger translation repair from the authenticated `GET /operations` workspace request
- pass the authenticated `organization_id` directly into the backfill
- query only that tenant's `document_text_spans` under the normal FORCE-RLS context
- preserve the strict 50-span budget and 0.5s cooperative delay
- deduplicate scheduling once per organization per web process with an in-memory lock/set

## Why
The runtime role must not enumerate tenants. FORCE RLS also means a global startup query has no organization context and therefore cannot discover cross-tenant spans. The repair is now context-aware: a customer workspace request already establishes a trusted organization identity, and the detached repair receives that exact tenant id.

## Implementation
- `us_lacey_unified_app.py`: removes the Phase D startup lifespan wrapper; the certified free-tier lifespan remains unchanged
- `us_lacey_pilot_app.py`: injects `BackgroundTasks` into `/operations` and schedules one tenant backfill after successful authenticated operation listing
- `translation_backfill.py`: removes tenant discovery entirely; load/persist paths require an explicit organization id, install the tenant GUC before querying, and fail closed on tenant mismatch
- no PostgreSQL grants, RLS policies, services, queues, cron jobs, or paid translation fallbacks were added

## Tests
- tenant SQL compilation contract: explicit `organization_id`, es/pt/zh -> en, missing translation only, LIMIT 50, no `organizations` read
- hard-cap/delay test updated for explicit tenant context
- in-memory scheduling dedupe test covers repeated requests for the same organization
- operations endpoint unit test proves the authenticated tenant id is handed to the JIT scheduler
- full CI and U.S. Lacey PostgreSQL gate required before merge

## Scope note
The live module is `src/litoral_trace/us_lacey/translation_backfill.py`; there is no active `src/litoral_trace/commands/translation_backfill.py` in this product branch.