### PR TITLE
feat(lacey): Phase 3 deterministic line-item binding

### DIFF
--- a/src/litoral_trace/lacey_engine/multi_agent/line_binding.py
+++ b/src/litoral_trace/lacey_engine/multi_agent/line_binding.py
@@ -1,0 +1,169 @@
+"""Deterministic commercial/botanical line identity binding.
+
+Binding never asks an LLM to invent identity.  It derives the strongest available key
+from exact evidence in the required priority order: SKU, line number, Engine 2 row
+locator, then a deterministic evidence fingerprint.  Non-line fields remain unbound.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, replace
+import hashlib
+import re
+from typing import Mapping, Sequence
+from uuid import UUID
+
+from .contracts import CandidateEnvelope
+
+
+LINE_SCOPED_FIELDS = frozenset(
+    {
+        "description",
+        "article_component",
+        "hts_code",
+        "entered_value",
+        "genus",
+        "species",
+        "country_of_harvest",
+        "plant_quantity",
+        "metric_unit",
+    }
+)
+
+
+@dataclass(frozen=True, slots=True)
+class RowLocator:
+    table_id: str
+    page: int
+    row_index: int
+
+
+SourceLocatorKey = tuple[UUID, int, str]
+
+_SKU_LABEL = re.compile(r"\bSKU\s*(?:NO\.?|NUMBER|#|:)?\s*([A-Z0-9][A-Z0-9._/-]{2,})\b", re.I)
+_LEADING_LINE_AND_SKU = re.compile(
+    r"^\s*(?:LINE\s*)?(\d{1,6})[.)]?\s+([A-Z0-9][A-Z0-9._/-]{2,})\b",
+    re.I,
+)
+_LEADING_SKU = re.compile(r"^\s*([A-Z0-9]*[A-Z][A-Z0-9]*[-_/][A-Z0-9._/-]*\d[A-Z0-9._/-]*)\b", re.I)
+_LINE_LABEL = re.compile(
+    r"\b(?:LINE|ITEM)\s*(?:NO\.?|NUMBER|#)?\s*[:#]?\s*(\d{1,6})\b",
+    re.I,
+)
+
+
+def source_locator_key(envelope: CandidateEnvelope) -> SourceLocatorKey:
+    return (
+        envelope.document_id,
+        envelope.candidate.page,
+        " ".join(envelope.candidate.source_text.split()),
+    )
+
+
+def derive_line_item_key(
+    envelope: CandidateEnvelope,
+    *,
+    row_locator: RowLocator | None = None,
+) -> str | None:
+    """Return deterministic line identity for one line-scoped candidate."""
+    if envelope.candidate.field_key not in LINE_SCOPED_FIELDS:
+        return None
+
+    source = " ".join(envelope.candidate.source_text.split()).strip()
+    if not source:
+        return None
+
+    labelled_sku = _SKU_LABEL.search(source)
+    if labelled_sku:
+        return f"SKU:{_normalize_token(labelled_sku.group(1))}"
+
+    leading = _LEADING_LINE_AND_SKU.search(source)
+    if leading and _looks_like_sku(leading.group(2)):
+        return f"SKU:{_normalize_token(leading.group(2))}"
+
+    leading_sku = _LEADING_SKU.search(source)
+    if leading_sku and _looks_like_sku(leading_sku.group(1)):
+        return f"SKU:{_normalize_token(leading_sku.group(1))}"
+
+    labelled_line = _LINE_LABEL.search(source)
+    if labelled_line:
+        return f"LINE:{int(labelled_line.group(1))}"
+
+    if leading:
+        return f"LINE:{int(leading.group(1))}"
+
+    if row_locator is not None:
+        table = _normalize_token(row_locator.table_id)
+        if table and row_locator.page >= 1 and row_locator.row_index >= 0:
+            return (
+                f"ROW:{envelope.document_id}:P{row_locator.page}:"
+                f"T{table}:R{row_locator.row_index}"
+            )
+
+    fingerprint_text = _fingerprintable_text(source)
+    if fingerprint_text is None:
+        return None
+    digest = hashlib.sha256(fingerprint_text.encode("utf-8")).hexdigest()[:24].upper()
+    return f"FP:{digest}"
+
+
+def bind_line_item(
+    envelope: CandidateEnvelope,
+    *,
+    row_locator: RowLocator | None = None,
+) -> CandidateEnvelope:
+    """Return a new frozen envelope with a derived key, preserving all other data."""
+    return replace(
+        envelope,
+        line_item_key=derive_line_item_key(envelope, row_locator=row_locator),
+    )
+
+
+def bind_line_items(
+    candidates: Sequence[CandidateEnvelope],
+    *,
+    row_locators: Mapping[SourceLocatorKey, RowLocator] | None = None,
+) -> tuple[CandidateEnvelope, ...]:
+    row_locators = row_locators or {}
+    return tuple(
+        bind_line_item(candidate, row_locator=row_locators.get(source_locator_key(candidate)))
+        for candidate in candidates
+    )
+
+
+def line_item_binding_accuracy(
+    expected_keys: Sequence[str | None],
+    candidates: Sequence[CandidateEnvelope],
+) -> float:
+    """Compute exact key accuracy for a labeled validation set."""
+    if len(expected_keys) != len(candidates):
+        raise ValueError("expected_keys and candidates must have the same length")
+    if not expected_keys:
+        return 1.0
+    correct = sum(
+        1 for expected, candidate in zip(expected_keys, candidates) if candidate.line_item_key == expected
+    )
+    return correct / len(expected_keys)
+
+
+def _normalize_token(value: str) -> str:
+    return re.sub(r"[^A-Z0-9._/-]+", "", value.upper()).strip("-_/.")
+
+
+def _looks_like_sku(value: str) -> bool:
+    token = _normalize_token(value)
+    return (
+        len(token) >= 4
+        and bool(re.search(r"[A-Z]", token))
+        and bool(re.search(r"\d", token))
+        and any(separator in token for separator in ("-", "_", "/"))
+    )
+
+
+def _fingerprintable_text(source: str) -> str | None:
+    normalized = re.sub(r"[^A-Z0-9]+", " ", source.upper()).strip()
+    tokens = normalized.split()
+    # A one- or two-token snippet such as "Acacia" or "18,900" is evidence for a
+    # value, not reliable evidence for a row identity.  Leave it explicitly unbound.
+    if len(tokens) < 4 or len(normalized) < 16:
+        return None
+    return normalized

--- a/tests/lacey_engine/test_multi_agent_line_binding.py
+++ b/tests/lacey_engine/test_multi_agent_line_binding.py
@@ -1,0 +1,186 @@
+from __future__ import annotations
+
+from uuid import NAMESPACE_URL, uuid5, uuid4
+
+from litoral_trace.lacey_engine.ai_shadow import AICandidate
+from litoral_trace.lacey_engine.domain import EvidenceClass
+from litoral_trace.lacey_engine.multi_agent.contracts import (
+    CandidateEnvelope,
+    DocumentType,
+    SpecialistRole,
+)
+from litoral_trace.lacey_engine.multi_agent.line_binding import (
+    RowLocator,
+    bind_line_item,
+    bind_line_items,
+    derive_line_item_key,
+    line_item_binding_accuracy,
+    source_locator_key,
+)
+
+
+def _envelope(
+    field_key: str,
+    source_text: str,
+    *,
+    value: str = "fixture",
+    document_type: DocumentType = DocumentType.COMMERCIAL_INVOICE,
+) -> CandidateEnvelope:
+    candidate = AICandidate(
+        field_key=field_key,
+        value=value,
+        normalized_value=value,
+        evidence_class=EvidenceClass.EXPLICIT,
+        page=1,
+        source_text=source_text,
+        confidence=0.9,
+        provider="fixture",
+        model="fixture",
+    )
+    return CandidateEnvelope(
+        candidate=candidate,
+        document_id=uuid5(NAMESPACE_URL, document_type.value),
+        document_type=document_type,
+        specialist=(
+            SpecialistRole.BOTANICAL
+            if document_type in {DocumentType.BOTANICAL_DECLARATION, DocumentType.SUPPLIER_ORIGIN}
+            else SpecialistRole.COMMERCIAL_LINES
+        ),
+        agent_run_id=uuid4(),
+        line_item_key=None,
+        source_span_id=None,
+    )
+
+
+def test_sku_binding_has_priority_and_aligns_commercial_and_botanical_rows():
+    commercial = _envelope(
+        "hts_code",
+        "1 ACT-TRAY-18 Acacia solid-wood serving trays 4419.90.9000 420 18,900.00",
+        value="4419.90.9000",
+    )
+    botanical = _envelope(
+        "species",
+        "ACT-TRAY-18 Serving tray / solid wood Acacia mangium Vietnam 315 KG",
+        value="mangium",
+        document_type=DocumentType.BOTANICAL_DECLARATION,
+    )
+
+    assert derive_line_item_key(commercial) == "SKU:ACT-TRAY-18"
+    assert derive_line_item_key(botanical) == "SKU:ACT-TRAY-18"
+
+
+def test_explicit_sku_label_beats_line_number():
+    envelope = _envelope(
+        "entered_value",
+        "Line 7 SKU: TEK-SRV-04 Entered Value 11,200.00",
+        value="11,200.00",
+    )
+
+    assert derive_line_item_key(envelope) == "SKU:TEK-SRV-04"
+
+
+def test_line_number_is_second_priority_when_no_sku_is_available():
+    envelope = _envelope(
+        "description",
+        "Line 12 commercial description polished serving tray",
+        value="polished serving tray",
+    )
+
+    assert derive_line_item_key(envelope) == "LINE:12"
+
+
+def test_engine2_row_locator_precedes_fingerprint():
+    envelope = _envelope(
+        "description",
+        "Acacia solid wood serving tray food service grade",
+        value="Acacia solid wood serving tray",
+    )
+    locator = RowLocator(table_id="commercial-lines", page=1, row_index=3)
+
+    key = derive_line_item_key(envelope, row_locator=locator)
+
+    assert key.startswith("ROW:")
+    assert key.endswith(":P1:TCOMMERCIAL-LINES:R3")
+
+
+def test_deterministic_fingerprint_is_last_resort_for_rich_row_evidence():
+    source = "Acacia solid wood serving tray 4419 90 9000 420 pieces 18900 USD"
+    first = _envelope("hts_code", source, value="4419.90.9000")
+    second = _envelope("entered_value", source, value="18,900.00")
+
+    assert derive_line_item_key(first).startswith("FP:")
+    assert derive_line_item_key(first) == derive_line_item_key(second)
+
+
+def test_sparse_or_global_evidence_remains_explicitly_unbound():
+    sparse = _envelope("species", "Acacia", value="Acacia", document_type=DocumentType.BOTANICAL_DECLARATION)
+    global_field = _envelope(
+        "description",
+        "Importer Northstar Kitchen Imports LLC",
+        value="Importer Northstar Kitchen Imports LLC",
+    )
+    # Change the field to a genuinely global key without changing AICandidate itself.
+    global_candidate = AICandidate(
+        field_key="importer_name",
+        value="Northstar Kitchen Imports LLC",
+        normalized_value="Northstar Kitchen Imports LLC",
+        evidence_class=EvidenceClass.EXPLICIT,
+        page=1,
+        source_text="Northstar Kitchen Imports LLC",
+        confidence=0.9,
+        provider="fixture",
+        model="fixture",
+    )
+    global_envelope = CandidateEnvelope(
+        candidate=global_candidate,
+        document_id=global_field.document_id,
+        document_type=DocumentType.ENTRY_WORKSHEET,
+        specialist=SpecialistRole.CUSTOMS_IDENTITY,
+        agent_run_id=uuid4(),
+        line_item_key=None,
+        source_span_id=None,
+    )
+
+    assert derive_line_item_key(sparse) is None
+    assert derive_line_item_key(global_envelope) is None
+
+
+def test_bind_line_items_returns_new_frozen_envelopes_and_metric():
+    first = _envelope(
+        "hts_code",
+        "1 ACT-TRAY-18 Acacia tray 4419.90.9000 420 18,900.00",
+        value="4419.90.9000",
+    )
+    second = _envelope(
+        "description",
+        "Line 2 rubberwood kitchen cutting board",
+        value="rubberwood kitchen cutting board",
+    )
+    third = _envelope(
+        "entered_value",
+        "Teak salad server commercial row without explicit locator 11200 USD",
+        value="11200",
+    )
+    row_locators = {
+        source_locator_key(third): RowLocator(table_id="invoice", page=1, row_index=4)
+    }
+
+    bound = bind_line_items((first, second, third), row_locators=row_locators)
+
+    assert first.line_item_key is None
+    assert [item.line_item_key for item in bound] == [
+        "SKU:ACT-TRAY-18",
+        "LINE:2",
+        next(item.line_item_key for item in bound if item is bound[2]),
+    ]
+    assert bound[2].line_item_key is not None and bound[2].line_item_key.startswith("ROW:")
+    assert line_item_binding_accuracy(
+        ("SKU:ACT-TRAY-18", "LINE:2", bound[2].line_item_key),
+        bound,
+    ) == 1.0
+
+
+def test_bind_line_item_never_overwrites_with_an_invented_value():
+    envelope = _envelope("species", "Acacia", value="Acacia", document_type=DocumentType.BOTANICAL_DECLARATION)
+    bound = bind_line_item(envelope)
+    assert bound.line_item_key is None


### PR DESCRIPTION
## Phase 3
Implements deterministic `line_item_key` derivation without any LLM adjudication.

Priority is exactly:
1. explicit SKU (labelled or row-leading SKU evidence)
2. commercial line number
3. Engine 2 row locator (`table + page + row`)
4. deterministic fingerprint of sufficiently rich exact row evidence

Global fields remain unbound. Sparse snippets such as a bare genus/species/value also remain explicitly `None` rather than receiving a guessed identity.

`CandidateEnvelope` remains frozen; binding uses `dataclasses.replace()` and never mutates the existing `AICandidate`.

Adds `line_item_binding_accuracy` for labeled validation sets and tests cross-document SKU alignment between commercial and botanical rows, priority ordering, row-locator fallback, fingerprint fallback, and explicit non-binding cases.