### PR TITLE
feat(lacey): phase 4 deterministic authority fusion

### DIFF
--- a/src/litoral_trace/lacey_engine/multi_agent/authority.py
+++ b/src/litoral_trace/lacey_engine/multi_agent/authority.py
@@ -1,0 +1,163 @@
+"""Deterministic source authority for multi-extractor candidate fusion."""
+from __future__ import annotations
+
+import hashlib
+
+from ..ai_shadow import comparison_key
+from .contracts import CandidateEnvelope, DocumentType, SpecialistRole
+
+
+FIELD_SPECIALIST: dict[str, SpecialistRole] = {
+    "importer_name": SpecialistRole.CUSTOMS_IDENTITY,
+    "importer_address": SpecialistRole.CUSTOMS_IDENTITY,
+    "consignee_name": SpecialistRole.CUSTOMS_IDENTITY,
+    "consignee_address": SpecialistRole.CUSTOMS_IDENTITY,
+    "filing_entry_reference": SpecialistRole.CUSTOMS_IDENTITY,
+    "manufacturer_id": SpecialistRole.CUSTOMS_IDENTITY,
+    "bill_of_lading": SpecialistRole.LOGISTICS,
+    "container_number": SpecialistRole.LOGISTICS,
+    "estimated_arrival_date": SpecialistRole.LOGISTICS,
+    "description": SpecialistRole.COMMERCIAL_LINES,
+    "article_component": SpecialistRole.COMMERCIAL_LINES,
+    "hts_code": SpecialistRole.COMMERCIAL_LINES,
+    "entered_value": SpecialistRole.COMMERCIAL_LINES,
+    "genus": SpecialistRole.BOTANICAL,
+    "species": SpecialistRole.BOTANICAL,
+    "country_of_harvest": SpecialistRole.BOTANICAL,
+    "plant_quantity": SpecialistRole.BOTANICAL,
+    "metric_unit": SpecialistRole.BOTANICAL,
+}
+
+
+# Higher number means greater documentary authority for this field.  Equal numbers
+# intentionally encode equal authority where the brief uses "/" rather than ">".
+_DOCUMENT_AUTHORITY: dict[str, dict[DocumentType, int]] = {
+    "filing_entry_reference": {DocumentType.ENTRY_WORKSHEET: 100},
+    "manufacturer_id": {
+        DocumentType.ENTRY_WORKSHEET: 100,
+        DocumentType.COMMERCIAL_INVOICE: 80,
+    },
+    "importer_name": {
+        DocumentType.ENTRY_WORKSHEET: 100,
+        DocumentType.COMMERCIAL_INVOICE: 80,
+        DocumentType.BILL_OF_LADING: 60,
+        DocumentType.ARRIVAL_NOTICE: 40,
+    },
+    "importer_address": {
+        DocumentType.ENTRY_WORKSHEET: 100,
+        DocumentType.COMMERCIAL_INVOICE: 80,
+        DocumentType.BILL_OF_LADING: 60,
+        DocumentType.ARRIVAL_NOTICE: 40,
+    },
+    "consignee_name": {
+        DocumentType.ENTRY_WORKSHEET: 100,
+        DocumentType.BILL_OF_LADING: 100,
+        DocumentType.ARRIVAL_NOTICE: 80,
+    },
+    "consignee_address": {
+        DocumentType.ENTRY_WORKSHEET: 100,
+        DocumentType.BILL_OF_LADING: 100,
+        DocumentType.ARRIVAL_NOTICE: 80,
+    },
+    "hts_code": {
+        DocumentType.ENTRY_WORKSHEET: 100,
+        DocumentType.COMMERCIAL_INVOICE: 80,
+    },
+    "entered_value": {
+        DocumentType.ENTRY_WORKSHEET: 100,
+        DocumentType.COMMERCIAL_INVOICE: 100,
+    },
+    "bill_of_lading": {
+        DocumentType.BILL_OF_LADING: 100,
+        DocumentType.ENTRY_WORKSHEET: 60,
+        DocumentType.ARRIVAL_NOTICE: 60,
+    },
+    "container_number": {
+        DocumentType.BILL_OF_LADING: 100,
+        DocumentType.ARRIVAL_NOTICE: 80,
+        DocumentType.ENTRY_WORKSHEET: 70,
+        DocumentType.PACKING_LIST: 50,
+    },
+    "estimated_arrival_date": {
+        DocumentType.ARRIVAL_NOTICE: 100,
+        DocumentType.BILL_OF_LADING: 100,
+        DocumentType.ENTRY_WORKSHEET: 60,
+    },
+    "genus": {
+        DocumentType.BOTANICAL_DECLARATION: 100,
+        DocumentType.SUPPLIER_ORIGIN: 80,
+    },
+    "species": {
+        DocumentType.BOTANICAL_DECLARATION: 100,
+        DocumentType.SUPPLIER_ORIGIN: 80,
+    },
+    "country_of_harvest": {
+        DocumentType.BOTANICAL_DECLARATION: 100,
+        DocumentType.SUPPLIER_ORIGIN: 100,
+    },
+    "plant_quantity": {
+        DocumentType.BOTANICAL_DECLARATION: 100,
+        DocumentType.SUPPLIER_ORIGIN: 80,
+    },
+    "metric_unit": {
+        DocumentType.BOTANICAL_DECLARATION: 100,
+        DocumentType.SUPPLIER_ORIGIN: 80,
+    },
+    "description": {
+        DocumentType.COMMERCIAL_INVOICE: 100,
+        DocumentType.ENTRY_WORKSHEET: 80,
+        DocumentType.PACKING_LIST: 50,
+        DocumentType.BILL_OF_LADING: 30,
+    },
+    "article_component": {
+        DocumentType.COMMERCIAL_INVOICE: 100,
+        DocumentType.ENTRY_WORKSHEET: 80,
+        DocumentType.PACKING_LIST: 50,
+    },
+}
+
+
+def document_authority(field_key: str, document_type: DocumentType) -> int:
+    return _DOCUMENT_AUTHORITY.get(field_key, {}).get(document_type, 0)
+
+
+def correct_specialist(candidate: CandidateEnvelope) -> bool:
+    expected = FIELD_SPECIALIST.get(candidate.candidate.field_key)
+    return expected is not None and candidate.specialist is expected
+
+
+def normalized_candidate_value(candidate: CandidateEnvelope) -> str:
+    value = comparison_key(candidate.candidate.field_key, candidate.candidate.normalized_value)
+    return value or candidate.candidate.normalized_value
+
+
+def authority_tuple(
+    candidate: CandidateEnvelope,
+    *,
+    corroborating_documents: int,
+) -> tuple[int, int, int, int, float]:
+    """Return the required lexicographic priority; model confidence is last."""
+    return (
+        int(candidate.candidate.evidence_verified),
+        document_authority(candidate.candidate.field_key, candidate.document_type),
+        int(correct_specialist(candidate)),
+        corroborating_documents,
+        candidate.candidate.confidence,
+    )
+
+
+def candidate_identity(candidate: CandidateEnvelope) -> str:
+    """Stable opaque id for deterministic tie-breaking and Phase 5 resolver choices."""
+    raw = "|".join(
+        (
+            str(candidate.document_id),
+            candidate.document_type.value,
+            candidate.specialist.value,
+            candidate.candidate.field_key,
+            candidate.line_item_key or "",
+            str(candidate.candidate.page),
+            candidate.candidate.normalized_value,
+            candidate.candidate.source_text,
+        )
+    )
+    return "cand_" + hashlib.sha256(raw.encode("utf-8")).hexdigest()[:20]

--- a/src/litoral_trace/lacey_engine/multi_agent/fusion.py
+++ b/src/litoral_trace/lacey_engine/multi_agent/fusion.py
@@ -1,0 +1,141 @@
+"""Deterministic candidate fusion by evidence and documentary authority."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable, Mapping
+
+from .authority import (
+    authority_tuple,
+    candidate_identity,
+    normalized_candidate_value,
+)
+from .contracts import CandidateEnvelope
+from .line_binding import LINE_SCOPED_FIELDS
+
+
+@dataclass(frozen=True, slots=True)
+class FusionKey:
+    field_key: str
+    line_item_key: str | None
+    # Line-scoped candidates that could not be bound must never collapse into one
+    # synthetic line. Give each such item a deterministic private grouping identity.
+    unbound_identity: str | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class FusionConflict:
+    key: FusionKey
+    candidates: tuple[CandidateEnvelope, ...]
+    normalized_values: tuple[str, ...]
+    requires_ai_resolution: bool
+
+
+@dataclass(frozen=True, slots=True)
+class FusionResult:
+    fused_candidates: tuple[CandidateEnvelope, ...]
+    conflicts: tuple[FusionConflict, ...]
+
+
+def fusion_key(candidate: CandidateEnvelope) -> FusionKey:
+    field_key = candidate.candidate.field_key
+    if field_key in LINE_SCOPED_FIELDS and candidate.line_item_key is None:
+        return FusionKey(field_key, None, candidate_identity(candidate))
+    return FusionKey(field_key, candidate.line_item_key, None)
+
+
+def fuse_candidates(candidates: Iterable[CandidateEnvelope]) -> FusionResult:
+    """Fuse candidates using the required lexicographic authority order."""
+    groups: dict[FusionKey, list[CandidateEnvelope]] = {}
+    for candidate in candidates:
+        groups.setdefault(fusion_key(candidate), []).append(candidate)
+
+    fused: list[CandidateEnvelope] = []
+    conflicts: list[FusionConflict] = []
+
+    for key in sorted(groups, key=_fusion_key_sort):
+        group = groups[key]
+        documents_by_value: dict[str, set[object]] = {}
+        for candidate in group:
+            normalized = normalized_candidate_value(candidate)
+            documents_by_value.setdefault(normalized, set()).add(candidate.document_id)
+
+        ranked = sorted(
+            group,
+            key=lambda candidate: (
+                authority_tuple(
+                    candidate,
+                    corroborating_documents=len(
+                        documents_by_value[normalized_candidate_value(candidate)]
+                    ),
+                ),
+                candidate_identity(candidate),
+            ),
+            reverse=True,
+        )
+        winner = ranked[0]
+        fused.append(winner)
+
+        values = tuple(sorted(documents_by_value))
+        if len(values) > 1:
+            conflicts.append(
+                FusionConflict(
+                    key=key,
+                    candidates=tuple(ranked),
+                    normalized_values=values,
+                    requires_ai_resolution=_has_comparable_top_conflict(
+                        ranked,
+                        documents_by_value=documents_by_value,
+                    ),
+                )
+            )
+
+    return FusionResult(tuple(fused), tuple(conflicts))
+
+
+def cross_document_fusion_accuracy(
+    expected: Mapping[FusionKey, str],
+    result: FusionResult,
+) -> float:
+    """Exact normalized-value accuracy over a labeled fusion set."""
+    if not expected:
+        return 1.0
+    actual = {
+        fusion_key(candidate): normalized_candidate_value(candidate)
+        for candidate in result.fused_candidates
+    }
+    correct = sum(1 for key, value in expected.items() if actual.get(key) == value)
+    return correct / len(expected)
+
+
+def _has_comparable_top_conflict(
+    ranked: list[CandidateEnvelope],
+    *,
+    documents_by_value: dict[str, set[object]],
+) -> bool:
+    if len(ranked) < 2:
+        return False
+    top = ranked[0]
+    top_value = normalized_candidate_value(top)
+    top_score = authority_tuple(
+        top,
+        corroborating_documents=len(documents_by_value[top_value]),
+    )
+    # Confidence is intentionally excluded from comparability: if two conflicting
+    # candidates tie through corroboration, model confidence must not silently settle
+    # a regulatory conflict. Phase 5 may select an existing candidate or NEEDS_REVIEW.
+    top_structural = top_score[:-1]
+    return any(
+        normalized_candidate_value(other) != top_value
+        and authority_tuple(
+            other,
+            corroborating_documents=len(
+                documents_by_value[normalized_candidate_value(other)]
+            ),
+        )[:-1]
+        == top_structural
+        for other in ranked[1:]
+    )
+
+
+def _fusion_key_sort(key: FusionKey) -> tuple[str, str, str]:
+    return (key.field_key, key.line_item_key or "", key.unbound_identity or "")

--- a/tests/lacey_engine/test_multi_agent_fusion.py
+++ b/tests/lacey_engine/test_multi_agent_fusion.py
@@ -1,0 +1,262 @@
+from __future__ import annotations
+
+from dataclasses import replace
+from uuid import NAMESPACE_URL, uuid4, uuid5
+
+from litoral_trace.lacey_engine.ai_shadow import AICandidate
+from litoral_trace.lacey_engine.domain import EvidenceClass
+from litoral_trace.lacey_engine.multi_agent.authority import (
+    authority_tuple,
+    document_authority,
+)
+from litoral_trace.lacey_engine.multi_agent.contracts import (
+    CandidateEnvelope,
+    DocumentType,
+    SpecialistRole,
+)
+from litoral_trace.lacey_engine.multi_agent.fusion import (
+    FusionKey,
+    cross_document_fusion_accuracy,
+    fuse_candidates,
+)
+
+
+def _envelope(
+    field_key: str,
+    value: str,
+    *,
+    document_type: DocumentType,
+    specialist: SpecialistRole,
+    verified: bool = True,
+    confidence: float = 0.5,
+    line_item_key: str | None = None,
+    document_seed: str | None = None,
+) -> CandidateEnvelope:
+    candidate = AICandidate(
+        field_key=field_key,
+        value=value,
+        normalized_value=value,
+        evidence_class=EvidenceClass.EXPLICIT,
+        page=1,
+        source_text=f"ROW {line_item_key or '-'} {field_key} {value} supporting evidence",
+        confidence=confidence,
+        provider="fixture",
+        model="fixture",
+        evidence_verified=verified,
+    )
+    return CandidateEnvelope(
+        candidate=candidate,
+        document_id=uuid5(NAMESPACE_URL, document_seed or f"{document_type.value}:{value}"),
+        document_type=document_type,
+        specialist=specialist,
+        agent_run_id=uuid4(),
+        line_item_key=line_item_key,
+        source_span_id=None,
+    )
+
+
+def test_authority_table_encodes_required_precedence():
+    assert document_authority("hts_code", DocumentType.ENTRY_WORKSHEET) > document_authority(
+        "hts_code", DocumentType.COMMERCIAL_INVOICE
+    )
+    assert document_authority("entered_value", DocumentType.ENTRY_WORKSHEET) == document_authority(
+        "entered_value", DocumentType.COMMERCIAL_INVOICE
+    )
+    assert document_authority("genus", DocumentType.BOTANICAL_DECLARATION) > document_authority(
+        "genus", DocumentType.SUPPLIER_ORIGIN
+    )
+    assert document_authority("country_of_harvest", DocumentType.BOTANICAL_DECLARATION) == document_authority(
+        "country_of_harvest", DocumentType.SUPPLIER_ORIGIN
+    )
+    assert document_authority("genus", DocumentType.PACKING_LIST) == 0
+
+
+def test_verified_evidence_beats_higher_document_authority():
+    verified_invoice = _envelope(
+        "hts_code",
+        "4419.90.9000",
+        document_type=DocumentType.COMMERCIAL_INVOICE,
+        specialist=SpecialistRole.COMMERCIAL_LINES,
+        verified=True,
+        line_item_key="SKU:ACT-TRAY-18",
+    )
+    unverified_entry = _envelope(
+        "hts_code",
+        "4421.99.9880",
+        document_type=DocumentType.ENTRY_WORKSHEET,
+        specialist=SpecialistRole.COMMERCIAL_LINES,
+        verified=False,
+        confidence=0.99,
+        line_item_key="SKU:ACT-TRAY-18",
+    )
+
+    result = fuse_candidates((unverified_entry, verified_invoice))
+    assert result.fused_candidates == (verified_invoice,)
+
+
+def test_document_authority_beats_model_confidence_when_verification_is_equal():
+    invoice = _envelope(
+        "hts_code",
+        "4421.99.9880",
+        document_type=DocumentType.COMMERCIAL_INVOICE,
+        specialist=SpecialistRole.COMMERCIAL_LINES,
+        confidence=0.99,
+        line_item_key="SKU:ACT-TRAY-18",
+    )
+    entry = _envelope(
+        "hts_code",
+        "4419.90.9000",
+        document_type=DocumentType.ENTRY_WORKSHEET,
+        specialist=SpecialistRole.COMMERCIAL_LINES,
+        confidence=0.51,
+        line_item_key="SKU:ACT-TRAY-18",
+    )
+
+    result = fuse_candidates((invoice, entry))
+    assert result.fused_candidates == (entry,)
+    assert result.conflicts[0].requires_ai_resolution is False
+
+
+def test_correct_specialist_precedes_corroboration_and_confidence():
+    correct = _envelope(
+        "entered_value",
+        "18900.00",
+        document_type=DocumentType.COMMERCIAL_INVOICE,
+        specialist=SpecialistRole.COMMERCIAL_LINES,
+        confidence=0.5,
+        line_item_key="SKU:ACT-TRAY-18",
+        document_seed="correct",
+    )
+    wrong = _envelope(
+        "entered_value",
+        "99999.00",
+        document_type=DocumentType.COMMERCIAL_INVOICE,
+        specialist=SpecialistRole.BOTANICAL,
+        confidence=0.99,
+        line_item_key="SKU:ACT-TRAY-18",
+        document_seed="wrong",
+    )
+
+    result = fuse_candidates((wrong, correct))
+    assert result.fused_candidates == (correct,)
+
+
+def test_cross_document_corroboration_precedes_confidence():
+    a1 = _envelope(
+        "country_of_harvest",
+        "Vietnam",
+        document_type=DocumentType.BOTANICAL_DECLARATION,
+        specialist=SpecialistRole.BOTANICAL,
+        confidence=0.6,
+        line_item_key="SKU:ACT-TRAY-18",
+        document_seed="a1",
+    )
+    a2 = _envelope(
+        "country_of_harvest",
+        "Vietnam",
+        document_type=DocumentType.SUPPLIER_ORIGIN,
+        specialist=SpecialistRole.BOTANICAL,
+        confidence=0.6,
+        line_item_key="SKU:ACT-TRAY-18",
+        document_seed="a2",
+    )
+    b = _envelope(
+        "country_of_harvest",
+        "Indonesia",
+        document_type=DocumentType.SUPPLIER_ORIGIN,
+        specialist=SpecialistRole.BOTANICAL,
+        confidence=0.99,
+        line_item_key="SKU:ACT-TRAY-18",
+        document_seed="b",
+    )
+
+    result = fuse_candidates((b, a1, a2))
+    assert result.fused_candidates[0].candidate.value == "Vietnam"
+
+
+def test_model_confidence_is_only_final_authority_dimension():
+    low = _envelope(
+        "entered_value",
+        "18900.00",
+        document_type=DocumentType.COMMERCIAL_INVOICE,
+        specialist=SpecialistRole.COMMERCIAL_LINES,
+        confidence=0.6,
+        line_item_key="SKU:ACT-TRAY-18",
+        document_seed="low",
+    )
+    high = _envelope(
+        "entered_value",
+        "17760.00",
+        document_type=DocumentType.COMMERCIAL_INVOICE,
+        specialist=SpecialistRole.COMMERCIAL_LINES,
+        confidence=0.9,
+        line_item_key="SKU:ACT-TRAY-18",
+        document_seed="high",
+    )
+
+    assert authority_tuple(low, corroborating_documents=1)[:-1] == authority_tuple(
+        high, corroborating_documents=1
+    )[:-1]
+    result = fuse_candidates((low, high))
+    assert result.fused_candidates == (high,)
+    assert result.conflicts[0].requires_ai_resolution is True
+
+
+def test_equal_authority_real_conflict_is_flagged_for_phase_five():
+    invoice = _envelope(
+        "entered_value",
+        "18900.00",
+        document_type=DocumentType.COMMERCIAL_INVOICE,
+        specialist=SpecialistRole.COMMERCIAL_LINES,
+        confidence=0.8,
+        line_item_key="SKU:ACT-TRAY-18",
+    )
+    entry = _envelope(
+        "entered_value",
+        "19000.00",
+        document_type=DocumentType.ENTRY_WORKSHEET,
+        specialist=SpecialistRole.COMMERCIAL_LINES,
+        confidence=0.7,
+        line_item_key="SKU:ACT-TRAY-18",
+    )
+
+    result = fuse_candidates((invoice, entry))
+    assert len(result.conflicts) == 1
+    assert result.conflicts[0].requires_ai_resolution is True
+
+
+def test_unbound_line_candidates_are_never_collapsed_into_one_line():
+    first = _envelope(
+        "hts_code",
+        "4419.90.9000",
+        document_type=DocumentType.COMMERCIAL_INVOICE,
+        specialist=SpecialistRole.COMMERCIAL_LINES,
+        line_item_key=None,
+        document_seed="row-one",
+    )
+    second = _envelope(
+        "hts_code",
+        "4421.99.9880",
+        document_type=DocumentType.COMMERCIAL_INVOICE,
+        specialist=SpecialistRole.COMMERCIAL_LINES,
+        line_item_key=None,
+        document_seed="row-two",
+    )
+
+    result = fuse_candidates((first, second))
+    assert len(result.fused_candidates) == 2
+    assert result.conflicts == ()
+
+
+def test_cross_document_fusion_accuracy_uses_normalized_winner_value():
+    candidate = _envelope(
+        "hts_code",
+        "4419.90.9000",
+        document_type=DocumentType.ENTRY_WORKSHEET,
+        specialist=SpecialistRole.COMMERCIAL_LINES,
+        line_item_key="SKU:ACT-TRAY-18",
+    )
+    result = fuse_candidates((candidate,))
+    key = FusionKey("hts_code", "SKU:ACT-TRAY-18")
+
+    assert cross_document_fusion_accuracy({key: "4419.90.9000"}, result) == 1.0


### PR DESCRIPTION
## Summary
- add deterministic document authority matrix and specialist authority rules
- add cross-document candidate fusion with corroboration-aware ranking
- preserve unbound line-scoped candidates as distinct identities
- surface true comparable conflicts for Phase 5 AI resolution
- add coverage for precedence, corroboration, confidence fallback, conflicts, and line isolation

## Validation gate
Merge only if the full pull-request CI suite is green (Syntax, Alembic canonical head, Pytest).