### PR TITLE
feat(lacey): Phase 1 deterministic document router

### DIFF
--- a/src/litoral_trace/lacey_engine/multi_agent/__init__.py
+++ b/src/litoral_trace/lacey_engine/multi_agent/__init__.py
@@ -10,14 +10,32 @@ from .contracts import (
     SpecialistResult,
     SpecialistRole,
 )
+from .router import (
+    AmbiguousDocumentClassifier,
+    RoutingAssignment,
+    RoutingClassification,
+    RoutingPlan,
+    build_routing_plan,
+    classify_page,
+    route_document,
+    router_document_accuracy,
+)
 
 __all__ = [
     "AgentTask",
+    "AmbiguousDocumentClassifier",
     "CandidateEnvelope",
     "DocumentType",
     "MultiAgentExtractionResult",
     "RoutedDocument",
+    "RoutingAssignment",
+    "RoutingClassification",
+    "RoutingPlan",
     "SpecialistFailure",
     "SpecialistResult",
     "SpecialistRole",
+    "build_routing_plan",
+    "classify_page",
+    "route_document",
+    "router_document_accuracy",
 ]

--- a/src/litoral_trace/lacey_engine/multi_agent/router.py
+++ b/src/litoral_trace/lacey_engine/multi_agent/router.py
@@ -1,0 +1,269 @@
+"""Deterministic document routing for the Lacey multi-extractor pipeline.
+
+The router intentionally prefers explainable lexical/layout signals.  A bounded external
+classifier may be injected for genuinely ambiguous pages, but it is never called when
+rule-based confidence is already sufficient.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+import re
+from typing import Iterable, Mapping, Protocol
+from uuid import UUID
+
+from .contracts import DocumentType, RoutedDocument, SpecialistRole
+
+
+DEFAULT_LLM_ESCALATION_THRESHOLD = 0.72
+_HEADER_WINDOW_CHARS = 1200
+
+
+@dataclass(frozen=True, slots=True)
+class RoutingClassification:
+    document_type: DocumentType
+    confidence: float
+    signals: tuple[str, ...]
+
+
+class AmbiguousDocumentClassifier(Protocol):
+    """Bounded fallback used only after deterministic routing is inconclusive."""
+
+    def classify(
+        self,
+        *,
+        filename: str,
+        page_number: int,
+        text: str,
+        deterministic: RoutingClassification,
+    ) -> RoutingClassification: ...
+
+
+@dataclass(frozen=True, slots=True)
+class RoutingAssignment:
+    document: RoutedDocument
+    specialists: tuple[SpecialistRole, ...]
+
+
+@dataclass(frozen=True, slots=True)
+class RoutingPlan:
+    assignments: tuple[RoutingAssignment, ...]
+
+    @property
+    def documents(self) -> tuple[RoutedDocument, ...]:
+        return tuple(assignment.document for assignment in self.assignments)
+
+    def specialists_for(self, document: RoutedDocument) -> tuple[SpecialistRole, ...]:
+        for assignment in self.assignments:
+            if assignment.document == document:
+                return assignment.specialists
+        return ()
+
+
+@dataclass(frozen=True, slots=True)
+class _Signal:
+    pattern: re.Pattern[str]
+    weight: float
+    label: str
+    header_only: bool = False
+
+
+def _signal(pattern: str, weight: float, label: str, *, header_only: bool = False) -> _Signal:
+    return _Signal(re.compile(pattern, re.IGNORECASE | re.MULTILINE), weight, label, header_only)
+
+
+_SIGNALS: dict[DocumentType, tuple[_Signal, ...]] = {
+    DocumentType.COMMERCIAL_INVOICE: (
+        _signal(r"\bCOMMERCIAL\s+INVOICE\b", 14, "header:commercial_invoice", header_only=True),
+        _signal(r"\bInvoice\s+(?:No\.?|Number)\b", 4, "field:invoice_number"),
+        _signal(r"\bCommercial\s+Line\s+Items?\b", 4, "section:commercial_line_items"),
+        _signal(r"\bEntered\s+Value\b", 2, "field:entered_value"),
+    ),
+    DocumentType.ENTRY_WORKSHEET: (
+        _signal(r"\b(?:U\.S\.\s+)?ENTRY\s+WORKSHEET\b", 14, "header:entry_worksheet", header_only=True),
+        _signal(r"\bEntry\s*/\s*Filing\s+Reference\b", 5, "field:filing_reference"),
+        _signal(r"\bEntry\s+Summary\s+Lines?\b", 4, "section:entry_summary_lines"),
+        _signal(r"\bImporter\s+Number\b", 2, "field:importer_number"),
+    ),
+    DocumentType.BILL_OF_LADING: (
+        _signal(r"\b(?:OCEAN\s+)?BILL\s+OF\s+LADING\b", 14, "header:bill_of_lading", header_only=True),
+        _signal(r"\bPort\s+of\s+Loading\b", 3, "field:port_of_loading"),
+        _signal(r"\bPort\s+of\s+Discharge\b", 3, "field:port_of_discharge"),
+        _signal(r"\bShipper\b.*\bConsignee\b", 2, "section:shipper_consignee"),
+    ),
+    DocumentType.ARRIVAL_NOTICE: (
+        _signal(r"\bARRIVAL\s+NOTICE\b", 14, "header:arrival_notice", header_only=True),
+        _signal(r"\bCarrier\s+Reference\b", 4, "field:carrier_reference"),
+        _signal(r"\bAvailability\b.*\bcustoms\s+release\b", 3, "field:availability"),
+        _signal(r"\bETA\b", 2, "field:eta"),
+    ),
+    DocumentType.BOTANICAL_DECLARATION: (
+        _signal(r"\bBOTANICAL\b.*\b(?:LACEY\b.*)?\bDECLARATION\b", 14, "header:botanical_declaration", header_only=True),
+        _signal(r"\bGenus\b.*\bSpecies\b", 4, "columns:genus_species"),
+        _signal(r"\bCountry\s+of\s+Harvest\b", 4, "field:harvest_country"),
+        _signal(r"\bPlant\s+Quantity\b", 2, "field:plant_quantity"),
+    ),
+    DocumentType.SUPPLIER_ORIGIN: (
+        _signal(r"\bSUPPLIER\s+(?:MATERIAL\s+)?ORIGIN\s+STATEMENT\b", 14, "header:supplier_origin", header_only=True),
+        _signal(r"\bStatement\s+of\s+Material\s+Origin\b", 5, "section:material_origin"),
+        _signal(r"\bScientific\s+Name\b", 3, "field:scientific_name"),
+        _signal(r"\bHarvest\s+Country\b", 3, "field:harvest_country"),
+    ),
+    DocumentType.PACKING_LIST: (
+        _signal(r"\bPACKING\s+LIST\b", 14, "header:packing_list", header_only=True),
+        _signal(r"\bPackage\s+Detail\b", 4, "section:package_detail"),
+        _signal(r"\bCartons\b.*\bPieces\b", 3, "columns:cartons_pieces"),
+        _signal(r"\bNet\s+Wt\.?\b.*\bGross\s+Wt\.?\b", 3, "columns:weights"),
+    ),
+}
+
+
+_SPECIALISTS: dict[DocumentType, tuple[SpecialistRole, ...]] = {
+    DocumentType.COMMERCIAL_INVOICE: (
+        SpecialistRole.COMMERCIAL_LINES,
+        SpecialistRole.CUSTOMS_IDENTITY,
+    ),
+    DocumentType.ENTRY_WORKSHEET: (
+        SpecialistRole.CUSTOMS_IDENTITY,
+        SpecialistRole.COMMERCIAL_LINES,
+    ),
+    DocumentType.BILL_OF_LADING: (
+        SpecialistRole.LOGISTICS,
+        SpecialistRole.CUSTOMS_IDENTITY,
+    ),
+    DocumentType.BOTANICAL_DECLARATION: (SpecialistRole.BOTANICAL,),
+    DocumentType.SUPPLIER_ORIGIN: (SpecialistRole.BOTANICAL,),
+    DocumentType.PACKING_LIST: (SpecialistRole.COMMERCIAL_LINES,),
+    # The routing table in the Phase 1 brief omits Arrival Notice, while the later
+    # authority table makes it a primary ETA source and LOGISTICS owns ETA.  Route it
+    # only to LOGISTICS so that omission does not discard authoritative ETA evidence.
+    DocumentType.ARRIVAL_NOTICE: (SpecialistRole.LOGISTICS,),
+    DocumentType.UNKNOWN: (),
+}
+
+
+def _normalized_text(text: str) -> str:
+    return " ".join(str(text or "").replace("\x00", " ").split())
+
+
+def classify_page(text: str, *, filename: str = "") -> RoutingClassification:
+    """Classify one page using deterministic, explainable signals only."""
+    normalized = _normalized_text(text)
+    header = normalized[:_HEADER_WINDOW_CHARS]
+    scores: dict[DocumentType, float] = {kind: 0.0 for kind in DocumentType}
+    matched: dict[DocumentType, list[str]] = {kind: [] for kind in DocumentType}
+    header_hit: dict[DocumentType, bool] = {kind: False for kind in DocumentType}
+
+    for kind, signals in _SIGNALS.items():
+        for signal in signals:
+            haystack = header if signal.header_only else normalized
+            if signal.pattern.search(haystack):
+                scores[kind] += signal.weight
+                matched[kind].append(signal.label)
+                header_hit[kind] = header_hit[kind] or signal.header_only
+
+    filename_folded = filename.replace("_", " ").replace("-", " ")
+    for kind, hints in {
+        DocumentType.COMMERCIAL_INVOICE: ("commercial invoice",),
+        DocumentType.ENTRY_WORKSHEET: ("entry worksheet",),
+        DocumentType.BILL_OF_LADING: ("bill of lading",),
+        DocumentType.ARRIVAL_NOTICE: ("arrival notice",),
+        DocumentType.BOTANICAL_DECLARATION: ("botanical declaration",),
+        DocumentType.SUPPLIER_ORIGIN: ("supplier origin",),
+        DocumentType.PACKING_LIST: ("packing list",),
+    }.items():
+        if any(hint.casefold() in filename_folded.casefold() for hint in hints):
+            scores[kind] += 1.0
+            matched[kind].append("filename_hint")
+
+    ordered = sorted(
+        ((kind, score) for kind, score in scores.items() if kind is not DocumentType.UNKNOWN),
+        key=lambda item: (item[1], item[0].value),
+        reverse=True,
+    )
+    winner, top_score = ordered[0]
+    second_score = ordered[1][1]
+    if top_score <= 0:
+        return RoutingClassification(DocumentType.UNKNOWN, 0.0, ())
+
+    margin = max(0.0, top_score - second_score)
+    if header_hit[winner]:
+        confidence = min(0.99, 0.88 + min(0.08, margin / 100.0) + min(0.03, top_score / 1000.0))
+    else:
+        confidence = min(0.86, 0.50 + min(0.20, top_score / 40.0) + min(0.16, margin / 50.0))
+
+    return RoutingClassification(winner, confidence, tuple(matched[winner]))
+
+
+def route_document(
+    *,
+    document_id: UUID,
+    page_texts: Mapping[int, str],
+    filename: str = "",
+    ambiguous_classifier: AmbiguousDocumentClassifier | None = None,
+    escalation_threshold: float = DEFAULT_LLM_ESCALATION_THRESHOLD,
+) -> tuple[RoutedDocument, ...]:
+    """Route a document, splitting page ranges when a PDF contains mixed document types."""
+    grouped_pages: dict[DocumentType, list[int]] = {}
+    grouped_confidence: dict[DocumentType, list[float]] = {}
+    grouped_signals: dict[DocumentType, list[str]] = {}
+
+    for page_number in sorted(page_texts):
+        text = page_texts[page_number]
+        classification = classify_page(text, filename=filename)
+        if classification.confidence < escalation_threshold and ambiguous_classifier is not None:
+            fallback = ambiguous_classifier.classify(
+                filename=filename,
+                page_number=page_number,
+                text=text,
+                deterministic=classification,
+            )
+            if fallback.document_type in DocumentType and fallback.confidence >= classification.confidence:
+                classification = RoutingClassification(
+                    fallback.document_type,
+                    min(1.0, max(0.0, fallback.confidence)),
+                    classification.signals + tuple(f"llm:{signal}" for signal in fallback.signals),
+                )
+
+        grouped_pages.setdefault(classification.document_type, []).append(page_number)
+        grouped_confidence.setdefault(classification.document_type, []).append(classification.confidence)
+        grouped_signals.setdefault(classification.document_type, []).extend(classification.signals)
+
+    routed: list[RoutedDocument] = []
+    for kind in sorted(grouped_pages, key=lambda item: min(grouped_pages[item])):
+        confidences = grouped_confidence[kind]
+        signals = tuple(dict.fromkeys(grouped_signals[kind]))
+        routed.append(
+            RoutedDocument(
+                document_id=document_id,
+                document_type=kind,
+                pages=tuple(grouped_pages[kind]),
+                confidence=min(confidences) if confidences else 0.0,
+                signals=signals,
+            )
+        )
+    return tuple(routed)
+
+
+def build_routing_plan(documents: Iterable[RoutedDocument]) -> RoutingPlan:
+    """Attach each routed document to its deterministic specialist fan-out."""
+    return RoutingPlan(
+        assignments=tuple(
+            RoutingAssignment(document=document, specialists=_SPECIALISTS[document.document_type])
+            for document in documents
+        )
+    )
+
+
+def router_document_accuracy(
+    expected: Mapping[tuple[UUID, int], DocumentType],
+    routed_documents: Iterable[RoutedDocument],
+) -> float:
+    """Return page-level routing accuracy for a labeled packet."""
+    if not expected:
+        return 1.0
+    actual: dict[tuple[UUID, int], DocumentType] = {}
+    for document in routed_documents:
+        for page in document.pages:
+            actual[(document.document_id, page)] = document.document_type
+    correct = sum(1 for key, kind in expected.items() if actual.get(key) is kind)
+    return correct / len(expected)

--- a/tests/fixtures/lacey_router_packet_7_docs.json
+++ b/tests/fixtures/lacey_router_packet_7_docs.json
@@ -1,0 +1,54 @@
+{
+  "source": "Parsed text from the seven synthetic Lacey packet PDFs generated for LT-TEST-2026-0912-A.",
+  "documents": [
+    {
+      "filename": "01_Commercial_Invoice.pdf",
+      "expected_type": "COMMERCIAL_INVOICE",
+      "pages": {
+        "1": "SYNTHETIC TEST DOCUMENT - NOT FOR COMMERCIAL OR CUSTOMS USE Shipment LT-TEST-2026-0912-A | Page 1\nCOMMERCIAL INVOICE\nSynthetic multi-line-item import transaction\nSeller / Exporter Importer of Record\nMekong Homewares Co., Ltd.\n28 Nguyen Van Linh Export Zone\nDistrict 7, Ho Chi Minh City 700000\nVietnam\nNorthstar Kitchen Imports LLC\n104 Harbor Commerce Blvd.\nSavannah, GA 31401\nUnited States\nInvoice No. MHW-INV-260915-77 Invoice Date September 15, 2026\nShipment Ref. LT-TEST-2026-0912-A Terms FOB Ho Chi Minh City\nCurrency USD Port of Entry Savannah, Georgia, USA\nCommercial Line Items\nLine SKU Description HTSUS Qty (PCS) Unit Value Entered Value\n1 ACT-TRAY-18 Acacia solid-wood serving trays, rectangular, food-service grade 4419.90.9000 420 $45.00 $18,900.00\n2 RUB-CB-32 Rubberwood kitchen cutting boards with juice groove 4419.90.8000 600 $29.60 $17,760.00\n3 TEK-SRV-04 Teak salad-server pairs, hand-finished, two-piece sets 4421.99.9880 250 $44.80 $11,200.00\n$47,860.00\nManufacturer ID (MID): VNMKHOM123HCM\nCountry of manufacture: Vietnam. Country of harvest may differ by botanical line; see Botanical Declaration."
+      }
+    },
+    {
+      "filename": "02_Bill_of_Lading.pdf",
+      "expected_type": "BILL_OF_LADING",
+      "pages": {
+        "1": "SYNTHETIC TEST DOCUMENT - NOT FOR COMMERCIAL OR CUSTOMS USE Shipment LT-TEST-2026-0912-A | Page 1\nOCEAN BILL OF LADING\nSynthetic carrier document with parties, container and ETA\nShipper Consignee Notify / Importer\nMekong Homewares Co., Ltd.\n28 Nguyen Van Linh Export Zone\nDistrict 7, Ho Chi Minh City 700000\nVietnam\nAtlantic Home Goods Distribution Inc.\n825 Portside Logistics Pkwy.\nPooler, GA 31322\nUnited States\nNorthstar Kitchen Imports LLC\n104 Harbor Commerce Blvd.\nSavannah, GA 31401\nUnited States\nOcean Bill of Lading OOLU-TEST-260912-01 Container No. TLLU4827315\nVessel / Voyage MV Pacific Meridian / PM0926E ETA Savannah October 3, 2026\nPort of Loading Cat Lai, Ho Chi Minh City, Vietnam Port of Discharge Savannah, GA, USA\nCargo Description\nMarks & Nos. Packages Description of Goods Gross Wt.\nMHW / LT-TEST-2026-0912-A 64 CARTONS 3 PALLETS WOODEN KITCHENWARE AND HOUSEHOLD ARTICLES\nAcacia serving trays; rubberwood cutting boards; teak salad-server pairs.\nCommercial Invoice MHW-INV-260915-77\n1,118 KG\nFreight: PREPAID\nPlace of delivery: Atlantic Home Goods Distribution Inc., Pooler, Georgia."
+      }
+    },
+    {
+      "filename": "03_Entry_Worksheet.pdf",
+      "expected_type": "ENTRY_WORKSHEET",
+      "pages": {
+        "1": "SYNTHETIC TEST DOCUMENT - NOT FOR COMMERCIAL OR CUSTOMS USE Shipment LT-TEST-2026-0912-A | Page 1\nU.S. ENTRY WORKSHEET\nSynthetic broker worksheet / entry-preparation record\nEntry / Filing Reference 123-4567890-1 Estimated Arrival 10/03/2026\nImporter Number 88-7654321 Manufacturer ID VNMKHOM123HCM\nBill of Lading OOLU-TEST-260912-01 Container TLLU4827315\nImporter of Record\nNorthstar Kitchen Imports LLC\n104 Harbor Commerce Blvd.\nSavannah, GA 31401\nUnited States\nConsignee\nAtlantic Home Goods Distribution Inc.\n825 Portside Logistics Pkwy.\nPooler, GA 31322\nUnited States\nEntry Summary Lines\nLine HTSUS Commercial Description Entered Value USD Origin\n1 4419.90.9000 Acacia solid-wood serving trays, rectangular, food-service grade 18,900.00 VN\n2 4419.90.8000 Rubberwood kitchen cutting boards with juice groove 17,760.00 VN\n3 4421.99.9880 Teak salad-server pairs, hand-finished, two-piece sets 11,200.00 VN\nTOTAL 47,860.00\nBroker note: Botanical harvest origin is controlled by the botanical declaration and may not match customs country of origin for every component."
+      }
+    },
+    {
+      "filename": "04_Botanical_Declaration.pdf",
+      "expected_type": "BOTANICAL_DECLARATION",
+      "pages": {
+        "1": "SYNTHETIC TEST DOCUMENT - NOT FOR COMMERCIAL OR CUSTOMS USE Shipment LT-TEST-2026-0912-A | Page 1\nBOTANICAL / LACEY SUPPORTING DECLARATION\nSynthetic scientific-name and harvest-origin statement\nDeclaration Scope\nThis declaration covers shipment LT-TEST-2026-0912-A, invoice MHW-INV-260915-77, B/L OOLU-TEST-260912-01. Each row is a separate botanical merchandise line and must not be merged with another HTS code or species.\nSKU Article / Component Genus Species Country of Harvest Plant Quantity Metric Unit Source Lot\nACT-TRAY-18 Serving tray / solid wood Acacia mangium Vietnam 315 KG VN-AC-2608-17\nRUB-CB-32 Cutting board / solid wood Hevea brasiliensis Vietnam 510 KG VN-HB-2608-41\nTEK-SRV-04 Salad servers / solid wood Tectona grandis Indonesia 145 KG ID-TG-2607-09\nSupplier certification: the scientific names above identify the plant material used in the imported articles. Packaging materials, pallets, cartons and auxiliary dunnage are excluded from this botanical declaration.\nAuthorized signatory: Nguyen Thi Lan - Compliance Manager\nSigned: September 15, 2026"
+      }
+    },
+    {
+      "filename": "05_Packing_List_with_Noise.pdf",
+      "expected_type": "PACKING_LIST",
+      "pages": {
+        "1": "SYNTHETIC TEST DOCUMENT - NOT FOR COMMERCIAL OR CUSTOMS USE Shipment LT-TEST-2026-0912-A | Page 1\nPACKING LIST\nSynthetic stress-test document containing packaging and row-header noise\nPacking List MHW-PL-260915-77 Container TLLU4827315\nInvoice MHW-INV-260915-77 Shipment Ref. LT-TEST-2026-0912-A\nPackage Detail\nRow Code Description / Packaging Text Cartons Pieces Net Wt. KG Gross Wt. KG\n1. ACT-TRAY-18 Acacia solid-wood serving trays 20 420 315 338\nPAL PAL PAL - heat-treated export pallet - - - 18\n2 RUB-CB-32 Rubberwood kitchen cutting boards 30 600 510 548\nAUX AUX-02 AUX - corner protectors / dunnage - - - 4\n3. TEK-SRV-04 Teak salad-server pairs 14 250 145 169\nCART ON BOX CARTON / BOX packaging only 64 - - 41\nTotals: 64 cartons, 1,270 saleable pieces, 970 KG net product weight, 1,118 KG gross shipment weight.\nIMPORTANT: Rows labeled PAL, AUX, CARTON, BOX and numerical row headers are packaging/administrative lines and are not merchandise descriptions."
+      }
+    },
+    {
+      "filename": "06_Supplier_Origin_Statement.pdf",
+      "expected_type": "SUPPLIER_ORIGIN",
+      "pages": {
+        "1": "SYNTHETIC TEST DOCUMENT - NOT FOR COMMERCIAL OR CUSTOMS USE Shipment LT-TEST-2026-0912-A | Page 1\nSUPPLIER MATERIAL ORIGIN STATEMENT\nSynthetic corroborating origin evidence\nStatement of Material Origin\nWe, Mekong Homewares Co., Ltd., certify the material origins for shipment LT-TEST-2026-0912-A and manufacturer ID VNMKHOM123HCM.\nLot SKU Material Scientific Name Harvest Country Mill / Supplier Reference\nVN-AC-2608-17 ACT-TRAY-18 Serving tray / solid wood Acacia mangium Vietnam SUP-VN-AC-2608-17\nVN-HB-2608-41 RUB-CB-32 Cutting board / solid wood Hevea brasiliensis Vietnam SUP-VN-HB-2608-41\nID-TG-2607-09 TEK-SRV-04 Salad servers / solid wood Tectona grandis Indonesia SUP-ID-TG-2607-09\nThe teak component identified as Tectona grandis was harvested in Indonesia and subsequently processed in Vietnam. Customs country of origin for the finished article remains Vietnam; harvest country is Indonesia.\nAll other listed plant material was harvested and processed in Vietnam.\nSigned: Tran Minh Khoa, Materials Compliance Officer - September 14, 2026"
+      }
+    },
+    {
+      "filename": "07_Arrival_Notice.pdf",
+      "expected_type": "ARRIVAL_NOTICE",
+      "pages": {
+        "1": "SYNTHETIC TEST DOCUMENT - NOT FOR COMMERCIAL OR CUSTOMS USE Shipment LT-TEST-2026-0912-A | Page 1\nARRIVAL NOTICE\nSynthetic carrier arrival notice\nCarrier Reference OOLU-TEST-260912-01 Container TLLU4827315\nVessel / Voyage MV Pacific Meridian / PM0926E ETA October 3, 2026\nDischarge Port Savannah, GA Availability Subject to customs release\nConsignee\nAtlantic Home Goods Distribution Inc.\n825 Portside Logistics Pkwy.\nPooler, GA 31322\nUnited States\nNotify Party / Importer\nNorthstar Kitchen Imports LLC\n104 Harbor Commerce Blvd.\nSavannah, GA 31401\nUnited States\nCargo\n64 cartons wooden kitchenware and household articles. Commercial invoice: MHW-INV-260915-77. Entry reference: 123-4567890-1."
+      }
+    }
+  ]
+}

--- a/tests/lacey_engine/test_multi_agent_router.py
+++ b/tests/lacey_engine/test_multi_agent_router.py
@@ -1,0 +1,143 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from uuid import NAMESPACE_URL, UUID, uuid5
+
+from litoral_trace.lacey_engine.multi_agent.contracts import DocumentType, SpecialistRole
+from litoral_trace.lacey_engine.multi_agent.router import (
+    RoutingClassification,
+    build_routing_plan,
+    route_document,
+    router_document_accuracy,
+)
+
+
+_PACKET_FIXTURE = Path(__file__).parents[1] / "fixtures" / "lacey_router_packet_7_docs.json"
+
+
+def _packet() -> dict[str, object]:
+    return json.loads(_PACKET_FIXTURE.read_text(encoding="utf-8"))
+
+
+def test_router_document_accuracy_on_generated_seven_pdf_packet():
+    packet = _packet()
+    routed_documents = []
+    expected: dict[tuple[UUID, int], DocumentType] = {}
+
+    for item in packet["documents"]:
+        filename = item["filename"]
+        document_id = uuid5(NAMESPACE_URL, filename)
+        expected_type = DocumentType(item["expected_type"])
+        page_texts = {int(page): text for page, text in item["pages"].items()}
+
+        routed = route_document(
+            document_id=document_id,
+            filename=filename,
+            page_texts=page_texts,
+        )
+
+        assert len(routed) == 1
+        assert routed[0].document_type is expected_type
+        assert routed[0].confidence >= 0.88
+        assert routed[0].signals
+        routed_documents.extend(routed)
+        for page in page_texts:
+            expected[(document_id, page)] = expected_type
+
+    assert router_document_accuracy(expected, routed_documents) == 1.0
+
+
+def test_routing_plan_fans_documents_out_to_expected_specialists():
+    expectations = {
+        DocumentType.COMMERCIAL_INVOICE: (
+            SpecialistRole.COMMERCIAL_LINES,
+            SpecialistRole.CUSTOMS_IDENTITY,
+        ),
+        DocumentType.ENTRY_WORKSHEET: (
+            SpecialistRole.CUSTOMS_IDENTITY,
+            SpecialistRole.COMMERCIAL_LINES,
+        ),
+        DocumentType.BILL_OF_LADING: (
+            SpecialistRole.LOGISTICS,
+            SpecialistRole.CUSTOMS_IDENTITY,
+        ),
+        DocumentType.BOTANICAL_DECLARATION: (SpecialistRole.BOTANICAL,),
+        DocumentType.SUPPLIER_ORIGIN: (SpecialistRole.BOTANICAL,),
+        DocumentType.PACKING_LIST: (SpecialistRole.COMMERCIAL_LINES,),
+        DocumentType.ARRIVAL_NOTICE: (SpecialistRole.LOGISTICS,),
+    }
+
+    for document_type, specialists in expectations.items():
+        routed = route_document(
+            document_id=uuid5(NAMESPACE_URL, document_type.value),
+            filename=f"{document_type.value}.pdf",
+            page_texts={1: _minimal_text(document_type)},
+        )[0]
+        plan = build_routing_plan((routed,))
+        assert plan.specialists_for(routed) == specialists
+
+
+def test_ambiguous_classifier_is_called_only_below_deterministic_threshold():
+    class FakeClassifier:
+        def __init__(self) -> None:
+            self.calls = 0
+
+        def classify(self, **kwargs) -> RoutingClassification:
+            self.calls += 1
+            return RoutingClassification(
+                DocumentType.SUPPLIER_ORIGIN,
+                0.93,
+                ("bounded_fallback",),
+            )
+
+    fallback = FakeClassifier()
+    ambiguous = route_document(
+        document_id=uuid5(NAMESPACE_URL, "ambiguous"),
+        filename="evidence.pdf",
+        page_texts={1: "Material provenance evidence for shipment LT-TEST."},
+        ambiguous_classifier=fallback,
+    )
+
+    assert fallback.calls == 1
+    assert ambiguous[0].document_type is DocumentType.SUPPLIER_ORIGIN
+    assert ambiguous[0].signals == ("llm:bounded_fallback",)
+
+    obvious = route_document(
+        document_id=uuid5(NAMESPACE_URL, "obvious"),
+        filename="invoice.pdf",
+        page_texts={1: "COMMERCIAL INVOICE\nInvoice No. INV-1\nCommercial Line Items\nEntered Value"},
+        ambiguous_classifier=fallback,
+    )
+
+    assert obvious[0].document_type is DocumentType.COMMERCIAL_INVOICE
+    assert fallback.calls == 1
+
+
+def test_router_splits_mixed_document_pdf_by_page_type():
+    routed = route_document(
+        document_id=uuid5(NAMESPACE_URL, "mixed-pdf"),
+        filename="packet.pdf",
+        page_texts={
+            1: "COMMERCIAL INVOICE\nInvoice No. INV-1\nCommercial Line Items\nEntered Value",
+            2: "PACKING LIST\nPackage Detail\nCartons Pieces\nNet Wt. Gross Wt.",
+        },
+    )
+
+    assert [(item.document_type, item.pages) for item in routed] == [
+        (DocumentType.COMMERCIAL_INVOICE, (1,)),
+        (DocumentType.PACKING_LIST, (2,)),
+    ]
+
+
+def _minimal_text(document_type: DocumentType) -> str:
+    return {
+        DocumentType.COMMERCIAL_INVOICE: "COMMERCIAL INVOICE\nInvoice No. INV-1\nCommercial Line Items\nEntered Value",
+        DocumentType.ENTRY_WORKSHEET: "U.S. ENTRY WORKSHEET\nEntry / Filing Reference X\nEntry Summary Lines\nImporter Number 1",
+        DocumentType.BILL_OF_LADING: "OCEAN BILL OF LADING\nShipper Consignee\nPort of Loading X\nPort of Discharge Y",
+        DocumentType.BOTANICAL_DECLARATION: "BOTANICAL / LACEY SUPPORTING DECLARATION\nGenus Species\nCountry of Harvest\nPlant Quantity",
+        DocumentType.SUPPLIER_ORIGIN: "SUPPLIER MATERIAL ORIGIN STATEMENT\nStatement of Material Origin\nScientific Name\nHarvest Country",
+        DocumentType.PACKING_LIST: "PACKING LIST\nPackage Detail\nCartons Pieces\nNet Wt. Gross Wt.",
+        DocumentType.ARRIVAL_NOTICE: "ARRIVAL NOTICE\nCarrier Reference X\nETA tomorrow\nAvailability Subject to customs release",
+        DocumentType.UNKNOWN: "",
+    }[document_type]


### PR DESCRIPTION
## Phase 1
Adds the document router on top of the merged Phase 0 contracts.

- deterministic header/keyword/layout-signal classification for the seven document types
- explainable `signals` and bounded confidence on every `RoutedDocument`
- optional ambiguity classifier invoked only below the deterministic threshold
- page-level routing so mixed PDFs can split into multiple routed page groups
- `RoutingPlan` + deterministic specialist fan-out
- page-level `router_document_accuracy`
- regression fixture built from the parsed text of the existing seven-PDF LT-TEST-2026-0912-A packet

### Specialist routing
- Commercial Invoice -> Commercial Lines + Customs Identity
- Entry Worksheet -> Customs Identity + Commercial Lines
- Bill of Lading -> Logistics + Customs Identity
- Botanical Declaration -> Botanical
- Supplier Origin -> Botanical
- Packing List -> Commercial Lines
- Arrival Notice -> Logistics (the Phase 1 table omitted it, but the later authority/field definitions make Arrival Notice authoritative for ETA and ETA belongs to Logistics)

No specialist extraction, fusion, or read-path changes are included in this PR.