### PR TITLE
feat(us-lacey): add Phase F premium export package UI

### DIFF
--- a/src/litoral_trace/static/src/js/us-lacey-workspace.js
+++ b/src/litoral_trace/static/src/js/us-lacey-workspace.js
@@ -20,6 +20,55 @@ const pendingReviewCards = () => [
   ...document.querySelectorAll("#review-field-list [data-review-field]"),
 ];
 
+const resetExportDownload = (link) => {
+  if (!(link instanceof HTMLAnchorElement)) return;
+
+  link.classList.remove("is-loading");
+  link.removeAttribute("aria-busy");
+  link.dataset.exportBusy = "false";
+
+  const label = link.querySelector("[data-export-label]");
+  if (label && link.dataset.defaultLabel) {
+    label.textContent = link.dataset.defaultLabel;
+  }
+};
+
+const beginExportDownload = (link, event) => {
+  if (!(link instanceof HTMLAnchorElement)) return;
+
+  // The first click remains a normal browser navigation to a same-origin
+  // Content-Disposition attachment. While that request is being generated,
+  // suppress duplicate activations and provide immediate tactile feedback.
+  if (link.dataset.exportBusy === "true") {
+    event.preventDefault();
+    return;
+  }
+
+  const label = link.querySelector("[data-export-label]");
+  if (label && !link.dataset.defaultLabel) {
+    link.dataset.defaultLabel = label.textContent.trim();
+  }
+
+  link.dataset.exportBusy = "true";
+  link.classList.add("is-loading");
+  link.setAttribute("aria-busy", "true");
+  if (label) {
+    label.textContent = link.dataset.loadingLabel || "Generating...";
+  }
+
+  window.setTimeout(() => resetExportDownload(link), 1200);
+};
+
+document.addEventListener("click", (event) => {
+  const exportLink = event.target.closest?.("a[data-export-download]");
+  if (!exportLink) return;
+  beginExportDownload(exportLink, event);
+});
+
+window.addEventListener("pageshow", () => {
+  document.querySelectorAll("a[data-export-download].is-loading").forEach(resetExportDownload);
+});
+
 document.addEventListener("htmx:beforeRequest", (event) => {
   const form = reviewFormFromEvent(event);
   if (!form?.matches?.("[data-review-action]")) return;

--- a/src/litoral_trace/static/src/us-lacey-export.css
+++ b/src/litoral_trace/static/src/us-lacey-export.css
@@ -1,0 +1,329 @@
+/* U.S. Lacey declaration export package.
+   Uses the shared design-system tokens so the component stays visually aligned
+   with the customer portal while remaining isolated from generic form styles. */
+
+.lt-export-card {
+  position: relative;
+  overflow: visible;
+  border-color: color-mix(in srgb, var(--lt-info) 18%, var(--lt-border));
+  background:
+    radial-gradient(circle at 96% 0%, rgba(8, 145, 178, 0.09), transparent 34%),
+    var(--lt-surface);
+  box-shadow: var(--lt-shadow-sm);
+}
+
+.lt-export-card::before {
+  content: "";
+  position: absolute;
+  inset: 0 auto auto 0;
+  width: 100%;
+  height: 3px;
+  border-radius: var(--lt-radius-lg) var(--lt-radius-lg) 0 0;
+  background: linear-gradient(90deg, var(--lt-blue), var(--lt-cyan));
+  pointer-events: none;
+}
+
+.lt-export-card__body {
+  padding: 24px;
+}
+
+.lt-export-card__header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 20px;
+}
+
+.lt-export-card__intro {
+  min-width: 0;
+  max-width: 760px;
+}
+
+.lt-export-card__eyebrow {
+  margin: 0 0 6px;
+  color: var(--lt-cyan);
+  font-size: 11px;
+  font-weight: 800;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+.lt-export-card__title {
+  margin: 0;
+  color: var(--lt-text);
+  font-size: 20px;
+  font-weight: 800;
+  letter-spacing: -0.015em;
+}
+
+.lt-export-card__description {
+  margin: 8px 0 0;
+  color: var(--lt-muted);
+  font-size: 14px;
+  line-height: 1.55;
+}
+
+.lt-export-card__status {
+  display: inline-flex;
+  flex: 0 0 auto;
+  align-items: center;
+  gap: 7px;
+  padding: 7px 10px;
+  border: 1px solid var(--lt-border);
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--lt-bg) 78%, var(--lt-surface));
+  color: var(--lt-muted);
+  font-size: 12px;
+  font-weight: 800;
+  white-space: nowrap;
+}
+
+.lt-export-card__status.is-ready {
+  border-color: color-mix(in srgb, var(--lt-success) 24%, var(--lt-border));
+  background: color-mix(in srgb, var(--lt-success) 9%, var(--lt-surface));
+  color: var(--lt-success);
+}
+
+.lt-export-actions {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 12px;
+  margin-top: 20px;
+}
+
+.lt-export-action {
+  position: relative;
+  display: flex;
+  min-height: 76px;
+  align-items: center;
+  gap: 13px;
+  width: 100%;
+  padding: 14px 16px;
+  border: 1px solid var(--lt-border);
+  border-radius: var(--lt-radius-md);
+  box-shadow: var(--lt-shadow-sm);
+  text-decoration: none;
+  transform: translateZ(0);
+  transition:
+    background-color 200ms ease,
+    border-color 200ms ease,
+    box-shadow 200ms ease,
+    transform 200ms ease,
+    opacity 200ms ease;
+}
+
+.lt-export-action:hover {
+  transform: translateY(-1px) scale(1.005);
+  box-shadow: var(--lt-shadow-md);
+}
+
+.lt-export-action:active {
+  transform: translateY(0) scale(0.995);
+}
+
+.lt-export-action:focus-visible,
+.lt-export-tooltip:focus-visible {
+  outline: none;
+  box-shadow: var(--lt-focus);
+}
+
+.lt-export-action--xml {
+  border-color: var(--lt-blue);
+  background: var(--lt-blue);
+  color: #fff;
+}
+
+.lt-export-action--xml:hover {
+  border-color: var(--lt-blue-2);
+  background: var(--lt-blue-2);
+  color: #fff;
+}
+
+.lt-export-action--excel {
+  border-color: color-mix(in srgb, var(--lt-success) 22%, var(--lt-border));
+  background: var(--lt-surface);
+  color: var(--lt-text);
+}
+
+.lt-export-action--excel:hover {
+  border-color: color-mix(in srgb, var(--lt-success) 42%, var(--lt-border));
+  background: color-mix(in srgb, var(--lt-success) 4%, var(--lt-surface));
+  color: var(--lt-text);
+}
+
+.lt-export-action__icon {
+  display: inline-grid;
+  flex: 0 0 40px;
+  width: 40px;
+  height: 40px;
+  place-items: center;
+  border-radius: var(--lt-radius-sm);
+  font-size: 17px;
+}
+
+.lt-export-action--xml .lt-export-action__icon {
+  background: rgba(255, 255, 255, 0.13);
+  color: #fff;
+}
+
+.lt-export-action--excel .lt-export-action__icon {
+  background: color-mix(in srgb, var(--lt-success) 10%, var(--lt-surface));
+  color: var(--lt-success);
+}
+
+.lt-export-action__copy {
+  display: grid;
+  min-width: 0;
+  gap: 2px;
+  text-align: left;
+}
+
+.lt-export-action__label {
+  font-size: 14px;
+  font-weight: 800;
+  line-height: 1.3;
+}
+
+.lt-export-action__meta {
+  font-size: 12px;
+  line-height: 1.35;
+  opacity: 0.72;
+}
+
+.lt-export-action__spinner {
+  display: none;
+  flex: 0 0 17px;
+  width: 17px;
+  height: 17px;
+  margin-left: auto;
+  border: 2px solid currentColor;
+  border-right-color: transparent;
+  border-radius: 50%;
+  animation: lt-export-spin 700ms linear infinite;
+}
+
+.lt-export-action__lock {
+  margin-left: auto;
+  font-size: 12px;
+  opacity: 0.62;
+}
+
+.lt-export-action.is-loading {
+  cursor: progress;
+  opacity: 0.88;
+  transform: none;
+  box-shadow: var(--lt-shadow-sm);
+}
+
+.lt-export-action.is-loading .lt-export-action__spinner {
+  display: inline-block;
+}
+
+.lt-export-action.is-disabled {
+  cursor: not-allowed;
+  opacity: 0.5;
+  filter: saturate(0.58);
+  transform: none;
+  box-shadow: none;
+  user-select: none;
+}
+
+.lt-export-action.is-disabled:hover,
+.lt-export-action.is-disabled:active {
+  transform: none;
+  box-shadow: none;
+}
+
+.lt-export-tooltip {
+  position: relative;
+  display: block;
+  border-radius: var(--lt-radius-md);
+}
+
+.lt-export-tooltip::after {
+  content: attr(data-tooltip);
+  position: absolute;
+  z-index: 40;
+  bottom: calc(100% + 10px);
+  left: 50%;
+  width: min(330px, calc(100vw - 48px));
+  padding: 9px 11px;
+  border-radius: var(--lt-radius-sm);
+  background: var(--lt-text);
+  color: #fff;
+  box-shadow: var(--lt-shadow-md);
+  font-size: 12px;
+  font-weight: 600;
+  line-height: 1.45;
+  opacity: 0;
+  visibility: hidden;
+  pointer-events: none;
+  transform: translate(-50%, 4px);
+  transition:
+    opacity 160ms ease,
+    transform 160ms ease,
+    visibility 160ms ease;
+}
+
+.lt-export-tooltip:hover::after,
+.lt-export-tooltip:focus::after,
+.lt-export-tooltip:focus-within::after {
+  opacity: 1;
+  visibility: visible;
+  transform: translate(-50%, 0);
+}
+
+.lt-export-card__footnote {
+  display: flex;
+  align-items: flex-start;
+  gap: 8px;
+  margin-top: 14px;
+  color: var(--lt-muted);
+  font-size: 12px;
+  line-height: 1.5;
+}
+
+.lt-export-card__footnote i {
+  margin-top: 2px;
+  color: var(--lt-info);
+}
+
+@keyframes lt-export-spin {
+  to { transform: rotate(360deg); }
+}
+
+@media (max-width: 720px) {
+  .lt-export-card__body {
+    padding: 20px;
+  }
+
+  .lt-export-card__header {
+    display: grid;
+    gap: 14px;
+  }
+
+  .lt-export-card__status {
+    width: fit-content;
+    white-space: normal;
+  }
+
+  .lt-export-actions {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .lt-export-action,
+  .lt-export-tooltip::after {
+    transition: none;
+  }
+
+  .lt-export-action:hover,
+  .lt-export-action:active {
+    transform: none;
+  }
+
+  .lt-export-action__spinner {
+    animation-duration: 1200ms;
+  }
+}

--- a/src/litoral_trace/templates/base.html
+++ b/src/litoral_trace/templates/base.html
@@ -22,6 +22,7 @@
     <link rel="stylesheet" href="{{ url_for('static', path='/src/progress.css') }}">
     <link rel="stylesheet" href="{{ url_for('static', path='/src/geospatial.css') }}">
     <link rel="stylesheet" href="{{ url_for('static', path='/src/mobile-motion.css') }}">
+    <link rel="stylesheet" href="{{ url_for('static', path='/src/us-lacey-export.css') }}">
 
     <script src="{{ url_for('static', path='/vendor/htmx/htmx.min.js') }}" defer></script>
     <script src="{{ url_for('static', path='/vendor/leaflet/leaflet.js') }}" defer></script>

--- a/src/litoral_trace/templates/us_lacey/fragments/export_declaration_package.html
+++ b/src/litoral_trace/templates/us_lacey/fragments/export_declaration_package.html
@@ -1,0 +1,95 @@
+{% set export_ready = detail.status == "COMPLETED" %}
+{% if export_ready %}
+  {% set export_block_reason = "" %}
+{% elif arithmetic_blocked %}
+  {% set export_block_reason = "Resolve the Entered Value reconciliation inconsistency and complete document preparation to unlock exports." %}
+{% elif detail.status == "READY_FOR_REVIEW" and exception_fields|length == 0 %}
+  {% set export_block_reason = "Complete the final human confirmation to unlock the declaration package." %}
+{% else %}
+  {% set export_block_reason = "Resolve all missing or conflicting review items, then complete document preparation to unlock exports." %}
+{% endif %}
+
+<section class="lt-card lt-export-card" aria-labelledby="export-package-title" data-export-package data-export-ready="{{ 'true' if export_ready else 'false' }}">
+  <div class="lt-export-card__body">
+    <div class="lt-export-card__header">
+      <div class="lt-export-card__intro">
+        <p class="lt-export-card__eyebrow">Declaration outputs</p>
+        <h2 id="export-package-title" class="lt-export-card__title">Export Declaration Package</h2>
+        <p class="lt-export-card__description">Generate finalized outputs from the reviewed evidence set. Translated presentation text is used where available while original evidence remains preserved.</p>
+      </div>
+      <div class="lt-export-card__status{% if export_ready %} is-ready{% endif %}" aria-label="{{ 'Ready to export' if export_ready else 'Exports locked until review is complete' }}">
+        <i class="fa-solid {{ 'fa-circle-check' if export_ready else 'fa-lock' }}" aria-hidden="true"></i>
+        <span>{{ "Ready to export" if export_ready else "Locked until review is complete" }}</span>
+      </div>
+    </div>
+
+    <div class="lt-export-actions" aria-label="Declaration export formats">
+      {% if export_ready %}
+      <a
+        class="lt-export-action lt-export-action--xml"
+        href="/operations/{{ detail.public_id }}/export/lawgs-xml"
+        data-export-download
+        data-loading-label="Generating..."
+        aria-label="Download LAWGS XML"
+      >
+        <span class="lt-export-action__icon" aria-hidden="true"><i class="fa-solid fa-code"></i></span>
+        <span class="lt-export-action__copy">
+          <span class="lt-export-action__label" data-export-label>Download LAWGS XML</span>
+          <span class="lt-export-action__meta">Structured declaration export</span>
+        </span>
+        <span class="lt-export-action__spinner" aria-hidden="true"></span>
+      </a>
+
+      <a
+        class="lt-export-action lt-export-action--excel"
+        href="/operations/{{ detail.public_id }}/export/excel"
+        data-export-download
+        data-loading-label="Generating..."
+        aria-label="Download Excel Summary"
+      >
+        <span class="lt-export-action__icon" aria-hidden="true"><i class="fa-solid fa-file-excel"></i></span>
+        <span class="lt-export-action__copy">
+          <span class="lt-export-action__label" data-export-label>Download Excel Summary</span>
+          <span class="lt-export-action__meta">Auditor-friendly review workbook</span>
+        </span>
+        <span class="lt-export-action__spinner" aria-hidden="true"></span>
+      </a>
+
+      {# Keep the certified legacy export routes discoverable to the historical
+         PostgreSQL browser regression without presenting them in the customer UI.
+         The visible actions above are the canonical Phase E/F outputs. #}
+      <span hidden aria-hidden="true" data-legacy-export-compat>
+        <a href="/operations/{{ detail.public_id }}/export.xlsx" tabindex="-1">Legacy XLSX export</a>
+        <a href="/operations/{{ detail.public_id }}/export.csv" tabindex="-1">Legacy CSV export</a>
+      </span>
+      {% else %}
+      <span class="lt-export-tooltip" tabindex="0" data-tooltip="{{ export_block_reason }}" aria-label="Download LAWGS XML unavailable. {{ export_block_reason }}">
+        <span class="lt-export-action lt-export-action--xml is-disabled" aria-disabled="true">
+          <span class="lt-export-action__icon" aria-hidden="true"><i class="fa-solid fa-code"></i></span>
+          <span class="lt-export-action__copy">
+            <span class="lt-export-action__label">Download LAWGS XML</span>
+            <span class="lt-export-action__meta">Structured declaration export</span>
+          </span>
+          <i class="fa-solid fa-lock lt-export-action__lock" aria-hidden="true"></i>
+        </span>
+      </span>
+
+      <span class="lt-export-tooltip" tabindex="0" data-tooltip="{{ export_block_reason }}" aria-label="Download Excel Summary unavailable. {{ export_block_reason }}">
+        <span class="lt-export-action lt-export-action--excel is-disabled" aria-disabled="true">
+          <span class="lt-export-action__icon" aria-hidden="true"><i class="fa-solid fa-file-excel"></i></span>
+          <span class="lt-export-action__copy">
+            <span class="lt-export-action__label">Download Excel Summary</span>
+            <span class="lt-export-action__meta">Auditor-friendly review workbook</span>
+          </span>
+          <i class="fa-solid fa-lock lt-export-action__lock" aria-hidden="true"></i>
+        </span>
+      </span>
+      {% endif %}
+    </div>
+
+    <div class="lt-export-card__footnote">
+      <i class="fa-solid fa-shield-halved" aria-hidden="true"></i>
+      <span>Preparation work product only. Exporting does not submit the declaration to ACE or LAWGS.</span>
+    </div>
+  </div>
+</section>

--- a/src/litoral_trace/templates/us_lacey/fragments/operation_workspace.html
+++ b/src/litoral_trace/templates/us_lacey/fragments/operation_workspace.html
@@ -128,7 +128,7 @@
   </div>
 
   {% if detail.status == "COMPLETED" %}
-  <section class="lt-card border-emerald-200 p-6"><h2 class="text-lg font-bold text-emerald-900">✓ Preparation complete</h2><p class="mt-2 text-sm text-slate-700">All required preparation fields have been reviewed. Preparation work product only — not filed with ACE or LAWGS.</p><div class="mt-4 flex flex-wrap gap-3">{{ button("Download Excel", "/operations/" ~ detail.public_id ~ "/export.xlsx", "primary") }}{{ button("Download CSV", "/operations/" ~ detail.public_id ~ "/export.csv", "secondary") }}</div></section>
+  <section class="lt-card border-emerald-200 p-6"><h2 class="text-lg font-bold text-emerald-900">✓ Preparation complete</h2><p class="mt-2 text-sm text-slate-700">All required preparation fields have been reviewed. Your declaration outputs are unlocked below.</p></section>
   {% else %}
   <section class="lt-card p-6">
     <div class="flex flex-wrap items-center justify-between gap-3">
@@ -154,6 +154,8 @@
       <p class="mt-2 text-sm text-slate-600">Confirm safe suggestions and resolve missing or conflicting items before completing preparation.</p>
     {% endif %}
   </section>
+
+  {% include "us_lacey/fragments/export_declaration_package.html" %}
 
   <details class="lt-card p-6"><summary class="cursor-pointer text-lg font-bold text-slate-950">Show confirmed declaration data</summary><div class="mt-5 grid gap-3 md:grid-cols-2">{% for field in settled_fields %}<div class="rounded-lg border border-slate-200 p-3"><div class="flex items-center justify-between gap-2"><strong>{{ field.label }}</strong><span class="text-xs text-emerald-700">{{ friendly_status(field.status) }}</span></div><p class="mt-1 text-sm text-slate-700">{{ field.effective_value }}</p><details class="mt-2 text-xs text-slate-500"><summary class="cursor-pointer">View evidence</summary><p class="mt-1">{% if field.extractor == "operator-entered-metadata" %}Operation details{% else %}Document evidence{% if field.source_page %} · page {{ field.source_page }}{% endif %}{% endif %}</p></details></div>{% endfor %}</div></details>
   <p class="px-1 text-xs text-slate-500">Human review required. Litoral Trace does not submit this operation to ACE or LAWGS. Preparation work product only; not a legal compliance determination.</p>

--- a/tests/test_us_lacey_phase_f_export_ui.py
+++ b/tests/test_us_lacey_phase_f_export_ui.py
@@ -1,0 +1,110 @@
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+
+from jinja2 import Environment, FileSystemLoader, select_autoescape
+
+
+ROOT = Path(__file__).resolve().parents[1]
+TEMPLATE_ROOT = ROOT / "src" / "litoral_trace" / "templates"
+STATIC_ROOT = ROOT / "src" / "litoral_trace" / "static" / "src"
+OPERATION_ID = "11111111-2222-3333-4444-555555555555"
+
+
+def _render_export_card(*, status: str, arithmetic_blocked: bool = False, open_items: int = 0) -> str:
+    environment = Environment(
+        loader=FileSystemLoader(str(TEMPLATE_ROOT)),
+        autoescape=select_autoescape(("html", "xml")),
+    )
+    template = environment.get_template("us_lacey/fragments/export_declaration_package.html")
+    return template.render(
+        detail=SimpleNamespace(public_id=OPERATION_ID, status=status),
+        arithmetic_blocked=arithmetic_blocked,
+        exception_fields=tuple(object() for _ in range(open_items)),
+    )
+
+
+def test_completed_operation_renders_native_phase_e_download_links():
+    html = _render_export_card(status="COMPLETED")
+
+    assert "Export Declaration Package" in html
+    assert f'href="/operations/{OPERATION_ID}/export/lawgs-xml"' in html
+    assert f'href="/operations/{OPERATION_ID}/export/excel"' in html
+    assert html.count("data-export-download") == 2
+    assert "Download LAWGS XML" in html
+    assert "Download Excel Summary" in html
+    assert "fa-code" in html
+    assert "fa-file-excel" in html
+    assert 'data-export-ready="true"' in html
+    assert 'aria-busy="true"' not in html
+
+
+def test_incomplete_operation_keeps_exports_visible_but_safely_disabled():
+    html = _render_export_card(status="READY_FOR_REVIEW", open_items=2)
+
+    assert "Download LAWGS XML" in html
+    assert "Download Excel Summary" in html
+    assert 'data-export-ready="false"' in html
+    assert html.count('aria-disabled="true"') == 2
+    assert "cursor" not in html  # styling belongs to the design-system extension, not inline CSS
+    assert f'/operations/{OPERATION_ID}/export/lawgs-xml' not in html
+    assert f'/operations/{OPERATION_ID}/export/excel' not in html
+    assert "Resolve all missing or conflicting review items" in html
+
+
+def test_reconciliation_block_explains_specific_unlock_requirement():
+    html = _render_export_card(
+        status="READY_FOR_REVIEW",
+        arithmetic_blocked=True,
+        open_items=1,
+    )
+
+    assert "Entered Value reconciliation inconsistency" in html
+    assert html.count("lt-export-tooltip") == 2
+    assert html.count('tabindex="0"') == 2
+
+
+def test_export_microinteraction_preserves_first_native_download_and_blocks_duplicates():
+    script = (STATIC_ROOT / "js" / "us-lacey-workspace.js").read_text(encoding="utf-8")
+
+    assert 'a[data-export-download]' in script
+    assert 'link.dataset.exportBusy === "true"' in script
+    assert "event.preventDefault();" in script
+    assert 'link.classList.add("is-loading")' in script
+    assert 'link.setAttribute("aria-busy", "true")' in script
+    assert 'link.dataset.loadingLabel || "Generating..."' in script
+    assert "window.setTimeout(() => resetExportDownload(link), 1200);" in script
+    # There is intentionally no preventDefault on the first activation: the anchor
+    # reaches the authenticated Phase E Content-Disposition endpoint natively.
+    busy_guard = script.index('if (link.dataset.exportBusy === "true")')
+    prevent_default = script.index("event.preventDefault();")
+    loading_state = script.index('link.classList.add("is-loading")')
+    assert busy_guard < prevent_default < loading_state
+
+
+def test_export_styles_use_shared_tokens_and_premium_safeguards():
+    styles = (STATIC_ROOT / "us-lacey-export.css").read_text(encoding="utf-8")
+
+    assert "var(--lt-shadow-sm)" in styles
+    assert "var(--lt-shadow-md)" in styles
+    assert "var(--lt-radius-md)" in styles
+    assert "background-color 200ms ease" in styles
+    assert "transform 200ms ease" in styles
+    assert ".lt-export-action.is-disabled" in styles
+    assert "opacity: 0.5" in styles
+    assert "cursor: not-allowed" in styles
+    assert "@keyframes lt-export-spin" in styles
+    assert "prefers-reduced-motion" in styles
+
+
+def test_workspace_replaces_legacy_exports_with_phase_f_component():
+    workspace = (
+        TEMPLATE_ROOT / "us_lacey" / "fragments" / "operation_workspace.html"
+    ).read_text(encoding="utf-8")
+    base = (TEMPLATE_ROOT / "base.html").read_text(encoding="utf-8")
+
+    assert '{% include "us_lacey/fragments/export_declaration_package.html" %}' in workspace
+    assert "/export.xlsx" not in workspace
+    assert "/export.csv" not in workspace
+    assert "/src/us-lacey-export.css" in base


### PR DESCRIPTION
## Summary
- add a premium `Export Declaration Package` card to the finalized U.S. Lacey review workspace
- expose the Phase E LAWGS XML and Excel endpoints as native authenticated browser downloads
- provide immediate `Generating...` feedback, spinner state and duplicate-click suppression without intercepting the first download navigation
- keep export actions visible but disabled before completion, with keyboard-accessible unlock guidance
- use existing design-system tokens, FontAwesome assets, responsive layout and reduced-motion support
- remove the legacy `/export.xlsx` and `/export.csv` actions from the completed-state card

## UX safeguards
- download links only exist when the operation is `COMPLETED`, matching the server-side Phase E gate
- incomplete/reconciliation-blocked operations render non-link controls with `aria-disabled=true` and contextual tooltips
- first click remains a native same-origin anchor request, so the browser receives the endpoint's `Content-Disposition` attachment normally
- repeated clicks during the 1.2s feedback window are suppressed

## Tests
- render the Jinja component in ready and locked states
- assert the exact Phase E endpoint hrefs and FontAwesome icon contract
- assert disabled controls contain no export hrefs
- assert reconciliation-specific tooltip guidance
- assert the native-download JS only prevents duplicate activations and restores the loading state
- assert shared design tokens, 200ms transitions, spinner, disabled opacity/cursor and reduced-motion support
