### PR TITLE
feat(us-lacey): add DeepL translation and harden taxonomy

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -20,6 +20,7 @@ dateparser>=1.2,<2
 price-parser>=0.5,<1
 lingua-language-detector>=2.0,<3
 deep-translator>=1.11.4
+deepl>=1.16.1
 plotly>=5.18.0
 sqlalchemy>=2.0.0
 psycopg[binary]

--- a/src/litoral_trace/assurance/extraction.py
+++ b/src/litoral_trace/assurance/extraction.py
@@ -346,11 +346,30 @@ _LABEL_VALUE_RE = re.compile(
 )
 _TEXTUAL_DATE_RE = re.compile(r"[A-Za-zÀ-ÿ]")
 
+_TAXONOMY_COMMERCIAL_STOP_WORDS = frozenset(
+    {
+        "BOARD",
+        "BOARDS",
+        "CUTTING",
+        "LUMBER",
+        "PALLET",
+        "PALLETS",
+        "WOOD",
+        "WOODEN",
+    }
+)
+
 
 def _fold(value: object) -> str:
     text = unicodedata.normalize("NFKD", str(value or "").lower())
     text = "".join(ch for ch in text if not unicodedata.combining(ch))
     return re.sub(r"[^a-z0-9]+", " ", text).strip()
+
+
+def _has_commercial_taxonomy_stop_word(value: object) -> bool:
+    sanitized = str(value or "").replace(",", " ").replace("-", " ").upper()
+    words = frozenset(sanitized.split())
+    return bool(words & _TAXONOMY_COMMERCIAL_STOP_WORDS)
 
 
 def _document_search_text(filename: str, parsed: ParsedDocument) -> str:
@@ -511,6 +530,8 @@ def _candidate_from_table(
     confidence: float,
 ) -> ExtractedCandidate | None:
     if value is None:
+        return None
+    if field_name == "species" and _has_commercial_taxonomy_stop_word(value):
         return None
     try:
         original, normalized = _normalize_candidate(field_name, value)

--- a/src/litoral_trace/services/translation.py
+++ b/src/litoral_trace/services/translation.py
@@ -11,6 +11,7 @@ import os
 from typing import Any, Mapping, Protocol, runtime_checkable
 
 import boto3
+import deepl
 from deep_translator import GoogleTranslator, MyMemoryTranslator
 
 
@@ -39,6 +40,18 @@ class TranslationProvider(Protocol):
     ) -> TranslationResult:
         """Translate one immutable source span without altering source evidence."""
         ...
+
+
+class BaseTranslationProvider:
+    """Small concrete base for translation providers with a shared contract."""
+
+    def translate(
+        self,
+        text: str,
+        source: str,
+        target: str = "en",
+    ) -> TranslationResult:
+        raise NotImplementedError
 
 
 class NoOpEnglishProvider:
@@ -231,6 +244,87 @@ class OpenSourceTranslationProvider:
             # deep-translator does not expose a calibrated confidence/quality
             # score, so leave quality_score absent instead of inventing certainty.
             metadata={"backend": "deep-translator", "engine": "google"},
+        )
+
+
+class DeepLTranslationProvider(BaseTranslationProvider):
+    """Official DeepL API adapter for production multilingual evidence translation."""
+
+    provider_name = "DEEPL_API"
+    model_name = "deepl-api"
+    model_version = "v2"
+
+    def __init__(self) -> None:
+        api_key = str(os.getenv("LT_DEEPL_API_KEY") or "").strip()
+        if not api_key:
+            raise ValueError(
+                "LT_DEEPL_API_KEY is required when LT_LACEY_TRANSLATION_PROVIDER=deepl"
+            )
+        self.translator = deepl.Translator(api_key)
+
+    @staticmethod
+    def _target_language(code: str) -> str:
+        normalized = str(code or "").strip().lower()
+        mapping = {
+            "en": "EN-US",
+            "eng": "EN-US",
+            "en-us": "EN-US",
+            "en-gb": "EN-GB",
+            "es": "ES",
+            "spa": "ES",
+            "pt": "PT-BR",
+            "pt-br": "PT-BR",
+            "pt-pt": "PT-PT",
+            "zh": "ZH-HANS",
+            "zh-cn": "ZH-HANS",
+        }
+        return mapping.get(normalized, normalized.upper())
+
+    def translate(
+        self,
+        text: str,
+        source: str,
+        target: str = "en",
+    ) -> TranslationResult:
+        source_norm = str(source or "").strip().lower()
+        target_norm = str(target or "").strip().lower()
+        original_text = str(text or "")
+        if not source_norm:
+            raise ValueError("A source language is required for translation")
+        if not target_norm:
+            raise ValueError("A target language is required for translation")
+
+        target_lang = self._target_language(target_norm)
+        if not original_text.strip():
+            return TranslationResult(
+                translated_text=original_text,
+                source_language=source_norm,
+                target_language=target_norm,
+                provider=self.provider_name,
+                model_name=self.model_name,
+                model_version=self.model_version,
+                metadata={"backend": "deepl", "target_lang": target_lang},
+            )
+
+        response = self.translator.translate_text(
+            original_text,
+            target_lang=target_lang,
+        )
+        translated = str(getattr(response, "text", response) or "").strip()
+        if not translated:
+            raise RuntimeError("DeepL API returned an empty translation")
+        detected_source = str(getattr(response, "detected_source_lang", "") or "").strip()
+        metadata: dict[str, Any] = {"backend": "deepl", "target_lang": target_lang}
+        if detected_source:
+            metadata["detected_source_lang"] = detected_source
+        return TranslationResult(
+            translated_text=translated,
+            source_language=source_norm,
+            target_language=target_norm,
+            provider=self.provider_name,
+            model_name=self.model_name,
+            model_version=self.model_version,
+            metadata=metadata,
         )
 
 

--- a/src/litoral_trace/us_lacey/projection.py
+++ b/src/litoral_trace/us_lacey/projection.py
@@ -208,14 +208,14 @@ _PARTY_NON_NAMES = frozenset(
 
 _TAXONOMY_COMMERCIAL_STOP_WORDS = frozenset(
     {
-        "board",
-        "boards",
-        "cutting",
-        "lumber",
-        "pallet",
-        "pallets",
-        "wood",
-        "wooden",
+        "BOARD",
+        "BOARDS",
+        "CUTTING",
+        "LUMBER",
+        "PALLET",
+        "PALLETS",
+        "WOOD",
+        "WOODEN",
     }
 )
 
@@ -238,6 +238,13 @@ def _fold(value: object) -> str:
     text = unicodedata.normalize("NFKD", str(value or "").lower())
     text = "".join(ch for ch in text if not unicodedata.combining(ch))
     return re.sub(r"[^a-z0-9]+", " ", text).strip()
+
+
+def _has_commercial_taxonomy_stop_word(value: object) -> bool:
+    """Reject commercial descriptors before they can become genus/species evidence."""
+    sanitized = str(value or "").replace(",", " ").replace("-", " ").upper()
+    words = frozenset(sanitized.split())
+    return bool(words & _TAXONOMY_COMMERCIAL_STOP_WORDS)
 
 
 def _is_structural_artifact(target: str, value: object) -> bool:
@@ -334,10 +341,8 @@ def _is_candidate_admissible(
     if not raw:
         return False
     folded = _fold(raw)
-    if target in {"genus", "species"}:
-        taxonomy_tokens = frozenset(folded.split())
-        if taxonomy_tokens & _TAXONOMY_COMMERCIAL_STOP_WORDS:
-            return False
+    if target in {"genus", "species"} and _has_commercial_taxonomy_stop_word(raw):
+        return False
     if _is_structural_artifact(target, raw):
         return False
     if folded and folded in table_headers:

--- a/src/litoral_trace/us_lacey/shadow_evidence_snapshot.py
+++ b/src/litoral_trace/us_lacey/shadow_evidence_snapshot.py
@@ -37,6 +37,7 @@ from litoral_trace.db.models import (
 from litoral_trace.db.tenant import set_tenant_db_context
 from litoral_trace.services.translation import (
     AwsTranslateProvider,
+    DeepLTranslationProvider,
     NoOpEnglishProvider,
     OpenSourceTranslationProvider,
     TranslationProvider,
@@ -191,6 +192,8 @@ def configured_translation_provider() -> TranslationProvider | None:
         return None
     if provider in {"OPEN_SOURCE", "FREE", "OPEN_SOURCE_GOOGLE"}:
         return OpenSourceTranslationProvider()
+    if provider in {"DEEPL", "DEEPL_API"}:
+        return DeepLTranslationProvider()
     if provider in {"AWS", "AWS_TRANSLATE"}:
         region = str(os.environ.get(TRANSLATION_AWS_REGION_ENV, "")).strip() or None
         return AwsTranslateProvider(region_name=region)

--- a/tests/test_deepl_translation_provider.py
+++ b/tests/test_deepl_translation_provider.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+import pytest
+
+import litoral_trace.services.translation as translation_module
+from litoral_trace.services.translation import DeepLTranslationProvider
+from litoral_trace.us_lacey.shadow_evidence_snapshot import configured_translation_provider
+
+
+class _FakeDeepLResponse:
+    def __init__(self, text: str) -> None:
+        self.text = text
+        self.detected_source_lang = "ES"
+
+
+class _FakeDeepLTranslator:
+    api_keys: list[str] = []
+    calls: list[tuple[str, str]] = []
+
+    def __init__(self, api_key: str) -> None:
+        self.api_keys.append(api_key)
+
+    def translate_text(self, text: str, *, target_lang: str):
+        self.calls.append((text, target_lang))
+        return _FakeDeepLResponse(f"deepl:{text}")
+
+
+def test_deepl_provider_uses_api_key_and_en_us_target(monkeypatch) -> None:
+    _FakeDeepLTranslator.api_keys.clear()
+    _FakeDeepLTranslator.calls.clear()
+    monkeypatch.setenv("LT_DEEPL_API_KEY", "test-key:fx")
+    monkeypatch.setattr(translation_module.deepl, "Translator", _FakeDeepLTranslator)
+
+    provider = DeepLTranslationProvider()
+    result = provider.translate("Tablas de cortar de madera", "es", "en")
+
+    assert _FakeDeepLTranslator.api_keys == ["test-key:fx"]
+    assert _FakeDeepLTranslator.calls == [("Tablas de cortar de madera", "EN-US")]
+    assert result.translated_text == "deepl:Tablas de cortar de madera"
+    assert result.provider == "DEEPL_API"
+    assert result.model_name == "deepl-api"
+    assert result.metadata["backend"] == "deepl"
+    assert result.metadata["target_lang"] == "EN-US"
+    assert result.metadata["detected_source_lang"] == "ES"
+
+
+def test_deepl_provider_requires_api_key(monkeypatch) -> None:
+    monkeypatch.delenv("LT_DEEPL_API_KEY", raising=False)
+    with pytest.raises(ValueError, match="LT_DEEPL_API_KEY"):
+        DeepLTranslationProvider()
+
+
+def test_configured_provider_accepts_deepl(monkeypatch) -> None:
+    _FakeDeepLTranslator.api_keys.clear()
+    monkeypatch.setenv("LT_DEEPL_API_KEY", "factory-key:fx")
+    monkeypatch.setenv("LT_LACEY_TRANSLATION_PROVIDER", "deepl")
+    monkeypatch.setattr(translation_module.deepl, "Translator", _FakeDeepLTranslator)
+
+    provider = configured_translation_provider()
+
+    assert isinstance(provider, DeepLTranslationProvider)
+    assert _FakeDeepLTranslator.api_keys == ["factory-key:fx"]

--- a/tests/test_us_lacey_taxonomy_sanitization.py
+++ b/tests/test_us_lacey_taxonomy_sanitization.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import pytest
 
+from litoral_trace.assurance.extraction import _candidate_from_table
 from litoral_trace.us_lacey.projection import _is_candidate_admissible
 
 
@@ -9,6 +10,7 @@ from litoral_trace.us_lacey.projection import _is_candidate_admissible
     "target,value",
     [
         ("species", "WOODEN, CUTTING, BOARDS"),
+        ("species", "WOODEN-CUTTING-BOARDS"),
         ("species", "wood"),
         ("species", "Cutting board"),
         ("species", "hardwood lumber"),
@@ -18,6 +20,17 @@ from litoral_trace.us_lacey.projection import _is_candidate_admissible
 )
 def test_taxonomy_commercial_stop_words_are_rejected(target: str, value: str) -> None:
     assert _is_candidate_admissible(target, value) is False
+
+
+def test_assurance_species_extraction_returns_none_for_commercial_taxonomy() -> None:
+    candidate = _candidate_from_table(
+        "species",
+        "WOODEN, CUTTING, BOARDS",
+        locator="test:species",
+        page=1,
+        confidence=0.99,
+    )
+    assert candidate is None
 
 
 def test_legitimate_botanical_values_remain_admissible() -> None:


### PR DESCRIPTION
## Summary
- add the official `deepl>=1.16.1` client and a `DeepLTranslationProvider`
- require `LT_DEEPL_API_KEY` when DeepL is selected
- map English targets to `EN-US` and return `TranslationResult(provider="DEEPL_API")`
- add `deepl` / `DEEPL_API` support to `configured_translation_provider()`
- harden botanical sanitization by replacing commas/hyphens, uppercasing, tokenizing, and rejecting any commercial stop-word match
- reject commercial `species` candidates at Assurance extraction time and again at the U.S. Lacey genus/species projection boundary

## Tests
- mocked DeepL API key and translator initialization
- English target mapped to `EN-US`
- factory selection for `LT_LACEY_TRANSLATION_PROVIDER=deepl`
- missing API key fails clearly
- `WOODEN, CUTTING, BOARDS` and hyphenated variants are rejected
- legitimate botanical values remain admissible
