### PR TITLE
feat(lacey): Phase 2 specialized extractors

### DIFF
--- a/src/litoral_trace/lacey_engine/multi_agent/gemini_specialist_adapter.py
+++ b/src/litoral_trace/lacey_engine/multi_agent/gemini_specialist_adapter.py
@@ -1,0 +1,150 @@
+"""Scoped Gemini adapter for specialized extraction.
+
+This module deliberately reuses the existing shared HTTP transport, image rendering,
+provider configuration, candidate schema, Gemini response parser, and AI-shadow payload
+conversion.  It does not change the legacy ``GeminiInteractionsProvider`` path.
+"""
+from __future__ import annotations
+
+import base64
+from copy import deepcopy
+import json
+import time
+
+from ..ai_providers import (
+    AIProviderConfig,
+    _CANDIDATE_SCHEMA,
+    _PROMPT,
+    _document_images,
+    _post_json,
+)
+from ..ai_shadow import AIExtractionResult, AIShadowError, extraction_result_from_payload
+from ..gemini_provider import gemini_output_text
+
+
+class GeminiSpecialistProvider:
+    """Gemini structured extraction with a closed field set per specialist call."""
+
+    name = "gemini"
+
+    def __init__(self, config: AIProviderConfig) -> None:
+        if not config.allow_external:
+            raise AIShadowError("External AI provider is disabled by policy.")
+        if not config.api_key:
+            raise AIShadowError("Gemini requires US_LACEY_GEMINI_API_KEY or US_LACEY_AI_API_KEY.")
+        self.config = config
+        self.model = config.model
+
+    def extract_scoped(
+        self,
+        *,
+        filename: str,
+        content: bytes,
+        pages: tuple[int, ...],
+        allowed_fields: frozenset[str],
+        prompt: str,
+    ) -> AIExtractionResult:
+        if not pages:
+            return AIExtractionResult(
+                provider=self.name,
+                model=self.model,
+                schema_version="lacey_ai_shadow_v1",
+                candidates=(),
+                page_count=0,
+                latency_ms=0,
+            )
+        if min(pages) < 1:
+            raise AIShadowError("Specialist pages must be 1-indexed.")
+        if max(pages) > self.config.max_pages:
+            raise AIShadowError(
+                f"Specialist page {max(pages)} exceeds configured max_pages={self.config.max_pages}."
+            )
+
+        all_images = _document_images(filename, content, max(pages))
+        schema = _scoped_schema(allowed_fields)
+        candidates: list[dict[str, object]] = []
+        started = time.monotonic()
+
+        for page_number in pages:
+            try:
+                image = all_images[page_number - 1]
+            except IndexError as exc:
+                raise AIShadowError(
+                    f"Specialist requested page {page_number}, but the rendered document is shorter."
+                ) from exc
+
+            payload: dict[str, object] = {
+                "model": self.model,
+                "store": False,
+                "input": [
+                    {
+                        "type": "text",
+                        "text": (
+                            _PROMPT
+                            + "\n\nSPECIALIST DOMAIN:\n"
+                            + prompt.strip()
+                            + "\n\nCLOSED FIELD CONTRACT:\n"
+                            + ", ".join(sorted(allowed_fields))
+                            + "\nReturn no field outside that list. "
+                            + f"This image is page {page_number}; every candidate page must be {page_number}."
+                        ),
+                    },
+                    {
+                        "type": "image",
+                        "mime_type": "image/png",
+                        "data": base64.b64encode(image).decode("ascii"),
+                    },
+                ],
+                "generation_config": {"thinking_level": "low"},
+                "response_format": {
+                    "type": "text",
+                    "mime_type": "application/json",
+                    "schema": schema,
+                },
+            }
+            response = _post_json(
+                url=self.config.base_url,
+                payload=payload,
+                timeout=self.config.timeout_seconds,
+                headers={"x-goog-api-key": self.config.api_key},
+            )
+            try:
+                page_payload = json.loads(gemini_output_text(response))
+            except json.JSONDecodeError as exc:
+                raise AIShadowError("Gemini specialist structured output is invalid JSON.") from exc
+            if not isinstance(page_payload, dict) or not isinstance(
+                page_payload.get("candidates"), list
+            ):
+                raise AIShadowError("Gemini specialist output is missing candidates.")
+            for item in page_payload["candidates"]:
+                if isinstance(item, dict):
+                    candidate = dict(item)
+                    candidate["page"] = page_number
+                    candidates.append(candidate)
+
+        elapsed = int((time.monotonic() - started) * 1000)
+        return extraction_result_from_payload(
+            payload={"candidates": candidates},
+            provider=self.name,
+            model=self.model,
+            page_count=len(pages),
+            latency_ms=elapsed,
+        )
+
+
+def _scoped_schema(allowed_fields: frozenset[str]) -> dict[str, object]:
+    if not allowed_fields:
+        raise AIShadowError("Specialist allowed_fields cannot be empty.")
+    schema = deepcopy(_CANDIDATE_SCHEMA)
+    item_properties = schema["properties"]["candidates"]["items"]["properties"]
+    item_properties["field_key"]["enum"] = sorted(allowed_fields)
+    schema["properties"]["candidates"]["description"] = (
+        "Evidence-backed occurrences for this specialist only. Repeated field keys are expected "
+        "for line-item tables; never merge different rows into one value."
+    )
+    item_properties["source_text"]["description"] = (
+        "Exact supporting text. For commercial tables include the complete source row when "
+        "possible, including SKU or line number and quantity, so deterministic line binding can "
+        "run later without asking the model to invent identity."
+    )
+    return schema

--- a/src/litoral_trace/lacey_engine/multi_agent/specialist_runtime.py
+++ b/src/litoral_trace/lacey_engine/multi_agent/specialist_runtime.py
@@ -1,0 +1,109 @@
+"""Shared execution boundary for deterministic Lacey extraction specialists.
+
+Specialists own field scope and domain prompting, not transport.  The provider performs
+structured extraction through the existing AI-shadow conversion path; this runtime then
+enforces the specialist contract again before wrapping existing ``AICandidate`` objects.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Protocol
+from uuid import uuid4
+
+from ..ai_shadow import AIExtractionResult
+from .contracts import (
+    AgentTask,
+    CandidateEnvelope,
+    RoutedDocument,
+    SpecialistResult,
+    SpecialistRole,
+)
+
+
+@dataclass(frozen=True, slots=True)
+class SpecialistInputDocument:
+    routed: RoutedDocument
+    filename: str
+    content: bytes
+
+
+class ScopedAIExtractionProvider(Protocol):
+    name: str
+    model: str
+
+    def extract_scoped(
+        self,
+        *,
+        filename: str,
+        content: bytes,
+        pages: tuple[int, ...],
+        allowed_fields: frozenset[str],
+        prompt: str,
+    ) -> AIExtractionResult: ...
+
+
+class BaseSpecialistExtractor:
+    """Base class that guarantees a specialist cannot leak fields outside its scope."""
+
+    role: SpecialistRole
+    allowed_fields: frozenset[str]
+    prompt: str
+
+    def __init__(self, provider: ScopedAIExtractionProvider) -> None:
+        self.provider = provider
+
+    def task_for(self, documents: tuple[RoutedDocument, ...]) -> AgentTask:
+        return AgentTask(
+            role=self.role,
+            documents=documents,
+            allowed_fields=self.allowed_fields,
+        )
+
+    def extract(self, documents: tuple[SpecialistInputDocument, ...]) -> SpecialistResult:
+        agent_run_id = uuid4()
+        envelopes: list[CandidateEnvelope] = []
+        warnings: list[str] = []
+        latency_ms = 0
+
+        for source in documents:
+            result = self.provider.extract_scoped(
+                filename=source.filename,
+                content=source.content,
+                pages=source.routed.pages,
+                allowed_fields=self.allowed_fields,
+                prompt=self.prompt,
+            )
+            latency_ms += result.latency_ms or 0
+
+            for candidate in result.candidates:
+                if candidate.field_key not in self.allowed_fields:
+                    warnings.append(
+                        f"OUT_OF_SCOPE_FIELD:{candidate.field_key}:{source.routed.document_type.value}"
+                    )
+                    continue
+                if candidate.page not in source.routed.pages:
+                    warnings.append(
+                        f"OUT_OF_SCOPE_PAGE:{candidate.page}:{source.routed.document_type.value}"
+                    )
+                    continue
+                envelopes.append(
+                    CandidateEnvelope(
+                        candidate=candidate,
+                        document_id=source.routed.document_id,
+                        document_type=source.routed.document_type,
+                        specialist=self.role,
+                        agent_run_id=agent_run_id,
+                        # Phase 3 owns line binding.  Do not guess identity here.
+                        line_item_key=None,
+                        source_span_id=None,
+                    )
+                )
+
+        return SpecialistResult(
+            role=self.role,
+            candidates=tuple(envelopes),
+            provider=self.provider.name,
+            model=self.provider.model,
+            latency_ms=latency_ms,
+            warnings=tuple(warnings),
+        )

--- a/src/litoral_trace/lacey_engine/multi_agent/specialists/__init__.py
+++ b/src/litoral_trace/lacey_engine/multi_agent/specialists/__init__.py
@@ -1,0 +1,13 @@
+"""Domain-specialized Lacey extractors."""
+
+from .botanical import BotanicalExtractor
+from .commercial import CommercialLineExtractor
+from .customs import CustomsIdentityExtractor
+from .logistics import LogisticsExtractor
+
+__all__ = [
+    "BotanicalExtractor",
+    "CommercialLineExtractor",
+    "CustomsIdentityExtractor",
+    "LogisticsExtractor",
+]

--- a/src/litoral_trace/lacey_engine/multi_agent/specialists/botanical.py
+++ b/src/litoral_trace/lacey_engine/multi_agent/specialists/botanical.py
@@ -1,0 +1,27 @@
+"""Botanical evidence specialist."""
+from __future__ import annotations
+
+from ..contracts import SpecialistRole
+from ..specialist_runtime import BaseSpecialistExtractor
+
+
+class BotanicalExtractor(BaseSpecialistExtractor):
+    role = SpecialistRole.BOTANICAL
+    allowed_fields = frozenset(
+        {
+            "genus",
+            "species",
+            "country_of_harvest",
+            "plant_quantity",
+            "metric_unit",
+        }
+    )
+    prompt = """
+Extract only botanical merchandise evidence: genus, species, harvest country, plant-material
+quantity, and metric unit. Botanical Declarations are primary; Supplier Origin Statements may
+corroborate. Keep each botanical merchandise row separate and preserve the complete row in
+source_text when possible, especially explicit SKU/line locators. Never infer harvest country
+from customs origin, exporter/manufacturer address, routing, or port. Never use shipment gross
+weight as plant_quantity unless the document explicitly identifies it as plant material.
+Never take taxonomy from Packing Lists or packaging rows.
+"""

--- a/src/litoral_trace/lacey_engine/multi_agent/specialists/commercial.py
+++ b/src/litoral_trace/lacey_engine/multi_agent/specialists/commercial.py
@@ -1,0 +1,31 @@
+"""Commercial line specialist."""
+from __future__ import annotations
+
+from ..contracts import SpecialistRole
+from ..specialist_runtime import BaseSpecialistExtractor
+
+
+class CommercialLineExtractor(BaseSpecialistExtractor):
+    role = SpecialistRole.COMMERCIAL_LINES
+    # The legacy AI-shadow contract does not yet expose sku/line_number/commercial_quantity
+    # as AICandidate field keys. Preserve that safety contract here: the prompt requires the
+    # complete row (including those locators/quantities) in source_text, and Phase 3 derives
+    # line_item_key deterministically from that evidence instead of adding unsupported fields.
+    allowed_fields = frozenset(
+        {
+            "description",
+            "article_component",
+            "hts_code",
+            "entered_value",
+        }
+    )
+    prompt = """
+Extract commercial merchandise facts row by row. Emit separate candidates for description,
+article/component, HTS code, and entered value; never merge multiple merchandise rows.
+For every candidate from a table, preserve the complete commercial row in source_text when
+possible, including explicit SKU, line number, quantity and unit. Those row locators are
+evidence for the later deterministic line-binding stage, not free-form fields to invent.
+Packing Lists are corroborating evidence only and must never create botanical taxonomy.
+Ignore packaging/admin rows such as PAL, pallet, AUX, carton, box and standalone row numbers.
+Do not extract importer/consignee identity, shipment logistics, genus/species, or harvest country.
+"""

--- a/src/litoral_trace/lacey_engine/multi_agent/specialists/customs.py
+++ b/src/litoral_trace/lacey_engine/multi_agent/specialists/customs.py
@@ -1,0 +1,26 @@
+"""Customs identity specialist."""
+from __future__ import annotations
+
+from ..contracts import SpecialistRole
+from ..specialist_runtime import BaseSpecialistExtractor
+
+
+class CustomsIdentityExtractor(BaseSpecialistExtractor):
+    role = SpecialistRole.CUSTOMS_IDENTITY
+    allowed_fields = frozenset(
+        {
+            "importer_name",
+            "importer_address",
+            "consignee_name",
+            "consignee_address",
+            "filing_entry_reference",
+            "manufacturer_id",
+        }
+    )
+    prompt = """
+Extract only customs-party and filing identity facts explicitly supported by the page.
+Prefer Entry Worksheets for importer, filing reference, and manufacturer ID; Commercial
+Invoices and Bills of Lading may corroborate parties. Do not extract logistics, HTS,
+commercial values, taxonomy, or harvest-origin fields. Keep exact party/address evidence
+separate rather than combining unrelated blocks.
+"""

--- a/src/litoral_trace/lacey_engine/multi_agent/specialists/logistics.py
+++ b/src/litoral_trace/lacey_engine/multi_agent/specialists/logistics.py
@@ -1,0 +1,22 @@
+"""Shipment logistics specialist."""
+from __future__ import annotations
+
+from ..contracts import SpecialistRole
+from ..specialist_runtime import BaseSpecialistExtractor
+
+
+class LogisticsExtractor(BaseSpecialistExtractor):
+    role = SpecialistRole.LOGISTICS
+    allowed_fields = frozenset(
+        {
+            "bill_of_lading",
+            "container_number",
+            "estimated_arrival_date",
+        }
+    )
+    prompt = """
+Extract only shipment logistics identifiers and ETA explicitly supported by the page.
+Bills of Lading are primary for B/L and container. Arrival Notices and Bills of Lading
+may support ETA. Do not extract customs-party identities, HTS, commercial values,
+taxonomy, or harvest origin. Never mistake seal/equipment identifiers for containers.
+"""

--- a/tests/lacey_engine/test_gemini_specialist_adapter.py
+++ b/tests/lacey_engine/test_gemini_specialist_adapter.py
@@ -1,0 +1,100 @@
+from __future__ import annotations
+
+import json
+
+from litoral_trace.lacey_engine.ai_providers import AIProviderConfig
+from litoral_trace.lacey_engine.multi_agent.gemini_specialist_adapter import (
+    GeminiSpecialistProvider,
+    _scoped_schema,
+)
+
+
+def _config() -> AIProviderConfig:
+    return AIProviderConfig(
+        mode="SHADOW",
+        provider="gemini",
+        model="gemini-test",
+        base_url="https://example.invalid/v1beta/interactions",
+        api_key="test-key",
+        timeout_seconds=30.0,
+        max_pages=8,
+        allow_external=True,
+    )
+
+
+def test_scoped_schema_closes_field_key_enum():
+    schema = _scoped_schema(frozenset({"hts_code", "entered_value"}))
+
+    item = schema["properties"]["candidates"]["items"]
+    assert item["properties"]["field_key"]["enum"] == ["entered_value", "hts_code"]
+    assert "complete source row" in item["properties"]["source_text"]["description"]
+
+
+def test_adapter_reuses_shared_transport_and_ai_shadow_conversion(monkeypatch):
+    import litoral_trace.lacey_engine.multi_agent.gemini_specialist_adapter as module
+
+    captured_payloads: list[dict[str, object]] = []
+
+    monkeypatch.setattr(
+        module,
+        "_document_images",
+        lambda filename, content, max_pages: [b"page-1", b"page-2", b"page-3"][:max_pages],
+    )
+
+    def fake_post_json(*, url, payload, timeout, headers):
+        captured_payloads.append(payload)
+        page_number = 2
+        return {
+            "output_text": json.dumps(
+                {
+                    "candidates": [
+                        {
+                            "field_key": "description",
+                            "value": "PAL",
+                            "evidence_class": "EXPLICIT",
+                            "page": page_number,
+                            "source_text": "PAL",
+                            "confidence": 0.99,
+                            "bbox": None,
+                            "reason": "packaging noise",
+                        },
+                        {
+                            "field_key": "hts_code",
+                            "value": "4419.90.9000",
+                            "evidence_class": "EXPLICIT",
+                            "page": page_number,
+                            "source_text": "1 ACT-TRAY-18 Acacia tray 4419.90.9000 420 18,900.00",
+                            "confidence": 0.96,
+                            "bbox": None,
+                            "reason": "commercial row",
+                        },
+                    ]
+                }
+            )
+        }
+
+    monkeypatch.setattr(module, "_post_json", fake_post_json)
+
+    provider = GeminiSpecialistProvider(_config())
+    result = provider.extract_scoped(
+        filename="fixture.pdf",
+        content=b"%PDF-fixture",
+        pages=(2,),
+        allowed_fields=frozenset({"description", "hts_code", "entered_value"}),
+        prompt="Extract commercial rows only.",
+    )
+
+    # The existing deterministic garbage filter still runs through
+    # extraction_result_from_payload and removes the PAL description.
+    assert [(candidate.field_key, candidate.value, candidate.page) for candidate in result.candidates] == [
+        ("hts_code", "4419.90.9000", 2)
+    ]
+    assert result.page_count == 1
+    assert len(captured_payloads) == 1
+
+    payload = captured_payloads[0]
+    prompt_text = payload["input"][0]["text"]
+    assert "Extract commercial rows only." in prompt_text
+    assert "CLOSED FIELD CONTRACT" in prompt_text
+    enum = payload["response_format"]["schema"]["properties"]["candidates"]["items"]["properties"]["field_key"]["enum"]
+    assert enum == ["description", "entered_value", "hts_code"]

--- a/tests/lacey_engine/test_multi_agent_specialists.py
+++ b/tests/lacey_engine/test_multi_agent_specialists.py
@@ -1,0 +1,141 @@
+from __future__ import annotations
+
+from uuid import NAMESPACE_URL, uuid5
+
+from litoral_trace.lacey_engine.ai_shadow import AICandidate, AIExtractionResult, AI_SHADOW_SCHEMA_VERSION
+from litoral_trace.lacey_engine.domain import EvidenceClass
+from litoral_trace.lacey_engine.multi_agent.contracts import DocumentType, RoutedDocument, SpecialistRole
+from litoral_trace.lacey_engine.multi_agent.specialist_runtime import SpecialistInputDocument
+from litoral_trace.lacey_engine.multi_agent.specialists import (
+    BotanicalExtractor,
+    CommercialLineExtractor,
+    CustomsIdentityExtractor,
+    LogisticsExtractor,
+)
+
+
+class FakeScopedProvider:
+    name = "fake"
+    model = "fake-model"
+
+    def __init__(self, candidates: tuple[AICandidate, ...]) -> None:
+        self.candidates = candidates
+        self.calls: list[dict[str, object]] = []
+
+    def extract_scoped(self, **kwargs) -> AIExtractionResult:
+        self.calls.append(kwargs)
+        return AIExtractionResult(
+            provider=self.name,
+            model=self.model,
+            schema_version=AI_SHADOW_SCHEMA_VERSION,
+            candidates=self.candidates,
+            page_count=len(kwargs["pages"]),
+            latency_ms=17,
+        )
+
+
+def _candidate(field_key: str, value: str, *, page: int = 1) -> AICandidate:
+    return AICandidate(
+        field_key=field_key,
+        value=value,
+        normalized_value=value,
+        evidence_class=EvidenceClass.EXPLICIT,
+        page=page,
+        source_text=f"ROW-1 SKU-1 {field_key} {value}",
+        confidence=0.9,
+        provider="fake",
+        model="fake-model",
+        evidence_verified=False,
+    )
+
+
+def _document(document_type: DocumentType = DocumentType.COMMERCIAL_INVOICE) -> SpecialistInputDocument:
+    routed = RoutedDocument(
+        document_id=uuid5(NAMESPACE_URL, document_type.value),
+        document_type=document_type,
+        pages=(1,),
+        confidence=0.98,
+        signals=("fixture",),
+    )
+    return SpecialistInputDocument(routed=routed, filename="fixture.pdf", content=b"%PDF-fixture")
+
+
+def test_specialist_allowed_fields_are_closed_and_domain_specific():
+    assert CustomsIdentityExtractor.allowed_fields == frozenset(
+        {
+            "importer_name",
+            "importer_address",
+            "consignee_name",
+            "consignee_address",
+            "filing_entry_reference",
+            "manufacturer_id",
+        }
+    )
+    assert LogisticsExtractor.allowed_fields == frozenset(
+        {"bill_of_lading", "container_number", "estimated_arrival_date"}
+    )
+    assert CommercialLineExtractor.allowed_fields == frozenset(
+        {"description", "article_component", "hts_code", "entered_value"}
+    )
+    assert BotanicalExtractor.allowed_fields == frozenset(
+        {"genus", "species", "country_of_harvest", "plant_quantity", "metric_unit"}
+    )
+
+
+def test_runtime_drops_provider_field_outside_specialist_scope_and_warns():
+    provider = FakeScopedProvider(
+        (
+            _candidate("hts_code", "4419.90.9000"),
+            _candidate("genus", "Acacia"),
+        )
+    )
+    specialist = CommercialLineExtractor(provider)
+
+    result = specialist.extract((_document(),))
+
+    assert result.role is SpecialistRole.COMMERCIAL_LINES
+    assert [item.candidate.field_key for item in result.candidates] == ["hts_code"]
+    assert result.candidates[0].line_item_key is None
+    assert result.candidates[0].source_span_id is None
+    assert result.warnings == ("OUT_OF_SCOPE_FIELD:genus:COMMERCIAL_INVOICE",)
+    assert provider.calls[0]["allowed_fields"] == CommercialLineExtractor.allowed_fields
+    assert "row" in str(provider.calls[0]["prompt"]).casefold()
+
+
+def test_runtime_drops_candidate_from_page_outside_routed_page_set():
+    provider = FakeScopedProvider((_candidate("container_number", "TLLU4827315", page=2),))
+    specialist = LogisticsExtractor(provider)
+
+    result = specialist.extract((_document(DocumentType.BILL_OF_LADING),))
+
+    assert result.candidates == ()
+    assert result.warnings == ("OUT_OF_SCOPE_PAGE:2:BILL_OF_LADING",)
+
+
+def test_task_for_preserves_closed_allowed_fields():
+    provider = FakeScopedProvider(())
+    specialist = BotanicalExtractor(provider)
+    routed = _document(DocumentType.BOTANICAL_DECLARATION).routed
+
+    task = specialist.task_for((routed,))
+
+    assert task.role is SpecialistRole.BOTANICAL
+    assert task.documents == (routed,)
+    assert task.allowed_fields is BotanicalExtractor.allowed_fields
+
+
+def test_agent_run_id_is_shared_inside_one_specialist_run():
+    provider = FakeScopedProvider(
+        (
+            _candidate("importer_name", "Northstar Kitchen Imports LLC"),
+            _candidate("manufacturer_id", "VNMKHOM123HCM"),
+        )
+    )
+    specialist = CustomsIdentityExtractor(provider)
+
+    result = specialist.extract((_document(DocumentType.ENTRY_WORKSHEET),))
+
+    assert len(result.candidates) == 2
+    assert len({item.agent_run_id for item in result.candidates}) == 1
+    assert all(item.specialist is SpecialistRole.CUSTOMS_IDENTITY for item in result.candidates)
+    assert result.latency_ms == 17


### PR DESCRIPTION
## Phase 2
Adds four closed-domain extraction specialists without changing the legacy Gemini read path.

### Specialists
- `CustomsIdentityExtractor`
- `LogisticsExtractor`
- `CommercialLineExtractor`
- `BotanicalExtractor`

Each specialist has a closed `frozenset` of allowed fields and a domain-scoped prompt. Output is enforced twice: the Gemini JSON schema only permits the specialist field set, and the Python runtime drops/warns on any provider field or page outside the specialist contract.

### Shared provider/runtime
- `GeminiSpecialistProvider` reuses the existing `_post_json`, image rendering, Gemini response parser, candidate schema and `extraction_result_from_payload` safety path.
- no specialist implements HTTP
- legacy `gemini_provider.py` remains unchanged
- current normalization and deterministic garbage filtering remain in force
- `CandidateEnvelope.line_item_key` remains explicitly `None`; Phase 3 owns deterministic line binding

### Commercial-row compatibility
The existing `AI_FIELDS` contract does not expose `sku`, `line_number`, or `commercial_quantity` as candidate keys. This PR intentionally does not mutate `ai_shadow.py`; instead the commercial prompt/schema requires full row evidence in `source_text` including SKU/line/quantity when present, so Phase 3 can bind rows deterministically without inventing new AI fields.

### Tests
Covers exact field scopes, out-of-scope field/page rejection, shared run IDs, scoped Gemini schema/prompt, shared transport use, and preservation of the existing PAL anti-garbage filter.