### PR TITLE
fix(us-lacey): authenticate fallback and sanitize taxonomy

### DIFF
--- a/src/litoral_trace/services/translation.py
+++ b/src/litoral_trace/services/translation.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 import logging
+import os
 from typing import Any, Mapping, Protocol, runtime_checkable
 
 import boto3
@@ -14,6 +15,7 @@ from deep_translator import GoogleTranslator, MyMemoryTranslator
 
 
 LOGGER = logging.getLogger(__name__)
+_DEFAULT_MYMEMORY_EMAIL = "soporte@litoraltrace.com"
 
 
 @dataclass(frozen=True, slots=True)
@@ -116,6 +118,11 @@ class OpenSourceTranslationProvider:
                 return candidate
         return None
 
+    @staticmethod
+    def _mymemory_contact_email() -> str:
+        configured = str(os.getenv("LT_MYMEMORY_EMAIL") or "").strip()
+        return configured or _DEFAULT_MYMEMORY_EMAIL
+
     def _translate_with(
         self,
         translator_cls: Any,
@@ -123,11 +130,15 @@ class OpenSourceTranslationProvider:
         text: str,
         source: str,
         target: str,
+        email: str | None = None,
     ) -> str:
-        translator = translator_cls(
-            source=self._backend_language(source),
-            target=self._backend_language(target),
-        )
+        kwargs: dict[str, Any] = {
+            "source": self._backend_language(source),
+            "target": self._backend_language(target),
+        }
+        if email is not None:
+            kwargs["email"] = email
+        translator = translator_cls(**kwargs)
         translated = str(translator.translate(text) or "").strip()
         if not translated:
             raise RuntimeError("Open-source translation engine returned an empty translation")
@@ -182,6 +193,7 @@ class OpenSourceTranslationProvider:
                     text=original_text,
                     source=source_norm,
                     target=target_norm,
+                    email=self._mymemory_contact_email(),
                 )
             except Exception as fallback_error:
                 LOGGER.warning(

--- a/src/litoral_trace/us_lacey/projection.py
+++ b/src/litoral_trace/us_lacey/projection.py
@@ -206,6 +206,20 @@ _PARTY_NON_NAMES = frozenset(
     }
 )
 
+_TAXONOMY_COMMERCIAL_STOP_WORDS = frozenset(
+    {
+        "board",
+        "boards",
+        "cutting",
+        "lumber",
+        "pallet",
+        "pallets",
+        "wood",
+        "wooden",
+    }
+)
+
+
 _PLANT_ROW_IDENTITY_TARGETS = frozenset(
     {
         "article_component",
@@ -320,6 +334,10 @@ def _is_candidate_admissible(
     if not raw:
         return False
     folded = _fold(raw)
+    if target in {"genus", "species"}:
+        taxonomy_tokens = frozenset(folded.split())
+        if taxonomy_tokens & _TAXONOMY_COMMERCIAL_STOP_WORDS:
+            return False
     if _is_structural_artifact(target, raw):
         return False
     if folded and folded in table_headers:

--- a/tests/test_open_source_translation_provider.py
+++ b/tests/test_open_source_translation_provider.py
@@ -39,13 +39,14 @@ class _FailingGoogleTranslator:
 
 
 class _FakeMyMemoryTranslator:
-    init_calls: list[tuple[str, str]] = []
+    init_calls: list[tuple[str, str, str]] = []
     translated_texts: list[str] = []
 
-    def __init__(self, *, source: str, target: str) -> None:
+    def __init__(self, *, source: str, target: str, email: str) -> None:
         self.source = source
         self.target = target
-        self.init_calls.append((source, target))
+        self.email = email
+        self.init_calls.append((source, target, email))
 
     def translate(self, text: str) -> str:
         self.translated_texts.append(text)
@@ -53,9 +54,10 @@ class _FakeMyMemoryTranslator:
 
 
 class _FailingMyMemoryTranslator:
-    def __init__(self, *, source: str, target: str) -> None:
+    def __init__(self, *, source: str, target: str, email: str) -> None:
         self.source = source
         self.target = target
+        self.email = email
 
     def translate(self, text: str) -> str:
         raise RuntimeError("secondary translator unavailable")
@@ -79,7 +81,11 @@ def test_open_source_provider_translates_without_cloud_credentials() -> None:
     assert _FakeGoogleTranslator.translated_texts == ["Factura comercial de madera"]
 
 
-def test_open_source_provider_falls_back_to_mymemory_when_google_fails(caplog) -> None:
+def test_open_source_provider_falls_back_to_mymemory_when_google_fails(
+    caplog,
+    monkeypatch,
+) -> None:
+    monkeypatch.setenv("LT_MYMEMORY_EMAIL", "translation-test@example.com")
     _FailingGoogleTranslator.init_calls.clear()
     _FakeMyMemoryTranslator.init_calls.clear()
     _FakeMyMemoryTranslator.translated_texts.clear()
@@ -103,7 +109,9 @@ def test_open_source_provider_falls_back_to_mymemory_when_google_fails(caplog) -
         "fallback_from": "OPEN_SOURCE_GOOGLE",
     }
     assert _FailingGoogleTranslator.init_calls == [("es", "en")]
-    assert _FakeMyMemoryTranslator.init_calls == [("es", "en")]
+    assert _FakeMyMemoryTranslator.init_calls == [
+        ("es", "en", "translation-test@example.com")
+    ]
     assert _FakeMyMemoryTranslator.translated_texts == ["Tablas de cortar de madera"]
 
     warning = next(
@@ -115,6 +123,21 @@ def test_open_source_provider_falls_back_to_mymemory_when_google_fails(caplog) -
     assert warning.translation_fallback_engine == "OPEN_SOURCE_MYMEMORY"
     assert warning.translation_error_type == "_GoogleRateLimitError"
     assert warning.translation_error_code == 429
+
+
+def test_open_source_provider_uses_default_mymemory_contact_email(monkeypatch) -> None:
+    monkeypatch.delenv("LT_MYMEMORY_EMAIL", raising=False)
+    _FakeMyMemoryTranslator.init_calls.clear()
+    provider = OpenSourceTranslationProvider(
+        translator_cls=_FailingGoogleTranslator,
+        fallback_translator_cls=_FakeMyMemoryTranslator,
+    )
+
+    provider.translate("Madera aserrada", "es", "en")
+
+    assert _FakeMyMemoryTranslator.init_calls == [
+        ("es", "en", "soporte@litoraltrace.com")
+    ]
 
 
 def test_open_source_provider_raises_when_all_engines_fail(caplog) -> None:

--- a/tests/test_us_lacey_taxonomy_sanitization.py
+++ b/tests/test_us_lacey_taxonomy_sanitization.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+import pytest
+
+from litoral_trace.us_lacey.projection import _is_candidate_admissible
+
+
+@pytest.mark.parametrize(
+    "target,value",
+    [
+        ("species", "WOODEN, CUTTING, BOARDS"),
+        ("species", "wood"),
+        ("species", "Cutting board"),
+        ("species", "hardwood lumber"),
+        ("genus", "PALLET"),
+        ("genus", "wooden pallets"),
+    ],
+)
+def test_taxonomy_commercial_stop_words_are_rejected(target: str, value: str) -> None:
+    assert _is_candidate_admissible(target, value) is False
+
+
+def test_legitimate_botanical_values_remain_admissible() -> None:
+    assert _is_candidate_admissible("genus", "Quercus") is True
+    assert _is_candidate_admissible("species", "rubra") is True
+    assert _is_candidate_admissible("species", "Pinus taeda") is True
+
+
+def test_stop_words_do_not_block_non_taxonomy_fields() -> None:
+    assert _is_candidate_admissible("merchandise_description", "WOODEN CUTTING BOARDS") is True


### PR DESCRIPTION
## Summary
- authenticate the MyMemory deep-translator fallback with `LT_MYMEMORY_EMAIL`, defaulting to `soporte@litoraltrace.com`
- keep Google as the primary open-source engine and only pass the contact email to MyMemory
- reject commercial vocabulary from U.S. Lacey `genus` / `species` candidates before they can enter the human-review field projection
- preserve legitimate botanical values and leave rejected taxonomy fields missing for manual completion

## Taxonomy guard
Strict token-level stop words: `WOODEN`, `WOOD`, `CUTTING`, `BOARD`, `BOARDS`, `PALLET`, `PALLETS`, `LUMBER`.

The guard is scoped only to `genus` and `species`; merchandise descriptions containing those words remain admissible.

## Tests
- MyMemory fallback receives the configured email
- safe default email is used when `LT_MYMEMORY_EMAIL` is unset
- commercial taxonomy noise such as `WOODEN, CUTTING, BOARDS` is rejected
- legitimate botanical names (`Quercus`, `rubra`, `Pinus taeda`) remain admissible
