### PR TITLE
fix(us-lacey): harden aggressive AI string sanitization

### DIFF
--- a/src/litoral_trace/lacey_engine/ai_shadow.py
+++ b/src/litoral_trace/lacey_engine/ai_shadow.py
@@ -104,7 +104,9 @@ class AIExtractionProvider(Protocol):
 _IDENTIFIER_FIELDS = {"bill_of_lading", "container_number", "filing_entry_reference", "manufacturer_id", "hts_code"}
 _CASE_INSENSITIVE_FIELDS = {"consignee_name", "consignee_address", "description", "species", "genus", "country_of_harvest", "metric_unit"}
 _GARBAGE_FILTER_FIELDS = frozenset({"article_component", "description"})
-_GARBAGE_EXACT_TOKENS = frozenset({"PAL", "AUX", "PALLET", "CARTON", "BOX", "N/A", "NONE"})
+_GARBAGE_MARKERS = frozenset({"PAL", "AUX", "PALLET", "CARTON", "BOX"})
+_GARBAGE_CLEAN_EXACT_TOKENS = frozenset({"NA", "NONE"})
+_GARBAGE_MARKER_PATTERN = re.compile(r"(?<![A-Z0-9])(?:PALLET|CARTON|AUX|BOX|PAL)(?![A-Z0-9])")
 
 def _fold(value: str) -> str:
     text = unicodedata.normalize("NFKD", str(value or ""))
@@ -155,12 +157,18 @@ def _is_deterministic_garbage_candidate(payload: Mapping[str, object]) -> bool:
     field_key = str(payload.get("field_key") or "").strip()
     if field_key not in _GARBAGE_FILTER_FIELDS:
         return False
-    value = " ".join(str(payload.get("value") or "").split()).strip()
-    if not value:
+    text = str(payload.get("value") or "").strip()
+    if not text:
         return False
-    if value.isdigit():
+    upper_text = text.upper()
+    clean_text = re.sub(r"[^A-Z0-9]", "", upper_text)
+    if not clean_text:
+        return False
+    if clean_text.isdigit():
         return True
-    return value.upper() in _GARBAGE_EXACT_TOKENS
+    if clean_text in _GARBAGE_CLEAN_EXACT_TOKENS or clean_text in _GARBAGE_MARKERS:
+        return True
+    return _GARBAGE_MARKER_PATTERN.search(upper_text) is not None
 
 def candidate_from_payload(*, payload: Mapping[str, object], provider: str, model: str) -> AICandidate:
     field_key = str(payload.get("field_key") or "").strip()

--- a/tests/lacey_engine/test_ai_deterministic_garbage_filter.py
+++ b/tests/lacey_engine/test_ai_deterministic_garbage_filter.py
@@ -16,11 +16,13 @@ def _candidate(field_key: str, value: str) -> dict[str, object]:
     }
 
 
-def test_deterministic_filter_drops_numeric_and_blacklisted_merchandise_rows():
+def test_deterministic_filter_drops_dirty_numeric_and_blacklisted_merchandise_rows():
     payload = {
         "candidates": [
-            _candidate("article_component", "1"),
-            _candidate("description", " PAL "),
+            _candidate("article_component", " 1. \n"),
+            _candidate("description", " PAL. \n"),
+            _candidate("description", "AUX-02"),
+            _candidate("description", "carton packaging"),
             _candidate("description", "Bandeja de madera"),
         ]
     }
@@ -36,10 +38,28 @@ def test_deterministic_filter_drops_numeric_and_blacklisted_merchandise_rows():
     ]
 
 
+def test_deterministic_filter_uses_punctuation_free_numeric_normalization():
+    payload = {
+        "candidates": [
+            _candidate("description", "\t2,\n"),
+            _candidate("article_component", " 003. "),
+            _candidate("description", "Bandeja de madera"),
+        ]
+    }
+
+    result = extraction_result_from_payload(
+        payload=payload,
+        provider="gemini",
+        model="test-model",
+    )
+
+    assert [candidate.value for candidate in result.candidates] == ["Bandeja de madera"]
+
+
 def test_deterministic_filter_is_scoped_to_article_component_and_description():
     payload = {
         "candidates": [
-            _candidate("plant_quantity", "1"),
+            _candidate("plant_quantity", " 1. \n"),
             _candidate("description", "Bandeja de madera"),
         ]
     }
@@ -51,6 +71,65 @@ def test_deterministic_filter_is_scoped_to_article_component_and_description():
     )
 
     assert [(candidate.field_key, candidate.value) for candidate in result.candidates] == [
-        ("plant_quantity", "1"),
+        ("plant_quantity", "1."),
         ("description", "Bandeja de madera"),
     ]
+
+
+def test_deterministic_filter_keeps_na_and_none_blocked_after_cleanup():
+    payload = {
+        "candidates": [
+            _candidate("description", " N/A. "),
+            _candidate("article_component", " NONE! "),
+            _candidate("description", "Bandeja de madera"),
+        ]
+    }
+
+    result = extraction_result_from_payload(
+        payload=payload,
+        provider="gemini",
+        model="test-model",
+    )
+
+    assert [candidate.value for candidate in result.candidates] == ["Bandeja de madera"]
+
+
+def test_deterministic_filter_does_not_destroy_legitimate_words_containing_markers():
+    payload = {
+        "candidates": [
+            _candidate("description", "Palo Santo wood boards"),
+            _candidate("description", "Palm wood tray"),
+            _candidate("description", "Wooden toolbox handle"),
+            _candidate("description", "Auxiliary wooden frame"),
+        ]
+    }
+
+    result = extraction_result_from_payload(
+        payload=payload,
+        provider="gemini",
+        model="test-model",
+    )
+
+    assert [candidate.value for candidate in result.candidates] == [
+        "Palo Santo wood boards",
+        "Palm wood tray",
+        "Wooden toolbox handle",
+        "Auxiliary wooden frame",
+    ]
+
+
+def test_deterministic_filter_rejects_punctuation_obfuscated_exact_marker():
+    payload = {
+        "candidates": [
+            _candidate("description", " P.A.L. "),
+            _candidate("description", "Bandeja de madera"),
+        ]
+    }
+
+    result = extraction_result_from_payload(
+        payload=payload,
+        provider="gemini",
+        model="test-model",
+    )
+
+    assert [candidate.value for candidate in result.candidates] == ["Bandeja de madera"]


### PR DESCRIPTION
## Summary
- aggressively normalize AI candidate strings with `re.sub(r'[^A-Z0-9]', '', text.upper())`
- reject punctuation/whitespace-obfuscated numeric rows via `clean_text.isdigit()`
- reject standalone packaging/auxiliary markers `PAL`, `PALLET`, `AUX`, `CARTON`, and `BOX`, including dirty forms such as `PAL.` and `AUX-02`
- preserve legitimate words that merely contain those sequences (`Palo Santo`, `Palm wood`, `toolbox`, `auxiliary`)
- retain cleaned exact rejection for `N/A` and `NONE`
- keep the filter scoped to `article_component` and `description` before `AICandidate` creation

## Tests
- rejects `" 1. \n"`, `"\t2,\n"`, and `" 003. "`
- rejects dirty packaging values such as `" PAL. \n"`, `"P.A.L."`, `"AUX-02"`, and `"carton packaging"`
- preserves `"Bandeja de madera"`, `"Palo Santo wood boards"`, `"Palm wood tray"`, `"Wooden toolbox handle"`, and `"Auxiliary wooden frame"`
- confirms non-target fields such as `plant_quantity` remain unaffected

## Review hardening
An initial arbitrary-substring implementation was tightened before merge after automated review identified false-positive risk for legitimate merchandise names. The final implementation uses bounded marker matching plus exact compact-form checks, while retaining the requested aggressive punctuation/whitespace sanitization.
