### PR TITLE
fix(us-lacey): harden AI engine resilience

### DIFF
--- a/src/litoral_trace/lacey_engine/ai_providers.py
+++ b/src/litoral_trace/lacey_engine/ai_providers.py
@@ -12,6 +12,7 @@ import base64
 import hashlib
 from io import BytesIO
 import json
+import logging
 import mimetypes
 import os
 import time
@@ -33,6 +34,12 @@ PROVIDER_QWEN_OLLAMA = "qwen_ollama"
 PROVIDER_MISTRAL_OCR = "mistral_ocr"
 PROVIDER_OPENAI = "openai"
 PROVIDER_GEMINI = "gemini"
+
+
+LOGGER = logging.getLogger(__name__)
+_TRANSIENT_HTTP_STATUS_CODES = frozenset({500, 502, 503, 504})
+_POST_JSON_MAX_ATTEMPTS = 3
+_POST_JSON_RETRY_DELAY_SECONDS = 2.0
 
 
 @dataclass(frozen=True, slots=True)
@@ -210,13 +217,48 @@ def _post_json(
     if headers:
         merged_headers.update(headers)
     request = Request(url, data=body, headers=merged_headers, method="POST")
-    try:
-        with urlopen(request, timeout=timeout) as response:
-            raw = response.read()
-    except HTTPError as exc:
-        raise AIShadowError(f"AI provider returned HTTP {exc.code}.") from exc
-    except (URLError, TimeoutError, OSError) as exc:
-        raise AIShadowError("AI provider request failed.") from exc
+    host = urlparse(url).hostname or "unknown"
+
+    raw: bytes | None = None
+    for attempt in range(1, _POST_JSON_MAX_ATTEMPTS + 1):
+        try:
+            with urlopen(request, timeout=timeout) as response:
+                raw = response.read()
+            break
+        except HTTPError as exc:
+            if exc.code not in _TRANSIENT_HTTP_STATUS_CODES:
+                raise AIShadowError(f"AI provider returned HTTP {exc.code}.") from exc
+            LOGGER.warning(
+                "AI provider returned a transient HTTP error; retrying request.",
+                extra={
+                    "ai_provider_host": host,
+                    "ai_provider_http_status": exc.code,
+                    "ai_provider_attempt": attempt,
+                    "ai_provider_max_attempts": _POST_JSON_MAX_ATTEMPTS,
+                },
+            )
+            if attempt >= _POST_JSON_MAX_ATTEMPTS:
+                raise AIShadowError(
+                    f"AI provider returned HTTP {exc.code} after {_POST_JSON_MAX_ATTEMPTS} attempts."
+                ) from exc
+        except (URLError, TimeoutError, OSError) as exc:
+            LOGGER.warning(
+                "AI provider network request failed; retrying request.",
+                extra={
+                    "ai_provider_host": host,
+                    "ai_provider_error_type": type(exc).__name__,
+                    "ai_provider_attempt": attempt,
+                    "ai_provider_max_attempts": _POST_JSON_MAX_ATTEMPTS,
+                },
+            )
+            if attempt >= _POST_JSON_MAX_ATTEMPTS:
+                raise AIShadowError(
+                    f"AI provider request failed after {_POST_JSON_MAX_ATTEMPTS} attempts."
+                ) from exc
+        time.sleep(_POST_JSON_RETRY_DELAY_SECONDS)
+
+    if raw is None:
+        raise AIShadowError("AI provider request failed without a response.")
     try:
         parsed = json.loads(raw.decode("utf-8"))
     except (UnicodeDecodeError, json.JSONDecodeError) as exc:

--- a/src/litoral_trace/lacey_engine/ai_shadow.py
+++ b/src/litoral_trace/lacey_engine/ai_shadow.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 from dataclasses import dataclass, replace
 from enum import Enum
 import json
+import math
 import re
 import unicodedata
 from datetime import datetime
@@ -128,16 +129,22 @@ def comparison_key(field_key: str, value: str | None) -> str | None:
     return normalized.upper() if field_key in _IDENTIFIER_FIELDS else _fold(normalized)
 
 def _bbox_from_payload(payload: object) -> BoundingBox | None:
-    if payload is None:
+    """Best-effort spatial metadata parser that never rejects otherwise valid text.
+
+    Vision models occasionally reverse coordinate pairs or emit malformed geometry.
+    Inverted finite pairs are normalized; unusable geometry is discarded so the
+    evidence text can still flow through the shadow pipeline without a rectangle.
+    """
+    if payload is None or not isinstance(payload, (list, tuple)) or len(payload) != 4:
         return None
-    if not isinstance(payload, (list, tuple)) or len(payload) != 4:
-        raise AIShadowError("AI candidate bbox must contain four numbers.")
     try:
-        x0, top, x1, bottom = (float(item) for item in payload)
-    except (TypeError, ValueError) as exc:
-        raise AIShadowError("AI candidate bbox contains an invalid coordinate.") from exc
-    if x1 < x0 or bottom < top:
-        raise AIShadowError("AI candidate bbox is inverted.")
+        x_a, y_a, x_b, y_b = (float(item) for item in payload)
+    except (TypeError, ValueError):
+        return None
+    if not all(math.isfinite(value) for value in (x_a, y_a, x_b, y_b)):
+        return None
+    x0, x1 = sorted((x_a, x_b))
+    top, bottom = sorted((y_a, y_b))
     return BoundingBox(x0=x0, top=top, x1=x1, bottom=bottom)
 
 def candidate_from_payload(*, payload: Mapping[str, object], provider: str, model: str) -> AICandidate:

--- a/src/litoral_trace/us_lacey/ai_review.py
+++ b/src/litoral_trace/us_lacey/ai_review.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 import hashlib
 import json
+import logging
 import os
 from typing import Mapping
 
@@ -32,6 +33,9 @@ from litoral_trace.us_lacey.db import get_us_lacey_db_session
 
 AI_REVIEW_OFF = "OFF"
 AI_REVIEW_SHADOW = "SHADOW"
+
+
+LOGGER = logging.getLogger(__name__)
 
 
 @dataclass(frozen=True, slots=True)
@@ -296,6 +300,51 @@ def _call_gemini_decision(
     )
 
 
+def _safe_call_review_decision(
+    *,
+    provider_config: AIProviderConfig,
+    model: str,
+    field_name: str,
+    issue: ReconciliationIssue,
+    candidates: tuple[ReviewCandidate, ...],
+    task: AITask,
+) -> AIReviewRecommendation | None:
+    """Return no recommendation when an external AI provider is unavailable.
+
+    Reconciliation advice is shadow-only. Exhausted provider retries therefore
+    degrade to human review rather than failing the surrounding ingestion worker.
+    """
+    try:
+        if provider_config.provider == PROVIDER_GEMINI:
+            return _call_gemini_decision(
+                provider_config=provider_config,
+                model=model,
+                field_name=field_name,
+                issue=issue,
+                candidates=candidates,
+                thinking_level="high" if task is AITask.ADJUDICATE else "medium",
+            )
+        return _call_openai_decision(
+            provider_config=provider_config,
+            model=model,
+            field_name=field_name,
+            issue=issue,
+            candidates=candidates,
+        )
+    except AIShadowError as exc:
+        LOGGER.warning(
+            "AI review recommendation unavailable; leaving issue for human review.",
+            extra={
+                "ai_review_provider": provider_config.provider,
+                "ai_review_model": model,
+                "ai_review_issue_id": getattr(issue, "id", None),
+                "ai_review_field_name": field_name,
+                "ai_review_error_type": type(exc).__name__,
+            },
+        )
+        return None
+
+
 def _review_candidates(rows: list[UsLaceyFieldCandidate]) -> tuple[ReviewCandidate, ...]:
     """Deduplicate exact candidate values while retaining strongest source record."""
     strongest: dict[str, UsLaceyFieldCandidate] = {}
@@ -388,23 +437,16 @@ def recommend_open_reconciliation_issues(*, organization_id: int, operation_id: 
             ):
                 continue
 
-            if provider_config.provider == PROVIDER_GEMINI:
-                recommendation = _call_gemini_decision(
-                    provider_config=provider_config,
-                    model=model,
-                    field_name=str(issue.field_name or ""),
-                    issue=issue,
-                    candidates=candidates,
-                    thinking_level="high" if task is AITask.ADJUDICATE else "medium",
-                )
-            else:
-                recommendation = _call_openai_decision(
-                    provider_config=provider_config,
-                    model=model,
-                    field_name=str(issue.field_name or ""),
-                    issue=issue,
-                    candidates=candidates,
-                )
+            recommendation = _safe_call_review_decision(
+                provider_config=provider_config,
+                model=model,
+                field_name=str(issue.field_name or ""),
+                issue=issue,
+                candidates=candidates,
+                task=task,
+            )
+            if recommendation is None:
+                continue
             current_evidence["ai_recommendation"] = {
                 "schema_version": "lacey_ai_candidate_recommendation_v1",
                 "provider": provider_config.provider,

--- a/tests/lacey_engine/test_ai_engine_resilience.py
+++ b/tests/lacey_engine/test_ai_engine_resilience.py
@@ -1,0 +1,148 @@
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+from urllib.error import HTTPError, URLError
+
+import pytest
+
+from litoral_trace.lacey_engine import ai_providers
+from litoral_trace.lacey_engine.ai_providers import AIProviderConfig
+from litoral_trace.lacey_engine.ai_routing import AITask
+from litoral_trace.lacey_engine.ai_shadow import AIShadowError, candidate_from_payload
+from litoral_trace.us_lacey import ai_review
+from litoral_trace.us_lacey.ai_review import ReviewCandidate
+
+
+def _candidate_payload(bbox):
+    return {
+        "field_key": "description",
+        "value": "Wooden cutting boards",
+        "evidence_class": "EXPLICIT",
+        "page": 1,
+        "source_text": "Wooden cutting boards",
+        "confidence": 0.9,
+        "bbox": bbox,
+        "reason": None,
+    }
+
+
+def test_inverted_bbox_is_normalized_instead_of_rejecting_candidate():
+    candidate = candidate_from_payload(
+        payload=_candidate_payload([90, 80, 10, 20]),
+        provider="gemini",
+        model="gemini-test",
+    )
+    assert candidate.bbox is not None
+    assert (candidate.bbox.x0, candidate.bbox.top, candidate.bbox.x1, candidate.bbox.bottom) == (10.0, 20.0, 90.0, 80.0)
+
+
+@pytest.mark.parametrize("bbox", [[1, 2, 3], [1, None, 3, 4], [1, 2, float("nan"), 4], "not-a-box"])
+def test_invalid_bbox_is_dropped_but_text_candidate_survives(bbox):
+    candidate = candidate_from_payload(
+        payload=_candidate_payload(bbox),
+        provider="gemini",
+        model="gemini-test",
+    )
+    assert candidate.value == "Wooden cutting boards"
+    assert candidate.bbox is None
+
+
+class _Response:
+    def __init__(self, payload: dict[str, object]):
+        self._raw = json.dumps(payload).encode("utf-8")
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+    def read(self):
+        return self._raw
+
+
+def test_post_json_retries_http_500_and_succeeds_on_third_attempt(monkeypatch):
+    calls = []
+
+    def fake_urlopen(request, timeout):
+        calls.append((request, timeout))
+        if len(calls) < 3:
+            raise HTTPError(request.full_url, 500, "Internal Server Error", None, None)
+        return _Response({"ok": True})
+
+    sleeps = []
+    monkeypatch.setattr(ai_providers, "urlopen", fake_urlopen)
+    monkeypatch.setattr(ai_providers.time, "sleep", lambda seconds: sleeps.append(seconds))
+
+    result = ai_providers._post_json(url="https://example.test/v1", payload={"x": 1}, timeout=3)
+
+    assert result == {"ok": True}
+    assert len(calls) == 3
+    assert sleeps == [2.0, 2.0]
+
+
+def test_post_json_retries_url_error_then_recovers(monkeypatch):
+    attempts = 0
+
+    def fake_urlopen(_request, timeout):
+        nonlocal attempts
+        attempts += 1
+        if attempts == 1:
+            raise URLError("temporary timeout")
+        return _Response({"ok": True})
+
+    monkeypatch.setattr(ai_providers, "urlopen", fake_urlopen)
+    monkeypatch.setattr(ai_providers.time, "sleep", lambda _seconds: None)
+
+    assert ai_providers._post_json(url="https://example.test/v1", payload={}, timeout=3) == {"ok": True}
+    assert attempts == 2
+
+
+def test_post_json_raises_only_after_three_transient_failures(monkeypatch):
+    attempts = 0
+
+    def fake_urlopen(request, timeout):
+        nonlocal attempts
+        attempts += 1
+        raise HTTPError(request.full_url, 503, "Unavailable", None, None)
+
+    monkeypatch.setattr(ai_providers, "urlopen", fake_urlopen)
+    monkeypatch.setattr(ai_providers.time, "sleep", lambda _seconds: None)
+
+    with pytest.raises(AIShadowError, match="after 3 attempts"):
+        ai_providers._post_json(url="https://example.test/v1", payload={}, timeout=3)
+    assert attempts == 3
+
+
+def test_ai_review_provider_failure_degrades_to_no_recommendation(monkeypatch):
+    config = AIProviderConfig(
+        "SHADOW", "gemini", "gemini-test", "https://example.test/interactions", "test-key", 3, 8, True
+    )
+    issue = SimpleNamespace(
+        id=77,
+        rule_code="US_LACEY_FIELD_CONFLICT",
+        severity="BLOCKING",
+        left_value="Chile",
+        right_value="Peru",
+    )
+    candidates = (
+        ReviewCandidate(1, "Chile", 1, "page:1", 0.9),
+        ReviewCandidate(2, "Peru", 1, "page:1", 0.9),
+    )
+    monkeypatch.setattr(
+        ai_review,
+        "_call_gemini_decision",
+        lambda **_kwargs: (_ for _ in ()).throw(AIShadowError("upstream unavailable")),
+    )
+
+    result = ai_review._safe_call_review_decision(
+        provider_config=config,
+        model="gemini-test",
+        field_name="country_of_harvest",
+        issue=issue,
+        candidates=candidates,
+        task=AITask.ADJUDICATE,
+    )
+
+    assert result is None


### PR DESCRIPTION
## Summary
- normalize inverted AI vision bounding boxes instead of aborting extraction
- drop malformed/non-finite bounding boxes to `None` while preserving valid evidence text
- retry transient provider failures (`500/502/503/504`, `URLError`, timeout/network errors) up to 3 attempts with structured warnings and bounded delay
- raise `AIShadowError` only after retries are exhausted
- isolate Gemini/OpenAI review recommendation failures so shadow advisory AI degrades to human review instead of aborting the worker

## Tests
- inverted bbox is reordered deterministically
- malformed/null-like bbox metadata is discarded while the candidate survives
- HTTP 500 retries twice and succeeds on the third attempt
- URL/network failure retries and recovers
- exhausted transient failures raise only after 3 attempts
- AI review provider failure returns no recommendation instead of propagating
