### PR TITLE
fix(us-lacey): add translation engine fallback

### DIFF
--- a/src/litoral_trace/services/translation.py
+++ b/src/litoral_trace/services/translation.py
@@ -6,10 +6,14 @@ counted as independent evidence.
 from __future__ import annotations
 
 from dataclasses import dataclass, field
+import logging
 from typing import Any, Mapping, Protocol, runtime_checkable
 
 import boto3
-from deep_translator import GoogleTranslator
+from deep_translator import GoogleTranslator, MyMemoryTranslator
+
+
+LOGGER = logging.getLogger(__name__)
 
 
 @dataclass(frozen=True, slots=True)
@@ -66,28 +70,68 @@ class NoOpEnglishProvider:
 
 
 class OpenSourceTranslationProvider:
-    """Free deep-translator adapter using its Google Translate backend.
+    """Free deep-translator adapter with a Google -> MyMemory fallback chain.
 
-    This backend does not use the paid Google Cloud Translation API and therefore
-    needs no cloud API key. The translator class is injectable so tests remain
-    deterministic and never need outbound network access.
+    Neither backend uses the paid Google Cloud Translation API. Translator
+    classes are injectable so tests remain deterministic and never need outbound
+    network access. Backend failures are logged without source text; if every
+    engine fails, the final exception is deliberately allowed to propagate.
     """
 
     provider_name = "OPEN_SOURCE_GOOGLE"
     model_name = "deep-translator-google"
     model_version = "1"
+    fallback_provider_name = "OPEN_SOURCE_MYMEMORY"
+    fallback_model_name = "deep-translator-mymemory"
+    fallback_model_version = "1"
 
-    def __init__(self, *, translator_cls: Any = GoogleTranslator) -> None:
+    def __init__(
+        self,
+        *,
+        translator_cls: Any = GoogleTranslator,
+        fallback_translator_cls: Any = MyMemoryTranslator,
+    ) -> None:
         self._translator_cls = translator_cls
+        self._fallback_translator_cls = fallback_translator_cls
 
     @staticmethod
     def _backend_language(code: str) -> str:
         normalized = (code or "").strip().lower()
-        # deep-translator/Google expects its Chinese locale code rather than the
-        # shadow detector's intentionally generic ISO-639 ``zh`` value.
+        # deep-translator expects its Chinese locale code rather than the shadow
+        # detector's intentionally generic ISO-639 ``zh`` value.
         if normalized == "zh":
             return "zh-CN"
         return normalized
+
+    @staticmethod
+    def _error_code(error: Exception) -> Any | None:
+        """Best-effort status/code extraction without logging error payload text."""
+        response = getattr(error, "response", None)
+        for candidate in (
+            getattr(error, "status_code", None),
+            getattr(error, "code", None),
+            getattr(response, "status_code", None),
+        ):
+            if candidate is not None:
+                return candidate
+        return None
+
+    def _translate_with(
+        self,
+        translator_cls: Any,
+        *,
+        text: str,
+        source: str,
+        target: str,
+    ) -> str:
+        translator = translator_cls(
+            source=self._backend_language(source),
+            target=self._backend_language(target),
+        )
+        translated = str(translator.translate(text) or "").strip()
+        if not translated:
+            raise RuntimeError("Open-source translation engine returned an empty translation")
+        return translated
 
     def translate(
         self,
@@ -106,20 +150,65 @@ class OpenSourceTranslationProvider:
                 provider=self.provider_name,
                 model_name=self.model_name,
                 model_version=self.model_version,
-                metadata={"backend": "deep-translator"},
+                metadata={"backend": "deep-translator", "engine": "google"},
             )
         if not source_norm:
             raise ValueError("A source language is required for translation")
         if not target_norm:
             raise ValueError("A target language is required for translation")
 
-        translator = self._translator_cls(
-            source=self._backend_language(source_norm),
-            target=self._backend_language(target_norm),
-        )
-        translated = str(translator.translate(original_text) or "").strip()
-        if not translated:
-            raise RuntimeError("Open-source translation provider returned an empty translation")
+        try:
+            translated = self._translate_with(
+                self._translator_cls,
+                text=original_text,
+                source=source_norm,
+                target=target_norm,
+            )
+        except Exception as google_error:
+            LOGGER.warning(
+                "Open-source translation engine failed; trying fallback.",
+                extra={
+                    "translation_engine": self.provider_name,
+                    "translation_fallback_engine": self.fallback_provider_name,
+                    "translation_source_language": source_norm,
+                    "translation_target_language": target_norm,
+                    "translation_error_type": type(google_error).__name__,
+                    "translation_error_code": self._error_code(google_error),
+                },
+            )
+            try:
+                translated = self._translate_with(
+                    self._fallback_translator_cls,
+                    text=original_text,
+                    source=source_norm,
+                    target=target_norm,
+                )
+            except Exception as fallback_error:
+                LOGGER.warning(
+                    "Open-source translation fallback engine failed; no engines remain.",
+                    extra={
+                        "translation_engine": self.fallback_provider_name,
+                        "translation_source_language": source_norm,
+                        "translation_target_language": target_norm,
+                        "translation_error_type": type(fallback_error).__name__,
+                        "translation_error_code": self._error_code(fallback_error),
+                    },
+                )
+                raise
+            return TranslationResult(
+                translated_text=translated,
+                source_language=source_norm,
+                target_language=target_norm,
+                provider=self.fallback_provider_name,
+                model_name=self.fallback_model_name,
+                model_version=self.fallback_model_version,
+                metadata={
+                    "backend": "deep-translator",
+                    "engine": "mymemory",
+                    "fallback_from": self.provider_name,
+                },
+            )
+
         return TranslationResult(
             translated_text=translated,
             source_language=source_norm,
@@ -129,7 +218,7 @@ class OpenSourceTranslationProvider:
             model_version=self.model_version,
             # deep-translator does not expose a calibrated confidence/quality
             # score, so leave quality_score absent instead of inventing certainty.
-            metadata={"backend": "deep-translator"},
+            metadata={"backend": "deep-translator", "engine": "google"},
         )
 
 

--- a/tests/test_open_source_translation_provider.py
+++ b/tests/test_open_source_translation_provider.py
@@ -1,5 +1,9 @@
 from __future__ import annotations
 
+import logging
+
+import pytest
+
 from litoral_trace.services.translation import OpenSourceTranslationProvider
 from litoral_trace.us_lacey.shadow_evidence_snapshot import configured_translation_provider
 
@@ -18,6 +22,45 @@ class _FakeGoogleTranslator:
         return f"translated:{text}"
 
 
+class _GoogleRateLimitError(RuntimeError):
+    status_code = 429
+
+
+class _FailingGoogleTranslator:
+    init_calls: list[tuple[str, str]] = []
+
+    def __init__(self, *, source: str, target: str) -> None:
+        self.source = source
+        self.target = target
+        self.init_calls.append((source, target))
+
+    def translate(self, text: str) -> str:
+        raise _GoogleRateLimitError("rate limited")
+
+
+class _FakeMyMemoryTranslator:
+    init_calls: list[tuple[str, str]] = []
+    translated_texts: list[str] = []
+
+    def __init__(self, *, source: str, target: str) -> None:
+        self.source = source
+        self.target = target
+        self.init_calls.append((source, target))
+
+    def translate(self, text: str) -> str:
+        self.translated_texts.append(text)
+        return f"fallback:{text}"
+
+
+class _FailingMyMemoryTranslator:
+    def __init__(self, *, source: str, target: str) -> None:
+        self.source = source
+        self.target = target
+
+    def translate(self, text: str) -> str:
+        raise RuntimeError("secondary translator unavailable")
+
+
 def test_open_source_provider_translates_without_cloud_credentials() -> None:
     _FakeGoogleTranslator.init_calls.clear()
     _FakeGoogleTranslator.translated_texts.clear()
@@ -31,8 +74,62 @@ def test_open_source_provider_translates_without_cloud_credentials() -> None:
     assert result.provider == "OPEN_SOURCE_GOOGLE"
     assert result.model_name == "deep-translator-google"
     assert result.model_version == "1"
+    assert result.metadata["engine"] == "google"
     assert _FakeGoogleTranslator.init_calls == [("es", "en")]
     assert _FakeGoogleTranslator.translated_texts == ["Factura comercial de madera"]
+
+
+def test_open_source_provider_falls_back_to_mymemory_when_google_fails(caplog) -> None:
+    _FailingGoogleTranslator.init_calls.clear()
+    _FakeMyMemoryTranslator.init_calls.clear()
+    _FakeMyMemoryTranslator.translated_texts.clear()
+    provider = OpenSourceTranslationProvider(
+        translator_cls=_FailingGoogleTranslator,
+        fallback_translator_cls=_FakeMyMemoryTranslator,
+    )
+
+    with caplog.at_level(logging.WARNING, logger="litoral_trace.services.translation"):
+        result = provider.translate("Tablas de cortar de madera", "es", "en")
+
+    assert result.translated_text == "fallback:Tablas de cortar de madera"
+    assert result.source_language == "es"
+    assert result.target_language == "en"
+    assert result.provider == "OPEN_SOURCE_MYMEMORY"
+    assert result.model_name == "deep-translator-mymemory"
+    assert result.model_version == "1"
+    assert result.metadata == {
+        "backend": "deep-translator",
+        "engine": "mymemory",
+        "fallback_from": "OPEN_SOURCE_GOOGLE",
+    }
+    assert _FailingGoogleTranslator.init_calls == [("es", "en")]
+    assert _FakeMyMemoryTranslator.init_calls == [("es", "en")]
+    assert _FakeMyMemoryTranslator.translated_texts == ["Tablas de cortar de madera"]
+
+    warning = next(
+        record
+        for record in caplog.records
+        if record.getMessage() == "Open-source translation engine failed; trying fallback."
+    )
+    assert warning.translation_engine == "OPEN_SOURCE_GOOGLE"
+    assert warning.translation_fallback_engine == "OPEN_SOURCE_MYMEMORY"
+    assert warning.translation_error_type == "_GoogleRateLimitError"
+    assert warning.translation_error_code == 429
+
+
+def test_open_source_provider_raises_when_all_engines_fail(caplog) -> None:
+    provider = OpenSourceTranslationProvider(
+        translator_cls=_FailingGoogleTranslator,
+        fallback_translator_cls=_FailingMyMemoryTranslator,
+    )
+
+    with caplog.at_level(logging.WARNING, logger="litoral_trace.services.translation"):
+        with pytest.raises(RuntimeError, match="secondary translator unavailable"):
+            provider.translate("Tablas de cortar de madera", "es", "en")
+
+    messages = [record.getMessage() for record in caplog.records]
+    assert "Open-source translation engine failed; trying fallback." in messages
+    assert "Open-source translation fallback engine failed; no engines remain." in messages
 
 
 def test_open_source_provider_maps_generic_chinese_code() -> None:


### PR DESCRIPTION
## Summary
- add a resilient open-source translation chain: Google first, MyMemory fallback
- emit structured warning logs when an engine fails without logging source evidence text
- report the engine that actually produced each `TranslationResult`
- deliberately re-raise the final fallback exception when all engines fail so the failure is observable upstream

## Provider behavior
- primary success: `provider=OPEN_SOURCE_GOOGLE`, `model_name=deep-translator-google`
- Google failure: warning includes engine, fallback engine, source/target language, exception type and best-effort status/error code
- MyMemory success: `provider=OPEN_SOURCE_MYMEMORY`, `model_name=deep-translator-mymemory`
- all engines fail: final MyMemory exception propagates after a structured warning

## Tests
- preserve deterministic Google success and language-code coverage
- mock Google rate-limit failure (`429`) and prove MyMemory returns the translation
- assert structured fallback warning metadata
- prove a dual-engine failure is not swallowed by the provider
