### PR TITLE
feat(us-lacey): optimize Gemini extraction prompt

### DIFF
--- a/src/litoral_trace/lacey_engine/ai_shadow.py
+++ b/src/litoral_trace/lacey_engine/ai_shadow.py
@@ -19,8 +19,9 @@ from .domain import BoundingBox, DocumentResolution, EvidenceClass, FieldStatus
 
 AI_SHADOW_SCHEMA_VERSION = "lacey_ai_shadow_v1"
 AI_FIELDS = (
-    "estimated_arrival_date", "bill_of_lading", "container_number", "consignee_name",
-    "consignee_address", "description", "species", "genus", "filing_entry_reference",
+    "estimated_arrival_date", "bill_of_lading", "container_number", "importer_name",
+    "importer_address", "consignee_name", "consignee_address", "description",
+    "entered_value", "article_component", "species", "genus", "filing_entry_reference",
     "manufacturer_id", "hts_code", "country_of_harvest", "plant_quantity", "metric_unit",
 )
 

--- a/src/litoral_trace/lacey_engine/gemini_provider.py
+++ b/src/litoral_trace/lacey_engine/gemini_provider.py
@@ -7,6 +7,7 @@ verification and human-review boundary before it can influence the preparation r
 from __future__ import annotations
 
 import base64
+from copy import deepcopy
 import json
 import time
 from typing import Mapping
@@ -23,6 +24,44 @@ from .ai_shadow import AIExtractionResult, AIShadowError, extraction_result_from
 
 PROVIDER_GEMINI = "gemini"
 GEMINI_INTERACTIONS_URL = "https://generativelanguage.googleapis.com/v1beta/interactions"
+
+
+_GEMINI_EXTRACTION_PROMPT = _PROMPT + """
+
+You are an expert U.S. Customs and Lacey Act auditor.
+Pay strict attention to tabular data (e.g., Commercial Invoices, Botanical Declarations).
+Extract EVERY line item. Do not merge different HTS codes or species into a single string.
+Look for Importer and Consignee specifically in Entry Worksheets or Bills of Lading.
+
+For multi-line or visually aligned tables, preserve row-level meaning. A wrapped cell may continue
+on the following visual line; associate it with the correct row before extracting candidates.
+For repeated line-item facts, emit a separate candidate object for EVERY occurrence. The outer
+`candidates` property is the array: repeat `field_key` as many times as needed instead of joining
+values with commas, slashes, semicolons, or prose. In particular, keep each HTS number, entered
+value, genus, species, plant quantity, and unit as an independent candidate tied to exact source
+text. Never collapse multiple merchandise rows into one synthetic value.
+
+Use the canonical field keys `hts_code` for HTS Number and `plant_quantity` for Quantity.
+Use `importer_name`/`importer_address` for importer facts, `consignee_name`/`consignee_address`
+for consignee facts, `entered_value` for declared line value, and `article_component` for the
+plant article/component description when those facts are explicitly present.
+"""
+
+# The provider-neutral contract is intentionally candidate-based rather than a Pydantic object
+# with one scalar property per regulatory field. Its top-level `candidates` array already allows
+# strict repeated values without breaking provenance. Gemini gets an annotated copy that makes
+# that cardinality explicit while keeping the downstream AI-shadow contract stable.
+_GEMINI_CANDIDATE_SCHEMA = deepcopy(_CANDIDATE_SCHEMA)
+_GEMINI_CANDIDATE_SCHEMA["properties"]["candidates"]["description"] = (
+    "Array of evidence-backed field occurrences. Emit one object per field occurrence and per "
+    "line item; repeated field_key values are expected for multi-line tables."
+)
+_GEMINI_CANDIDATE_SCHEMA["properties"]["candidates"]["items"]["properties"]["value"][
+    "description"
+] = (
+    "Exactly one scalar value for one field occurrence. Never concatenate multiple HTS codes, "
+    "entered values, genera, species, quantities, or units into one string."
+)
 
 
 def gemini_output_text(response: Mapping[str, object]) -> str:
@@ -76,7 +115,7 @@ class GeminiInteractionsProvider:
                     {
                         "type": "text",
                         "text": (
-                            _PROMPT
+                            _GEMINI_EXTRACTION_PROMPT
                             + f"\nThis image is page {page_number}. "
                             f"Every candidate page must be {page_number}."
                         ),
@@ -93,7 +132,7 @@ class GeminiInteractionsProvider:
                 "response_format": {
                     "type": "text",
                     "mime_type": "application/json",
-                    "schema": _CANDIDATE_SCHEMA,
+                    "schema": _GEMINI_CANDIDATE_SCHEMA,
                 },
             }
             response = _post_json(

--- a/tests/lacey_engine/test_ai_prompt_optimization.py
+++ b/tests/lacey_engine/test_ai_prompt_optimization.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+import json
+
+from litoral_trace.lacey_engine.ai_providers import AIProviderConfig
+from litoral_trace.lacey_engine.ai_shadow import AI_FIELDS
+from litoral_trace.lacey_engine import gemini_provider
+from litoral_trace.lacey_engine.gemini_provider import GeminiInteractionsProvider, _GEMINI_CANDIDATE_SCHEMA, _GEMINI_EXTRACTION_PROMPT
+
+
+def _config() -> AIProviderConfig:
+    return AIProviderConfig("SHADOW", "gemini", "gemini-3.5-flash-lite", "https://generativelanguage.googleapis.com/v1beta/interactions", "test-key", 30, 8, True)
+
+
+def _candidate(field_key: str, value: str, source_text: str) -> dict[str, object]:
+    return {"field_key": field_key, "value": value, "evidence_class": "EXPLICIT", "page": 77, "source_text": source_text, "confidence": 0.97, "bbox": None, "reason": None}
+
+
+def test_gemini_prompt_is_customs_table_and_line_item_aware():
+    assert "You are an expert U.S. Customs and Lacey Act auditor." in _GEMINI_EXTRACTION_PROMPT
+    assert "Extract EVERY line item" in _GEMINI_EXTRACTION_PROMPT
+    assert "Do not merge different HTS codes or species into a single string" in _GEMINI_EXTRACTION_PROMPT
+    assert "Look for Importer and Consignee specifically in Entry Worksheets or Bills of Lading" in _GEMINI_EXTRACTION_PROMPT
+    assert "multi-line or visually aligned tables" in _GEMINI_EXTRACTION_PROMPT
+
+
+def test_candidate_schema_explicitly_models_repeatable_line_item_occurrences():
+    candidates_schema = _GEMINI_CANDIDATE_SCHEMA["properties"]["candidates"]
+    assert candidates_schema["type"] == "array"
+    assert "one object per field occurrence" in candidates_schema["description"]
+    assert "Never concatenate multiple HTS codes" in candidates_schema["items"]["properties"]["value"]["description"]
+    assert {"importer_name", "entered_value", "article_component"}.issubset(set(AI_FIELDS))
+
+
+def test_gemini_preserves_multiple_hts_species_values_and_quantities(monkeypatch):
+    captured: dict[str, object] = {}
+    monkeypatch.setattr(gemini_provider, "_document_images", lambda *_args, **_kwargs: [b"image"])
+    candidates = [
+        _candidate("importer_name", "ACME IMPORTS LLC", "Importer: ACME IMPORTS LLC"),
+        _candidate("consignee_name", "ACME WAREHOUSE", "Consignee: ACME WAREHOUSE"),
+        _candidate("hts_code", "4418.99.90", "4418.99.90 | 12500 | Pinus | radiata | 20 M3"),
+        _candidate("entered_value", "12500", "4418.99.90 | 12500 | Pinus | radiata | 20 M3"),
+        _candidate("genus", "Pinus", "4418.99.90 | 12500 | Pinus | radiata | 20 M3"),
+        _candidate("species", "radiata", "4418.99.90 | 12500 | Pinus | radiata | 20 M3"),
+        _candidate("plant_quantity", "20", "4418.99.90 | 12500 | Pinus | radiata | 20 M3"),
+        _candidate("hts_code", "4421.99.98", "4421.99.98 | 8300 | Eucalyptus | grandis | 12 M3"),
+        _candidate("entered_value", "8300", "4421.99.98 | 8300 | Eucalyptus | grandis | 12 M3"),
+        _candidate("genus", "Eucalyptus", "4421.99.98 | 8300 | Eucalyptus | grandis | 12 M3"),
+        _candidate("species", "grandis", "4421.99.98 | 8300 | Eucalyptus | grandis | 12 M3"),
+        _candidate("plant_quantity", "12", "4421.99.98 | 8300 | Eucalyptus | grandis | 12 M3"),
+    ]
+    def fake_post_json(**kwargs):
+        captured.update(kwargs)
+        return {"output_text": json.dumps({"candidates": candidates})}
+    monkeypatch.setattr(gemini_provider, "_post_json", fake_post_json)
+    result = GeminiInteractionsProvider(_config()).extract(filename="invoice.pdf", content=b"pdf")
+    assert [c.value for c in result.candidates if c.field_key == "hts_code"] == ["4418.99.90", "4421.99.98"]
+    assert [c.value for c in result.candidates if c.field_key == "species"] == ["radiata", "grandis"]
+    assert [c.value for c in result.candidates if c.field_key == "plant_quantity"] == ["20", "12"]
+    payload = captured["payload"]
+    assert "Extract EVERY line item" in payload["input"][0]["text"]
+    assert payload["response_format"]["schema"]["properties"]["candidates"]["type"] == "array"


### PR DESCRIPTION
## Summary
- strengthen Gemini extraction instructions for U.S. Customs and Lacey Act documents
- explicitly prioritize multi-line/tabular extraction and require every line item
- instruct the model to look for Importer/Consignee in Entry Worksheets and Bills of Lading
- extend AI shadow field support with importer, entered value, and article/component fields
- keep the existing candidate-array contract and make repeated line-item cardinality explicit in the Gemini JSON schema
- prevent concatenation of multiple HTS codes, entered values, genera, species, quantities, or units into one synthetic string

## Schema note
The extraction contract is not a Pydantic object with one scalar property per regulatory field. It is already a top-level `candidates` array, where each candidate carries one field occurrence plus exact source provenance. To preserve compatibility and provenance, repeated values are represented as repeated candidate objects instead of replacing `value` with nested arrays.

## Tests
- prompt contains the requested Customs/Lacey auditor instructions
- schema explicitly declares candidate-array repeatability
- importer/entered-value/article-component fields are accepted
- simulated Gemini response preserves multiple HTS codes, species, and plant quantities as separate candidates
- focused Gemini suite: 9 passed
