### PR TITLE
feat(lacey): phase 5 restricted AI conflict resolver

### DIFF
--- a/src/litoral_trace/lacey_engine/multi_agent/resolver.py
+++ b/src/litoral_trace/lacey_engine/multi_agent/resolver.py
@@ -1,0 +1,271 @@
+"""Restricted AI resolver for true Phase 4 fusion conflicts.
+
+The resolver is deliberately incapable of returning a corrected business value.  The
+model may only select one opaque candidate ID that already exists in the conflict pool
+or return NEEDS_REVIEW.  A deterministic Python barrier re-validates that invariant
+independently of provider-side structured output enforcement.
+"""
+from __future__ import annotations
+
+import json
+from typing import Literal, Mapping, Protocol
+
+from pydantic import BaseModel, ConfigDict, Field, ValidationError, model_validator
+
+from ..ai_providers import AIProviderConfig, _post_json
+from ..ai_shadow import AIShadowError
+from ..gemini_provider import gemini_output_text
+from .authority import candidate_identity
+from .fusion import FusionConflict
+
+
+REASON_CODES: tuple[str, ...] = (
+    "HIGHER_AUTHORITY_SOURCE",
+    "STRONGER_CONTEXT_MATCH",
+    "CONSISTENT_WITH_LINE_ITEM",
+    "CORROBORATED_PROVENANCE",
+    "CLEARER_SOURCE_EVIDENCE",
+)
+
+
+class AIResolverDecision(BaseModel):
+    """Closed Phase 5 decision contract: choose an existing ID or request review."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    field_key: str
+    line_item_key: str | None
+    candidate_ids: list[str] = Field(min_length=1)
+    decision: Literal["SELECT", "NEEDS_REVIEW"]
+    selected_candidate_id: str | None = Field(
+        None,
+        description=(
+            "MUST be exactly one of the provided candidate IDs. Null if NEEDS_REVIEW."
+        ),
+    )
+    reason_code: str | None = Field(
+        None,
+        description=(
+            "Short code explaining the choice, e.g., 'HIGHER_AUTHORITY_SOURCE'. "
+            "Null if NEEDS_REVIEW."
+        ),
+    )
+
+    @model_validator(mode="after")
+    def validate_decision_shape(self) -> "AIResolverDecision":
+        if self.decision == "SELECT" and self.selected_candidate_id is None:
+            raise ValueError("SELECT requires selected_candidate_id")
+        if self.decision == "NEEDS_REVIEW":
+            if self.selected_candidate_id is not None:
+                raise ValueError("NEEDS_REVIEW requires selected_candidate_id=null")
+            if self.reason_code is not None:
+                raise ValueError("NEEDS_REVIEW requires reason_code=null")
+        return self
+
+
+class AIResolverProvider(Protocol):
+    """Provider boundary used by the resolver and unit-test stubs."""
+
+    def resolve_structured(
+        self,
+        *,
+        prompt: str,
+        schema: dict[str, object],
+    ) -> Mapping[str, object]: ...
+
+
+class GeminiAIResolverProvider:
+    """Gemini text-only structured resolver using the existing shared transport."""
+
+    name = "gemini"
+
+    def __init__(self, config: AIProviderConfig) -> None:
+        if not config.allow_external:
+            raise AIShadowError("External AI provider is disabled by policy.")
+        if not config.api_key:
+            raise AIShadowError(
+                "Gemini requires US_LACEY_GEMINI_API_KEY or US_LACEY_AI_API_KEY."
+            )
+        self.config = config
+        self.model = config.model
+
+    def resolve_structured(
+        self,
+        *,
+        prompt: str,
+        schema: dict[str, object],
+    ) -> Mapping[str, object]:
+        payload: dict[str, object] = {
+            "model": self.model,
+            "store": False,
+            "input": [{"type": "text", "text": prompt}],
+            "generation_config": {"thinking_level": "low"},
+            "response_format": {
+                "type": "text",
+                "mime_type": "application/json",
+                "schema": schema,
+            },
+        }
+        response = _post_json(
+            url=self.config.base_url,
+            payload=payload,
+            timeout=self.config.timeout_seconds,
+            headers={"x-goog-api-key": self.config.api_key},
+        )
+        try:
+            parsed = json.loads(gemini_output_text(response))
+        except json.JSONDecodeError as exc:
+            raise AIShadowError("Gemini resolver structured output is invalid JSON.") from exc
+        if not isinstance(parsed, dict):
+            raise AIShadowError("Gemini resolver output must be a JSON object.")
+        return parsed
+
+
+def resolve_conflict(
+    conflict: FusionConflict,
+    *,
+    provider: AIResolverProvider,
+) -> AIResolverDecision:
+    """Resolve one true conflict without ever accepting an invented business value."""
+    if not conflict.requires_ai_resolution:
+        raise ValueError("AI resolver accepts only conflicts requiring AI resolution.")
+
+    candidate_ids = [candidate_identity(candidate) for candidate in conflict.candidates]
+    prompt = build_resolver_prompt(conflict, candidate_ids=candidate_ids)
+    schema = resolver_output_schema(conflict, candidate_ids=candidate_ids)
+    raw = provider.resolve_structured(prompt=prompt, schema=schema)
+
+    try:
+        decision = AIResolverDecision.model_validate(raw)
+    except (ValidationError, TypeError, ValueError):
+        return _needs_review(conflict, candidate_ids)
+
+    # Deterministic post-AI barrier.  These checks do not trust provider-side schema
+    # enforcement and intentionally canonicalize any suspicious response to review.
+    if decision.field_key != conflict.key.field_key:
+        return _needs_review(conflict, candidate_ids)
+    if decision.line_item_key != conflict.key.line_item_key:
+        return _needs_review(conflict, candidate_ids)
+    if len(decision.candidate_ids) != len(candidate_ids):
+        return _needs_review(conflict, candidate_ids)
+    if set(decision.candidate_ids) != set(candidate_ids):
+        return _needs_review(conflict, candidate_ids)
+    if decision.reason_code is not None and decision.reason_code not in REASON_CODES:
+        return _needs_review(conflict, candidate_ids)
+
+    if decision.decision == "NEEDS_REVIEW":
+        return _needs_review(conflict, candidate_ids)
+
+    if decision.selected_candidate_id not in candidate_ids:
+        # Required fail-safe: hallucinated IDs silently degrade to human review.
+        return _needs_review(conflict, candidate_ids)
+
+    return AIResolverDecision(
+        field_key=conflict.key.field_key,
+        line_item_key=conflict.key.line_item_key,
+        candidate_ids=candidate_ids,
+        decision="SELECT",
+        selected_candidate_id=decision.selected_candidate_id,
+        reason_code=decision.reason_code,
+    )
+
+
+def build_resolver_prompt(
+    conflict: FusionConflict,
+    *,
+    candidate_ids: list[str] | None = None,
+) -> str:
+    """Build the bounded customs-auditor prompt from existing conflict evidence only."""
+    ids = candidate_ids or [candidate_identity(candidate) for candidate in conflict.candidates]
+    candidates = [
+        {
+            "candidate_id": candidate_id,
+            "value": candidate.candidate.value,
+            "source_text": candidate.candidate.source_text,
+            "document_type": candidate.document_type.value,
+        }
+        for candidate, candidate_id in zip(conflict.candidates, ids, strict=True)
+    ]
+    context = {
+        "field_key": conflict.key.field_key,
+        "line_item_key": conflict.key.line_item_key,
+        "candidates": candidates,
+    }
+    return (
+        "You are an expert customs auditor resolving a data conflict. "
+        "Analyze the provenance and context of these candidates. "
+        "You CANNOT invent a new value. You MUST select the most accurate candidate ID "
+        "from the provided list, or return NEEDS_REVIEW if it requires human judgment.\n\n"
+        "Never output a corrected, synthesized, normalized, inferred, or replacement business "
+        "value. The only selectable objects are the candidate IDs supplied below. "
+        "Use only one of these reason codes when SELECT is appropriate: "
+        + ", ".join(REASON_CODES)
+        + ". For NEEDS_REVIEW, selected_candidate_id and reason_code MUST both be null.\n\n"
+        "CONFLICT CONTEXT:\n"
+        + json.dumps(context, ensure_ascii=False, sort_keys=True)
+    )
+
+
+def resolver_output_schema(
+    conflict: FusionConflict,
+    *,
+    candidate_ids: list[str] | None = None,
+) -> dict[str, object]:
+    """Return a per-conflict schema whose string outputs are all closed enumerations."""
+    ids = candidate_ids or [candidate_identity(candidate) for candidate in conflict.candidates]
+    schema = AIResolverDecision.model_json_schema()
+    properties = schema["properties"]
+
+    properties["field_key"] = {
+        "type": "string",
+        "enum": [conflict.key.field_key],
+    }
+    if conflict.key.line_item_key is None:
+        properties["line_item_key"] = {"type": "null"}
+    else:
+        properties["line_item_key"] = {
+            "type": "string",
+            "enum": [conflict.key.line_item_key],
+        }
+    properties["candidate_ids"] = {
+        "type": "array",
+        "items": {"type": "string", "enum": ids},
+        "minItems": len(ids),
+        "maxItems": len(ids),
+    }
+    properties["decision"] = {
+        "type": "string",
+        "enum": ["SELECT", "NEEDS_REVIEW"],
+    }
+    properties["selected_candidate_id"] = {
+        "anyOf": [
+            {"type": "string", "enum": ids},
+            {"type": "null"},
+        ],
+        "description": (
+            "MUST be exactly one of the provided candidate IDs. Null if NEEDS_REVIEW."
+        ),
+    }
+    properties["reason_code"] = {
+        "anyOf": [
+            {"type": "string", "enum": list(REASON_CODES)},
+            {"type": "null"},
+        ],
+        "description": "Closed reason code. Null if NEEDS_REVIEW.",
+    }
+    schema["additionalProperties"] = False
+    return schema
+
+
+def _needs_review(
+    conflict: FusionConflict,
+    candidate_ids: list[str],
+) -> AIResolverDecision:
+    return AIResolverDecision(
+        field_key=conflict.key.field_key,
+        line_item_key=conflict.key.line_item_key,
+        candidate_ids=list(candidate_ids),
+        decision="NEEDS_REVIEW",
+        selected_candidate_id=None,
+        reason_code=None,
+    )

--- a/tests/lacey_engine/test_multi_agent_resolver.py
+++ b/tests/lacey_engine/test_multi_agent_resolver.py
@@ -1,0 +1,172 @@
+from __future__ import annotations
+
+import importlib
+import importlib.util
+from uuid import NAMESPACE_URL, uuid4, uuid5
+
+from litoral_trace.lacey_engine.ai_shadow import AICandidate
+from litoral_trace.lacey_engine.domain import EvidenceClass
+from litoral_trace.lacey_engine.multi_agent.authority import candidate_identity
+from litoral_trace.lacey_engine.multi_agent.contracts import (
+    CandidateEnvelope,
+    DocumentType,
+    SpecialistRole,
+)
+from litoral_trace.lacey_engine.multi_agent.fusion import fuse_candidates
+
+
+class StubResolverProvider:
+    def __init__(self, payload: dict[str, object]) -> None:
+        self.payload = payload
+        self.calls: list[dict[str, object]] = []
+
+    def resolve_structured(self, *, prompt: str, schema: dict[str, object]) -> dict[str, object]:
+        self.calls.append({"prompt": prompt, "schema": schema})
+        return self.payload
+
+
+def _resolver_module():
+    module_name = "litoral_trace.lacey_engine.multi_agent.resolver"
+    assert importlib.util.find_spec(module_name) is not None, "Phase 5 resolver module is missing"
+    return importlib.import_module(module_name)
+
+
+def _envelope(
+    value: str,
+    *,
+    document_type: DocumentType,
+    confidence: float,
+    document_seed: str,
+) -> CandidateEnvelope:
+    candidate = AICandidate(
+        field_key="entered_value",
+        value=value,
+        normalized_value=value,
+        evidence_class=EvidenceClass.EXPLICIT,
+        page=1,
+        source_text=f"SKU ACT-TRAY-18 entered value {value} USD supporting row",
+        confidence=confidence,
+        provider="fixture",
+        model="fixture",
+        evidence_verified=True,
+    )
+    return CandidateEnvelope(
+        candidate=candidate,
+        document_id=uuid5(NAMESPACE_URL, document_seed),
+        document_type=document_type,
+        specialist=SpecialistRole.COMMERCIAL_LINES,
+        agent_run_id=uuid4(),
+        line_item_key="SKU:ACT-TRAY-18",
+        source_span_id=None,
+    )
+
+
+def _real_conflict():
+    invoice = _envelope(
+        "18900.00",
+        document_type=DocumentType.COMMERCIAL_INVOICE,
+        confidence=0.80,
+        document_seed="invoice",
+    )
+    entry = _envelope(
+        "19000.00",
+        document_type=DocumentType.ENTRY_WORKSHEET,
+        confidence=0.70,
+        document_seed="entry",
+    )
+    conflict = fuse_candidates((invoice, entry)).conflicts[0]
+    assert conflict.requires_ai_resolution is True
+    return conflict
+
+
+def test_valid_candidate_id_resolves_conflict_without_free_value_output():
+    resolver = _resolver_module()
+    conflict = _real_conflict()
+    candidate_ids = [candidate_identity(candidate) for candidate in conflict.candidates]
+    selected_id = candidate_ids[-1]
+    provider = StubResolverProvider(
+        {
+            "field_key": conflict.key.field_key,
+            "line_item_key": conflict.key.line_item_key,
+            "candidate_ids": candidate_ids,
+            "decision": "SELECT",
+            "selected_candidate_id": selected_id,
+            "reason_code": "STRONGER_CONTEXT_MATCH",
+        }
+    )
+
+    result = resolver.resolve_conflict(conflict, provider=provider)
+
+    assert result.decision == "SELECT"
+    assert result.selected_candidate_id == selected_id
+    assert result.candidate_ids == candidate_ids
+    assert len(provider.calls) == 1
+
+    call = provider.calls[0]
+    prompt = str(call["prompt"])
+    assert "You CANNOT invent a new value" in prompt
+    assert "NEEDS_REVIEW" in prompt
+    for candidate, candidate_id in zip(conflict.candidates, candidate_ids, strict=True):
+        assert candidate_id in prompt
+        assert candidate.candidate.value in prompt
+        assert candidate.candidate.source_text in prompt
+        assert candidate.document_type.value in prompt
+
+    schema = call["schema"]
+    properties = schema["properties"]
+    assert set(properties) == {
+        "field_key",
+        "line_item_key",
+        "candidate_ids",
+        "decision",
+        "selected_candidate_id",
+        "reason_code",
+    }
+    assert "value" not in properties
+    assert "new_value" not in properties
+
+
+def test_hallucinated_candidate_id_fails_safe_to_needs_review():
+    resolver = _resolver_module()
+    conflict = _real_conflict()
+    candidate_ids = [candidate_identity(candidate) for candidate in conflict.candidates]
+    provider = StubResolverProvider(
+        {
+            "field_key": conflict.key.field_key,
+            "line_item_key": conflict.key.line_item_key,
+            "candidate_ids": candidate_ids,
+            "decision": "SELECT",
+            "selected_candidate_id": "cand_hallucinated_not_in_pool",
+            "reason_code": "STRONGER_CONTEXT_MATCH",
+        }
+    )
+
+    result = resolver.resolve_conflict(conflict, provider=provider)
+
+    assert result.decision == "NEEDS_REVIEW"
+    assert result.selected_candidate_id is None
+    assert result.reason_code is None
+    assert result.candidate_ids == candidate_ids
+
+
+def test_extra_free_value_field_is_rejected_and_fails_safe():
+    resolver = _resolver_module()
+    conflict = _real_conflict()
+    candidate_ids = [candidate_identity(candidate) for candidate in conflict.candidates]
+    provider = StubResolverProvider(
+        {
+            "field_key": conflict.key.field_key,
+            "line_item_key": conflict.key.line_item_key,
+            "candidate_ids": candidate_ids,
+            "decision": "SELECT",
+            "selected_candidate_id": candidate_ids[0],
+            "reason_code": "STRONGER_CONTEXT_MATCH",
+            "new_value": "99999.99",
+        }
+    )
+
+    result = resolver.resolve_conflict(conflict, provider=provider)
+
+    assert result.decision == "NEEDS_REVIEW"
+    assert result.selected_candidate_id is None
+    assert result.reason_code is None


### PR DESCRIPTION
## Phase 5
- add strict `AIResolverDecision` Pydantic contract
- add restricted resolver prompt with provenance/context only
- add per-conflict Structured Output schema with closed enums for field, line item, candidate IDs, decision, selected ID, and reason code
- add deterministic post-AI barrier: any hallucinated or mutated candidate ID falls back to `NEEDS_REVIEW`
- add Gemini resolver provider using the existing shared transport
- add tests for valid selection, hallucinated ID fail-safe, and rejection of extra free-value fields

## TDD evidence
1. Tests were committed first (`f9b50d77...`). CI run #1259 failed at Pytest while Syntax and Alembic were green, as expected before `resolver.py` existed.
2. Resolver implementation committed as `ac102ea500ffbe7485ab48d86f703894e616b407`.
3. CI run #1260 completed successfully: Python syntax gate ✅, Alembic canonical head ✅, full Pytest suite ✅.

No merge requested in this phase; PR is ready for review.