### PR TITLE
fix(us-lacey): add deterministic AI garbage filter

### DIFF
--- a/src/litoral_trace/lacey_engine/ai_shadow.py
+++ b/src/litoral_trace/lacey_engine/ai_shadow.py
@@ -103,6 +103,8 @@ class AIExtractionProvider(Protocol):
 
 _IDENTIFIER_FIELDS = {"bill_of_lading", "container_number", "filing_entry_reference", "manufacturer_id", "hts_code"}
 _CASE_INSENSITIVE_FIELDS = {"consignee_name", "consignee_address", "description", "species", "genus", "country_of_harvest", "metric_unit"}
+_GARBAGE_FILTER_FIELDS = frozenset({"article_component", "description"})
+_GARBAGE_EXACT_TOKENS = frozenset({"PAL", "AUX", "PALLET", "CARTON", "BOX", "N/A", "NONE"})
 
 def _fold(value: str) -> str:
     text = unicodedata.normalize("NFKD", str(value or ""))
@@ -148,6 +150,18 @@ def _bbox_from_payload(payload: object) -> BoundingBox | None:
     top, bottom = sorted((y_a, y_b))
     return BoundingBox(x0=x0, top=top, x1=x1, bottom=bottom)
 
+def _is_deterministic_garbage_candidate(payload: Mapping[str, object]) -> bool:
+    """Reject known non-merchandise rows before they become persisted AI candidates."""
+    field_key = str(payload.get("field_key") or "").strip()
+    if field_key not in _GARBAGE_FILTER_FIELDS:
+        return False
+    value = " ".join(str(payload.get("value") or "").split()).strip()
+    if not value:
+        return False
+    if value.isdigit():
+        return True
+    return value.upper() in _GARBAGE_EXACT_TOKENS
+
 def candidate_from_payload(*, payload: Mapping[str, object], provider: str, model: str) -> AICandidate:
     field_key = str(payload.get("field_key") or "").strip()
     if field_key not in AI_FIELDS:
@@ -187,7 +201,11 @@ def extraction_result_from_payload(*, payload: Mapping[str, object], provider: s
         raise AIShadowError("AI response must contain a candidates array.")
     if not all(isinstance(item, Mapping) for item in raw_candidates):
         raise AIShadowError("AI response contains a non-object candidate.")
-    candidates = tuple(candidate_from_payload(payload=item, provider=provider, model=model) for item in raw_candidates)
+    candidates = tuple(
+        candidate_from_payload(payload=item, provider=provider, model=model)
+        for item in raw_candidates
+        if not _is_deterministic_garbage_candidate(item)
+    )
     return AIExtractionResult(provider, model, AI_SHADOW_SCHEMA_VERSION, candidates, page_count, latency_ms)
 
 def verify_ai_evidence(*, engine2: DocumentResolution, ai: AIExtractionResult) -> AIExtractionResult:

--- a/tests/lacey_engine/test_ai_deterministic_garbage_filter.py
+++ b/tests/lacey_engine/test_ai_deterministic_garbage_filter.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+from litoral_trace.lacey_engine.ai_shadow import extraction_result_from_payload
+
+
+def _candidate(field_key: str, value: str) -> dict[str, object]:
+    return {
+        "field_key": field_key,
+        "value": value,
+        "evidence_class": "EXPLICIT",
+        "page": 1,
+        "source_text": value,
+        "confidence": 0.99,
+        "bbox": None,
+        "reason": None,
+    }
+
+
+def test_deterministic_filter_drops_numeric_and_blacklisted_merchandise_rows():
+    payload = {
+        "candidates": [
+            _candidate("article_component", "1"),
+            _candidate("description", " PAL "),
+            _candidate("description", "Bandeja de madera"),
+        ]
+    }
+
+    result = extraction_result_from_payload(
+        payload=payload,
+        provider="gemini",
+        model="test-model",
+    )
+
+    assert [(candidate.field_key, candidate.value) for candidate in result.candidates] == [
+        ("description", "Bandeja de madera")
+    ]
+
+
+def test_deterministic_filter_is_scoped_to_article_component_and_description():
+    payload = {
+        "candidates": [
+            _candidate("plant_quantity", "1"),
+            _candidate("description", "Bandeja de madera"),
+        ]
+    }
+
+    result = extraction_result_from_payload(
+        payload=payload,
+        provider="gemini",
+        model="test-model",
+    )
+
+    assert [(candidate.field_key, candidate.value) for candidate in result.candidates] == [
+        ("plant_quantity", "1"),
+        ("description", "Bandeja de madera"),
+    ]


### PR DESCRIPTION
## Summary
- add a deterministic Python filter before raw AI payload rows become `AICandidate` objects
- scope the filter to `article_component` and `description`
- discard purely numeric values via `str.isdigit()`
- discard exact blacklist tokens `PAL`, `AUX`, `PALLET`, `CARTON`, `BOX`, `N/A`, and `NONE` after whitespace cleanup and uppercase normalization
- preserve legitimate merchandise text such as `Bandeja de madera`

## Why
Prompt-level negative instructions are probabilistic. This filter runs in the provider-neutral payload processing path before candidates can flow into persistence/reconciliation, preventing packaging/header noise from reaching the frontend candidate set.

## Tests
- numeric `1` is removed from `article_component`
- `PAL` is removed from `description`
- `Bandeja de madera` is preserved
- numeric values in non-target fields such as `plant_quantity` remain untouched
